### PR TITLE
Fix for YAML Engine on Ruby 1.9.x

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,12 @@
 require 'rubygems'
 
+if RUBY_VERSION.to_f >= 1.9
+  # The psych engine for YAML doesn't handle `<<: *defaults` properly.
+  # See: https://github.com/tenderlove/psych/issues/8
+  require 'yaml'
+  YAML::ENGINE.yamler = 'syck'
+end
+
 # Set up gems listed in the Gemfile.
 gemfile = File.expand_path('../../Gemfile', __FILE__)
 begin
@@ -11,3 +18,4 @@ rescue Bundler::GemNotFound => e
   STDERR.puts "Try running `bundle install`."
   exit!
 end if File.exist?(gemfile)
+


### PR DESCRIPTION
The psych engine for YAML doesn't handle `<<: *defaults` properly in .yml files. (Hash keys are not merged correctly.)
See: https://github.com/tenderlove/psych/issues/8
