### PR TITLE
Small enhancements, more to go

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protected
 
     def require_admin!
-      redirect_to(root_path) and return(false) unless user_signed_in? && current_user.admin?
+      redirect_to root_path unless user_signed_in? && current_user.admin?
     end
 
 end

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -7,34 +7,40 @@ class DeploysController < ApplicationController
 
   def create
     @app = App.find_by_api_key!(params[:api_key])
-    if params[:deploy]
-      deploy = {
-        :username     => params[:deploy][:local_username],
-        :environment  => params[:deploy][:rails_env],
-        :repository   => params[:deploy][:scm_repository],
-        :revision     => params[:deploy][:scm_revision],
-        :message      => params[:deploy][:message]
-      }
-    end
-
-    # handle Heroku's HTTP post deployhook format
-    deploy ||= {
-      :username     => params[:user],
-      :environment  => params[:rack_env].try(:downcase) || params[:app],
-      :repository   => "git@heroku.com:#{params[:app]}.git",
-      :revision     => params[:head],
-    }
-
-    @deploy = @app.deploys.create!(deploy)
+    @deploy = @app.deploys.create!(default_deploy || heroku_deploy)
     render :xml => @deploy
   end
 
   def index
     # See AppsController#find_app for the reasoning behind this code.
     app = App.find(params[:app_id])
-    raise(Mongoid::Errors::DocumentNotFound.new(App,app.id)) unless current_user.admin? || current_user.watching?(app)
+    raise Mongoid::Errors::DocumentNotFound.new(App, app.id) unless current_user.admin? || current_user.watching?(app)
 
-    @deploys = app.deploys.order_by(:created_at.desc).paginate(:page =>  params[:page], :per_page => 10)
+    @deploys = app.deploys.order_by(:created_at.desc).paginate(:page => params[:page], :per_page => 10)
   end
-
+  
+  private
+  
+    def default_deploy
+      if params[:deploy]
+        {
+          :username     => params[:deploy][:local_username],
+          :environment  => params[:deploy][:rails_env],
+          :repository   => params[:deploy][:scm_repository],
+          :revision     => params[:deploy][:scm_revision],
+          :message      => params[:deploy][:message]
+        }
+      end
+    end
+  
+    # handle Heroku's HTTP post deployhook format
+    def heroku_deploy
+      {
+        :username     => params[:user],
+        :environment  => params[:rack_env].try(:downcase) || params[:app],
+        :repository   => "git@heroku.com:#{params[:app]}.git",
+        :revision     => params[:head],
+      }
+    end
+    
 end

--- a/app/controllers/errs_controller.rb
+++ b/app/controllers/errs_controller.rb
@@ -5,15 +5,12 @@ class ErrsController < ApplicationController
 
   def index
     app_scope = current_user.admin? ? App.all : current_user.apps
-    where_clause = {}
-    where_clause[:environment] = params[:environment] if(params[:environment].present?)
+    @errs = Err.for_apps(app_scope).in_env(params[:environment]).unresolved.ordered
     respond_to do |format|
       format.html do
-        @errs = Err.for_apps(app_scope).where(where_clause).unresolved.ordered.paginate(:page => params[:page], :per_page => current_user.per_page)
+        @errs = @errs.paginate(:page => params[:page], :per_page => current_user.per_page)
       end
-      format.atom do
-        @errs = Err.for_apps(app_scope).where(where_clause).unresolved.ordered
-      end
+      format.atom
     end
   end
 

--- a/app/models/err.rb
+++ b/app/models/err.rb
@@ -25,8 +25,11 @@ class Err
   scope :resolved, where(:resolved => true)
   scope :unresolved, where(:resolved => false)
   scope :ordered, order_by(:last_notice_at.desc)
-  scope :in_env, lambda {|env| where(:environment => env)}
   scope :for_apps, lambda {|apps| where(:app_id.in => apps.all.map(&:id))}
+  
+  def self.in_env(env)
+    env.present? ? where(:environment => env) : scoped
+  end
 
   def self.for(attrs)
     app = attrs.delete(:app)

--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -13,14 +13,14 @@
   - if current_user.admin?
     = link_to 'edit', edit_app_path(@app), :class => 'button'
     = link_to 'destroy', app_path(@app), :method => :delete, :confirm => 'Seriously?', :class => 'button'
-    - if @all_errs == true
+    - if @all_errs
       = link_to 'unresolved errs', app_path(@app), :class => 'button'
     - else
-      = link_to 'all errs', app_path(@app, {:all_errs => true}), :class => 'button'
+      = link_to 'all errs', app_path(@app, :all_errs => true), :class => 'button'
 
-%h3{:id => 'watchers_toggle'}
+%h3#watchers_toggle
   Watchers
-  %span{:class => 'click_span'} (show/hide)
+  %span.click_span (show/hide)
 #watchers_div
   - if @app.notify_all_users
     %table.watchers
@@ -42,9 +42,9 @@
               %em Sadly, no one is watching this app
 
 - if @app.github_url?
-  %h3{:id => 'repository_toggle'}
+  %h3#repository_toggle
     Repository
-    %span{:class => 'click_span'} (show/hide)
+    %span.click_span (show/hide)
   #repository_div
     %table.repository
       %thead
@@ -54,9 +54,9 @@
         %tr
           %td= link_to(@app.github_url, @app.github_url, :target => '_blank')
 
-%h3{:id => 'deploys_toggle'}
+%h3#deploys_toggle
   Latest Deploys
-  %span{:class => 'click_span'} (show/hide)
+  %span.click_span (show/hide)
 #deploys_div
   - if @deploys.any?
     %table.deploys


### PR DESCRIPTION
Simplified where_clauses in controllers.
In before filter you can simply redirect to halt execution (simplified require_admin!).
Extracted creating deploy logic to separate methods for defaut deploy and heroku deploy.
Haml views should use haml-style tag declarations:
  %h3#watchers_toggle
  not
  %h3{:id => 'watchers_toggle'}
