### PR TITLE
Fixed migration from Err to Problem, so that

### DIFF
--- a/db/migrate/20110905134638_link_errs_to_problems.rb
+++ b/db/migrate/20110905134638_link_errs_to_problems.rb
@@ -12,7 +12,11 @@ class LinkErrsToProblems < Mongoid::Migration
     puts "==== Create a Problem for each Err..."
     Err.all.each do |err|
       if err['app_id'] && app = App.where(:_id => err['app_id']).first
-        err.problem = app.problems.create
+        err.problem = app.problems.create(:_id => err.id)
+        err.problem.resolve! if err.resolved
+        # don't bother checking err for issue link, if it ain't got one the NoMethodError
+        # is raised, else this works fine.
+        err.problem.update_attribute(:issue_link, err.issue_link) rescue NoMethodError
         err.save
       end
     end


### PR DESCRIPTION
- old links to errors will keep working (problems have the same id's as original err)
- problems are marked resolved if the original err was resolved.
- if the err had an issue_link, then the new problem also has that link.
