### PR TITLE
unicorn on heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,6 @@ group :test do
 end
 
 group :heroku do
-  gem 'thin'
+  gem 'unicorn'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,6 @@ GEM
     crack (0.3.1)
     css_parser (1.2.5)
       addressable
-    daemons (1.1.4)
     database_cleaner (0.6.7)
     devise (1.4.7)
       bcrypt-ruby (~> 3.0)
@@ -56,7 +55,6 @@ GEM
       rspec (~> 2.0)
     erubis (2.6.6)
       abstract (>= 1.0.0)
-    eventmachine (0.12.10)
     factory_girl (1.3.3)
     factory_girl_rails (1.0.1)
       factory_girl (~> 1.3)
@@ -80,6 +78,7 @@ GEM
     inherited_resources (1.3.0)
       has_scope (~> 0.5.0)
       responders (~> 0.6.0)
+    kgio (2.6.0)
     libxml-ruby (2.2.2)
     lighthouse-api (2.0)
       activeresource (>= 3.0.0)
@@ -149,6 +148,7 @@ GEM
       rake (>= 0.8.7)
       rdoc (~> 3.4)
       thor (~> 0.14.4)
+    raindrops (0.8.0)
     rake (0.9.2)
     rbx-require-relative (0.0.5)
     rdoc (3.9.4)
@@ -187,10 +187,6 @@ GEM
       typhoeus
     ruby_core_source (0.1.5)
       archive-tar-minitar (>= 0.5.2)
-    thin (1.2.11)
-      daemons (>= 1.0.9)
-      eventmachine (>= 0.12.6)
-      rack (>= 1.0.0)
     thor (0.14.6)
     treetop (1.4.10)
       polyglot
@@ -199,6 +195,10 @@ GEM
       mime-types
       mime-types
     tzinfo (0.3.30)
+    unicorn (4.1.1)
+      kgio (~> 2.4)
+      rack
+      raindrops (~> 0.6)
     useragent (0.3.2)
     warden (1.0.5)
       rack (>= 1.0)
@@ -237,7 +237,7 @@ DEPENDENCIES
   ruby-debug
   ruby-debug19
   ruby-fogbugz
-  thin
+  unicorn
   useragent (~> 0.3.1)
   webmock
   will_paginate (>= 3)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails server thin -p $PORT
+web:   bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,4 @@
+# http://michaelvanrooijen.com/articles/2011/06/01-more-concurrency-on-a-single-heroku-dyno-with-the-new-celadon-cedar-stack/
+
+worker_processes 3 # amount of unicorn workers to spin up
+timeout 30         # restarts workers that hang for 30 seconds


### PR DESCRIPTION
Thin replaced by unicorn to get more concurrency from a single heroku dyno.

Read more at http://michaelvanrooijen.com/articles/2011/06/01-more-concurrency-on-a-single-heroku-dyno-with-the-new-celadon-cedar-stack/
