### PR TITLE
Allow user to select (None) for issue tracker.

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -35,7 +35,7 @@ class App
   accepts_nested_attributes_for :watchers, :allow_destroy => true,
     :reject_if => proc { |attrs| attrs[:user_id].blank? && attrs[:email].blank? }
   accepts_nested_attributes_for :issue_tracker, :allow_destroy => true,
-    :reject_if => proc { |attrs| !%w(lighthouseapp redmine pivotal fogbugz).include?(attrs[:issue_tracker_type]) }
+    :reject_if => proc { |attrs| !%w(none lighthouseapp redmine pivotal fogbugz).include?(attrs[:issue_tracker_type]) }
 
   # Mongoid Bug: find(id) on association proxies returns an Enumerator
   def self.find_by_id!(app_id)
@@ -68,9 +68,9 @@ class App
   def github_url_to_file(file)
     "#{self.github_url}/blob/master#{file}"
   end
- 
+
   def issue_tracker_configured?
-    issue_tracker && !issue_tracker.project_id.blank?
+    issue_tracker && issue_tracker.issue_tracker_type != "none" && !issue_tracker.project_id.blank?
   end
 
   protected
@@ -96,3 +96,4 @@ class App
     end
 
 end
+

--- a/app/models/issue_tracker.rb
+++ b/app/models/issue_tracker.rb
@@ -14,7 +14,7 @@ class IssueTracker
   field :project_id, :type => String
   field :username, :type => String
   field :password, :type => String
-  field :issue_tracker_type, :type => String, :default => 'lighthouseapp'
+  field :issue_tracker_type, :type => String, :default => 'none'
 
   def create_issue err
     case issue_tracker_type
@@ -130,3 +130,4 @@ class IssueTracker
     end
   end
 end
+

--- a/app/views/apps/_fields.html.haml
+++ b/app/views/apps/_fields.html.haml
@@ -39,6 +39,8 @@
   = f.fields_for :issue_tracker do |w|
     %div.issue_tracker.nested
       %div.choose
+        = w.radio_button :issue_tracker_type, :none
+        = label_tag :issue_tracker_type_lighthouseapp, '(None)', :for => label_for_attr(w, 'issue_tracker_type_none')
         = w.radio_button :issue_tracker_type, :lighthouseapp
         = label_tag :issue_tracker_type_lighthouseapp, 'Lighthouse', :for => label_for_attr(w, 'issue_tracker_type_lighthouseapp')
         = w.radio_button :issue_tracker_type, :redmine
@@ -75,3 +77,4 @@
         = w.text_field :username, :placeholder => 'Username/Email for your account'
         = w.label :password, 'account password'
         = w.password_field :password, :placeholder => 'Password for your account'
+


### PR DESCRIPTION
Allow user to select (None) for issue tracker. From a usability perspective, I wasn't quite sure if Errbit would break when I left the 'lighthouseapp' fields blank. 

This change is mostly just cosmetic.

All tests passing.
