### PR TITLE
Don't log DocumentNotFound exception

### DIFF
--- a/config/initializers/hoptoad.rb
+++ b/config/initializers/hoptoad.rb
@@ -2,5 +2,8 @@ HoptoadNotifier.configure do |config|
   # Internal Errbit errors are stored locally, but we need
   # to set a dummy API key so that HoptoadNotifier doesn't complain.
   config.api_key = "---------"
+
+  # Don't log error that causes 404 page
+  config.ignore << "Mongoid::Errors::DocumentNotFound"
 end
 


### PR DESCRIPTION
It resolves #125.

When `Mongoid::Errors::DocumentNotFound` is raising 404 page (http://git.io/h0blDg#L78) is rendered but this exception is also logged to `Self.Errbit`.

HoptoadNotifier ignores by default `ActiveRecord::RecordNotFound` so it's reasonable to ignore `Mongoid::Errors::DocumentNotFound` as well.
