### PR TITLE
use http instead of https in TravisCI image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Errbit [![TravisCI](https://travis-ci.org/errbit/errbit.png?branch=master)](http://travis-ci.org/errbit/errbit)
+Errbit [![TravisCI](http://travis-ci.org/errbit/errbit.png?branch=master)](http://travis-ci.org/errbit/errbit)
 ======
 
 **The open source self-hosted error catcher**


### PR DESCRIPTION
Image from TravisCI doesn't show, because of ssl warnings.

http://screencast.com/t/bFqLLhWq

So I've replaces https to http in image link.
