### PR TITLE
detect self-produced errors via hoptoad_notifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ platform :ruby do
   gem 'bson_ext', '~> 1.2'
 end
 
+group :production do
+  gem 'hoptoad_notifier'
+end
+
 group :development, :test do
   gem 'rspec-rails', '~> 2.5'
   gem 'webmock', :require => false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,9 @@ GEM
     haml (3.0.25)
     happymapper (0.3.2)
       libxml-ruby (~> 1.1.3)
+    hoptoad_notifier (2.4.9)
+      activesupport
+      builder
     i18n (0.5.0)
     libxml-ruby (1.1.4)
     lighthouse-api (2.0)
@@ -141,6 +144,7 @@ DEPENDENCIES
   devise (~> 1.1.8)
   factory_girl_rails
   haml
+  hoptoad_notifier
   lighthouse-api
   mongoid (= 2.0.0.rc.8)
   mongoid_rails_migrations

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -19,6 +19,12 @@ email_from: errbit@example.com
 # an email notification.
 email_at_notices: [1, 10, 100]
 
-# Set to false to suppress confirmation when 
+# Set to false to suppress confirmation when
 # resolving errors.
 confirm_resolve_err: true
+
+# This settings needed if you want to detect self-produced by Errbit issues
+# api_key: ABCDEF
+## port:         keep it blank if standart (80 for http and 443 for https connections)
+## secure:       set this to true if you have https for your Errbit installation
+

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -5,6 +5,9 @@ if ENV['HEROKU']
   Errbit::Config.host = ENV['ERRBIT_HOST']
   Errbit::Config.email_from = ENV['ERRBIT_EMAIL_FROM']
   Errbit::Config.email_at_notices = [1,3,10] #ENV['ERRBIT_EMAIL_AT_NOTICES']
+  Errbit::Config.api_key = ENV['ERRBIT_API_KEY']
+  Errbit::Config.secure = ENV['ERRBIT_SECURE']
+  Errbit::Config.secure = ENV['ERRBIT_PORT']
 else
   yaml = File.read(Rails.root.join('config','config.yml'))
   config = YAML.load(yaml)

--- a/config/initializers/errbit.rb
+++ b/config/initializers/errbit.rb
@@ -1,0 +1,7 @@
+HoptoadNotifier.configure do |config|
+  config.api_key = Errbit::Config.api_key
+  config.host    = Errbit::Config.host
+  config.port    = Errbit::Config.port
+  config.secure  = Errbit::Config.secure
+end if Rails.env.production? && Errbit::Config.api_key
+


### PR DESCRIPTION
to detect errors you need self-register Errbit application, and provide api_key by config.yml or in ERRBIT_API_KEY environment variable in heroku deployments
