### PR TITLE
Fix for "ArgumentError: invalid byte sequence in US-ASCII"

### DIFF
--- a/app/models/issue_trackers/github_issues_tracker.rb
+++ b/app/models/issue_trackers/github_issues_tracker.rb
@@ -21,7 +21,7 @@ class IssueTrackers::GithubIssuesTracker < IssueTracker
 
   def create_issue(err)
     client = Octokit::Client.new(:login => username, :token => api_token)
-    issue = client.create_issue(project_id, issue_title(err), body_template.result(binding), options = {})
+    issue = client.create_issue(project_id, issue_title(err), body_template.result(binding).unpack('C*').pack('U*'), options = {})
     err.update_attribute :issue_link, issue.html_url
   end
 


### PR DESCRIPTION
Fix for "ArgumentError: invalid byte sequence in US-ASCII" when creating github issue
