### PR TITLE
bgclr instead of transparent. annoying the error lines get too wide

### DIFF
--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -421,6 +421,7 @@ table thead + tbody tr:first-child td {
 }
 table th { background-color: #ececec; font-weight: bold; text-transform: uppercase; white-space: nowrap; }
 table tbody tr:nth-child(odd) td { background-color: #F9F9F9; }
+table tbody tr:nth-child(even) td { background-color: #fff; }
 table .main { width: 100%; }
 
 table.single_user {


### PR DESCRIPTION
something that bothered me was that when errors get to wide and go beyond the white background in the middle, they let the background shine through.
