### PR TITLE
Patch (w/tests) to add the Rails environment to the subject line of error notification emails.

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -7,7 +7,7 @@ class Mailer < ActionMailer::Base
     
     mail({
       :to       => @app.watchers.map(&:address),
-      :subject  => "[#{@app.name}] #{@notice.err.message}"
+      :subject  => "[#{@app.name}][#{@notice.err.environment}] #{@notice.err.message}"
     })
   end
   

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -24,6 +24,8 @@ describe NoticesController do
       email = ActionMailer::Base.deliveries.last
       email.to.should include(@app.watchers.first.email)
       email.subject.should include(@notice.err.message)
+      email.subject.should include("[#{@app.name}]")
+      email.subject.should include("[#{@notice.err.environment}]")
     end
   end
   


### PR DESCRIPTION
Hi -  I use errbit for a site that runs in both production and staging environments.  I keep errbit around for staging as it's an easy way to see what my client breaks while playing with things that aren't yet live.   But the emails don't immediately make it clear whether I can ignore them (staging) or need to deal with them (production).  The body of the email lists the rails environment, but not the subject.   The attached adds the environment to the subject so that it looks like "[appname][railsenv] ...."

Thanks!
