### PR TITLE
Added ics format for a problem, listing its linked notices in ics format.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,22 @@ module ApplicationHelper
     create_percentage_table_for(problem) {|notice| notice.message}
   end
 
+  def generate_problem_ical(notices)
+    RiCal.Calendar do |cal|
+      notices.each_with_index do |notice,idx|
+        cal.event do |event|
+          event.summary     = "#{idx+1} #{notice.message.to_s}"
+          event.description = notice.request['url']
+          event.dtstart     = notice.created_at.utc
+          event.dtend       = notice.created_at.utc + 60.minutes
+          event.organizer   = notice.server_environment && notice.server_environment["hostname"]
+          event.location    = notice.server_environment && notice.server_environment["project-root"]
+          event.url         = app_err_url(:app_id => notice.problem.app.id, :id => notice.problem)
+        end
+      end
+    end.to_s
+  end
+
   def generate_ical(deploys)
     RiCal.Calendar { |cal|
       deploys.each_with_index do |deploy,idx|

--- a/app/views/errs/show.html.haml
+++ b/app/views/errs/show.html.haml
@@ -11,6 +11,8 @@
   %strong Last Notice:
   = last_notice_at(@problem).to_s(:micro)
 - content_for :action_bar do
+  - if current_user.authentication_token
+    %span= link_to 'iCal', app_err_path(:app_id => @app.id, :id => @problem.id, :format => "ics", :auth_token => current_user.authentication_token), :class => "calendar_link"
   - if @problem.app.issue_tracker_configured?
     - if @problem.issue_link.blank?
       %span= link_to 'create issue', create_issue_app_err_path(@app, @problem), :method => :post, :class => "#{@app.issue_tracker.class::Label}_create create-issue"

--- a/app/views/errs/show.ics.haml
+++ b/app/views/errs/show.ics.haml
@@ -1,0 +1,1 @@
+= generate_problem_ical(@problem.notices.order_by(:created_at.asc))


### PR DESCRIPTION
Added ics format for a problem, listing its linked notices in ics format.

Strictly this shouldn't be necessary however our use case is that we're monitoring
a particular problem and what to know whether there is a pattern in when it's
occurring. Hence iCal and ics format. Quiet nice in combination with the deploy calendar
as then one can see whether a particular deployment might have caused the error.
