### PR TITLE
Support Airbrake and v2.2 API

### DIFF
--- a/lib/hoptoad.rb
+++ b/lib/hoptoad.rb
@@ -18,6 +18,7 @@ module Hoptoad
     def self.get_version_processor(version)
       case version
       when '2.0'; Hoptoad::V2
+      when '2.2'; Hoptoad::V2
       else;       raise ApiVersionError
       end
     end


### PR DESCRIPTION
I don't see any differences between the Airbrake 2.2 XML notice and the Hoptoad 2.0 one. I was able to use the airbrake gem with Errbit as-is. (This should resolve issue #74.)
