### PR TITLE
Reset notice count when an issue is resolved

### DIFF
--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -47,7 +47,7 @@ class Problem
   end
 
   def resolve!
-    self.update_attributes!(:resolved => true)
+    self.update_attributes!(:resolved => true, :notices_count => 0)
   end
 
   def unresolve!

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -106,6 +106,24 @@ describe Notice do
     end
   end
 
+  describe "email notifications for a resolved issue" do
 
+    before do
+      Errbit::Config.per_app_email_at_notices = true
+      @app = Factory(:app_with_watcher, :email_at_notices => [1])
+      @err = Factory(:err, :problem => Factory(:problem, :app => @app, :notices_count => 100))
+    end
+
+    after do
+      Errbit::Config.per_app_email_at_notices = false
+    end
+
+    it "should send email notification after 1 notice since an error has been resolved" do
+      @err.problem.resolve!
+      Mailer.should_receive(:err_notification).
+        and_return(mock('email', :deliver => true))
+      Factory(:notice, :err => @err)
+    end
+  end
 end
 


### PR DESCRIPTION
Reset notice count when an issue is resolved and send emails when appropriate
