### PR TITLE
Patch (w/ tests) to optionally suppress confirmation when resolving errors...

### DIFF
--- a/app/views/errs/show.html.haml
+++ b/app/views/errs/show.html.haml
@@ -8,7 +8,7 @@
   %strong Last Notice:
   = last_notice_at(@err).to_s(:micro)
 - content_for :action_bar do
-  %span= link_to 'resolve', resolve_app_err_path(@app, @err), :method => :put, :confirm => 'Seriously?', :class => 'resolve' if @err.unresolved?
+  %span= link_to 'resolve', resolve_app_err_path(@app, @err), :method => :put, :confirm => (Errbit::Config.confirm_resolve_err === false ? nil : 'Seriously?'), :class => 'resolve' if @err.unresolved?
 
 %h4= @notice.try(:message)
   

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -18,3 +18,7 @@ email_from: errbit@example.com
 # [1,3,7] = 1st, 3rd, and 7th occurence triggers
 # an email notification.
 email_at_notices: [1, 10, 100]
+
+# Set to false to suppress confirmation when 
+# resolving errors.
+confirm_resolve_err: true

--- a/spec/views/errs/show.html.haml_spec.rb
+++ b/spec/views/errs/show.html.haml_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe "errs/show.html.erb" do 
+  before do 
+    err = Factory(:err)
+    assign :err, err
+    assign :app, err.app
+    assign :notices, err.notices.ordered.paginate(:page => 1, :per_page => 1)
+    assign :notice, err.notices.first
+  end
+
+  describe "content_for :action_bar" do
+
+    it "should confirm the 'resolve' link by default" do
+      render 
+      action_bar = String.new(view.instance_variable_get(:@_content_for)[:action_bar])
+      resolve_link = action_bar.match(/(<a href.*?(class="resolve").*?>)/)[0]
+      resolve_link.should =~ /data-confirm="Seriously\?"/
+    end
+
+    it "should confirm the 'resolve' link if configuration is unset" do
+      Errbit::Config.stub(:confirm_resolve_err).and_return(nil)
+      render 
+      action_bar = String.new(view.instance_variable_get(:@_content_for)[:action_bar])
+      resolve_link = action_bar.match(/(<a href.*?(class="resolve").*?>)/)[0]
+      resolve_link.should =~ /data-confirm="Seriously\?"/
+    end
+
+    it "should not confirm the 'resolve' link if configured not to" do
+      Errbit::Config.stub(:confirm_resolve_err).and_return(false)
+      render 
+      action_bar = String.new(view.instance_variable_get(:@_content_for)[:action_bar])
+      resolve_link = action_bar.match(/(<a href.*?(class="resolve").*?>)/)[0]
+      resolve_link.should_not =~ /data-confirm=/
+    end
+
+  end
+
+end


### PR DESCRIPTION
Just started using errbit.  It's awesome, but I hate confirmation dialogs :)  I added a configuration option 'confirm_resolve_err' which if set _exactly_ to false will suppress the confirmation when resolving errors.  I set it up to match false exactly so that folks who upgrade, but don't update their config.yml will get the original behavior. 

Similar hooks could be added for users/apps, but I don't think that's a good idea.

Thanks!
