### PR TITLE
Configure "notification frequency" independently for each app.

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -8,6 +8,7 @@ class App
   field :resolve_errs_on_deploy, :type => Boolean, :default => false
   field :notify_on_errs, :type => Boolean, :default => true
   field :notify_on_deploys, :type => Boolean, :default => true
+  field :email_at_notices, :type => Array, :default => Errbit::Config.default_email_at_notices
 
   # Some legacy apps may have sting as key instead of BSON::ObjectID
   identity :type => String

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -55,11 +55,11 @@ class Notice
     agent_string = env_vars['HTTP_USER_AGENT']
     agent_string.blank? ? nil : UserAgent.parse(agent_string)
   end
-  
+
   def self.in_app_backtrace_line? line
     !!(line['file'] =~ %r{^\[PROJECT_ROOT\]/(?!(vendor))})
   end
-  
+
   def request
     read_attribute(:request) || {}
   end
@@ -83,11 +83,11 @@ class Notice
   def cache_last_notice_at
     err.update_attributes(:last_notice_at => created_at)
   end
-  
+
   protected
 
   def should_notify?
-    err.app.notify_on_errs? && Errbit::Config.email_at_notices.include?(err.notices.count) && err.app.watchers.any?
+    err.app.notify_on_errs? && err.app.email_at_notices.include?(err.notices.count) && err.app.watchers.any?
   end
 
 
@@ -122,3 +122,4 @@ class Notice
     end
   end
 end
+

--- a/app/views/apps/_fields.html.haml
+++ b/app/views/apps/_fields.html.haml
@@ -4,21 +4,34 @@
   = f.label :name
   = f.text_field :name
 
-%div.checkbox
-  = f.check_box :notify_on_errs
-  = f.label :notify_on_errs, 'Notify on errors'
-
 %div
   = f.label :github_url
   = f.text_field :github_url
+
+%fieldset
+  %legend Notifications
+  %div.checkbox
+    = f.check_box :notify_on_errs
+    = f.label :notify_on_errs, 'Notify on errors'
+  %div.email_at_notices_nested{:style => f.object.notify_on_errs ? '' : 'display: none;'}
+    .field-helpertext Send a notification every
+    -# Edit the email_at_notices array as a CSV string
+    = f.text_field :email_at_notices, :value => f.object.email_at_notices.join(", ")
+    .field-helpertext times an error occurs. (CSV)
+  %div.checkbox
+    = f.check_box :notify_on_deploys
+    = f.label :notify_on_deploys, 'Notify on deploys'
+
+:javascript
+  $('#app_notify_on_errs').change(function(){
+    var el = $('.email_at_notices_nested');
+    this.checked ? el.show() : el.hide();
+  });
 
 %div.checkbox
   = f.check_box :resolve_errs_on_deploy
   = f.label :resolve_errs_on_deploy, 'Resolve errs on deploy'
 
-%div.checkbox
-  = f.check_box :notify_on_deploys
-  = f.label :notify_on_deploys, 'Notify on deploys'
 
 %fieldset.nested-wrapper
   %legend Watchers

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -14,11 +14,13 @@ host: errbit.example.com
 # will be sent from.
 email_from: errbit@example.com
 
-# Configure when emails are sent for an error.
+# Configure the default value for when emails are sent for an error.
 # [1,3,7] = 1st, 3rd, and 7th occurence triggers
 # an email notification.
-email_at_notices: [1, 10, 100]
+# Each app can be configured individually.
+default_email_at_notices: [1, 10, 100]
 
-# Set to false to suppress confirmation when 
+# Set to false to suppress confirmation when
 # resolving errors.
 confirm_resolve_err: true
+

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -4,7 +4,7 @@ if ENV['HEROKU']
   Errbit::Config = OpenStruct.new
   Errbit::Config.host = ENV['ERRBIT_HOST']
   Errbit::Config.email_from = ENV['ERRBIT_EMAIL_FROM']
-  Errbit::Config.email_at_notices = [1,3,10] #ENV['ERRBIT_EMAIL_AT_NOTICES']
+  Errbit::Config.default_email_at_notices = [1,3,10] #ENV['ERRBIT_EMAIL_AT_NOTICES']
   Errbit::Application.config.action_mailer.smtp_settings = {
     :address        => "smtp.sendgrid.net",
     :port           => "25",
@@ -26,3 +26,4 @@ end
 (Errbit::Application.config.action_mailer.default_url_options ||= {}).tap do |default|
   default.merge! :host => Errbit::Config.host if default[:host].blank?
 end
+

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -350,6 +350,17 @@ form .error-messages ul {
   list-style-type: square;
 }
 
+form .field-helpertext {
+  display: inline;
+  text-transform: uppercase;
+}
+
+form input#app_email_at_notices {
+  width: 130px;
+  margin: 0 5px;
+}
+
+
 /* Tables */
 table {
   width: 100%;
@@ -683,3 +694,4 @@ span.click_span {
 #deploys_div, #repository_div, #watchers_div {
   display: none;
 }
+

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -241,6 +241,27 @@ describe AppsController do
         end
       end
 
+      context "changing email_at_notices" do
+        it "should parse legal csv values" do
+          put :update, :id => @app.id, :app => { :email_at_notices => '1,   4,      7,8,  10' }
+          @app.reload
+          @app.email_at_notices.should == [1, 4, 7, 8, 10]
+        end
+        context "failed parsing of CSV" do
+          it "should set the default value" do
+            @app = Factory(:app, :email_at_notices => [1, 2, 3, 4])
+            put :update, :id => @app.id, :app => { :email_at_notices => 'asdf, -1,0,foobar,gd00,0,abc' }
+            @app.reload
+            @app.email_at_notices.should == Errbit::Config.default_email_at_notices
+          end
+
+          it "should display a message" do
+            put :update, :id => @app.id, :app => { :email_at_notices => 'qwertyuiop' }
+            request.flash[:error].should match(/Couldn't parse/)
+          end
+        end
+      end
+
       context "setting up issue tracker", :cur => true do
         context "unknown tracker type" do
           before(:each) do
@@ -386,3 +407,4 @@ describe AppsController do
   end
 
 end
+

--- a/spec/factories/app_factories.rb
+++ b/spec/factories/app_factories.rb
@@ -1,5 +1,6 @@
 Factory.define(:app) do |p|
   p.name { Factory.next :app_name }
+  p.email_at_notices { [1, 10, 100] }
 end
 
 Factory.define(:app_with_watcher, :parent => :app) do |p|
@@ -26,3 +27,4 @@ Factory.define(:deploy) do |d|
   d.environment   'production'
   d.revision      ActiveSupport::SecureRandom.hex(10)
 end
+

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -21,15 +21,15 @@ describe Notice do
       notice.errors[:notifier].should include("can't be blank")
     end
   end
-  
+
   context '.in_app_backtrace_line?' do
     let(:backtrace) do [{
         'number'  => rand(999),
-        'file'    => '[GEM_ROOT]/gems/actionpack-3.0.4/lib/action_controller/metal/rescue.rb', 
+        'file'    => '[GEM_ROOT]/gems/actionpack-3.0.4/lib/action_controller/metal/rescue.rb',
         'method'  => ActiveSupport.methods.shuffle.first
       }, {
         'number'  => rand(999),
-        'file'    => '[PROJECT_ROOT]/vendor/plugins/seamless_database_pool/lib/seamless_database_pool/controller_filter.rb', 
+        'file'    => '[PROJECT_ROOT]/vendor/plugins/seamless_database_pool/lib/seamless_database_pool/controller_filter.rb',
         'method'  => ActiveSupport.methods.shuffle.first
       }, {
         'number'  => rand(999),
@@ -50,7 +50,7 @@ describe Notice do
       Notice.in_app_backtrace_line?(backtrace[2]).should == true
     end
   end
-  
+
   context '#from_xml' do
     before do
       @xml = Rails.root.join('spec','fixtures','hoptoad_test_notice.xml').read
@@ -159,20 +159,22 @@ describe Notice do
       notice.user_agent.browser.should == 'Chrome'
       notice.user_agent.version.to_s.should =~ /^10\.0/
     end
-    
+
     it "should be nil if HTTP_USER_AGENT is blank" do
       notice = Factory.build(:notice)
       notice.user_agent.should == nil
     end
   end
-  
-  describe "email notifications" do
+
+  describe "email notifications (configured individually for each app)" do
+    custom_thresholds = [2, 4, 8, 16, 32, 64]
+
     before do
-      @app = Factory(:app_with_watcher)
+      @app = Factory(:app_with_watcher, :email_at_notices => custom_thresholds)
       @err = Factory(:err, :app => @app)
     end
 
-    Errbit::Config.email_at_notices.each do |threshold|
+    custom_thresholds.each do |threshold|
       it "sends an email notification after #{threshold} notice(s)" do
         @err.notices.stub(:count).and_return(threshold)
         Mailer.should_receive(:err_notification).
@@ -183,3 +185,4 @@ describe Notice do
   end
 
 end
+


### PR DESCRIPTION
Configure "email_at_notices" independently for each app. We have a combination of both low and high traffic sites, so this feature is useful to stay on top of errors in some cases, and avoid getting spammed in others.

All tests written and passing.

Please note that I have changed `config/config.example.yml`, so you will need to rename `email_at_notices` to `default_email_at_notices` in your `config.yml`.
