### PR TITLE
Issue #31: Plaintext emails should not be HTML-escaped

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,5 @@ group :test do
   gem 'rspec', '~> 2.5'
   gem 'database_cleaner', '~> 0.6.0'
   gem 'factory_girl_rails'
+  gem 'email_spec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       bcrypt-ruby (~> 2.1.2)
       warden (~> 1.0.2)
     diff-lcs (1.1.2)
+    email_spec (1.1.1)
+      rspec (~> 2.0)
     erubis (2.6.6)
       abstract (>= 1.0.0)
     factory_girl (1.3.3)
@@ -139,6 +141,7 @@ DEPENDENCIES
   bson_ext (~> 1.2)
   database_cleaner (~> 0.6.0)
   devise (~> 1.1.8)
+  email_spec
   factory_girl_rails
   haml
   lighthouse-api

--- a/app/views/mailer/err_notification.text.erb
+++ b/app/views/mailer/err_notification.text.erb
@@ -1,4 +1,4 @@
-An err has just occurred in <%= @notice.err.environment %>: <%= @notice.err.message %>
+An err has just occurred in <%= @notice.err.environment %>: <%= raw(@notice.err.message) %>
 
 This err has occurred <%= pluralize @notice.err.notices_count, 'time' %>. You should really look into it here:
 

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Mailer do
+  context "Err Notification" do
+    include EmailSpec::Helpers
+    include EmailSpec::Matchers
+
+    it "should not html-escape the notice's message" do
+      @notice = Factory(:notice, :message => "class < ActionController::Base")
+      @email = Mailer.err_notification(@notice)
+      @email.should have_body_text("class < ActionController::Base")
+    end
+  end
+end


### PR DESCRIPTION
Here's a patch for the issue I reported a few weeks ago. In err notification emails, notice messages are not longer automatically HTML escaped.

I wasn't quite sure how to test this change, since I'm not super familiar with testing mailers – I added the email_spec gem and a new mailer_spec. Please let me know if there's another way you'd rather have me test this change.

Thanks!
