### PR TITLE
Update the latest value on the problem containing the error.

### DIFF
--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -45,6 +45,7 @@ class ErrorReport
       :fingerprint => fingerprint)
 
     err.notices << notice
+    err.respond_to?(:problem) && err.problem.cache_notice_attributes
     notice
   end
 end


### PR DESCRIPTION
This didn't seem to be happening for problems that had been merged together
and a new err came in. At least this is what we observed and doing a
rake errbit:db:update_problem_attrs updated the latest value for the problem.

This is just a demostration how this issue might be solved, I have no idea
whether this is the correct solution.
