### PR TITLE
add SystemTimer for ruby 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'pivotal-tracker'
 gem 'ruby-fogbugz', :require => 'fogbugz'
 gem 'octokit'
 gem 'inherited_resources'
+gem 'SystemTimer', :platform => :ruby_18
 
 group :production do
   gem 'hoptoad_notifier', "~> 2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GIT
 GEM
   remote: http://rubygems.org/
   specs:
+    SystemTimer (1.2.3)
     abstract (1.0.0)
     actionmailer (3.0.5)
       actionpack (= 3.0.5)
@@ -199,6 +200,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  SystemTimer
   bson_ext (~> 1.3.1)
   database_cleaner (~> 0.6.0)
   devise (~> 1.4.0)


### PR DESCRIPTION
will install/use it on 1.8 only <-> silence the warnings
