### PR TITLE
hoptoad-ios reports its API version as 2.1.

### DIFF
--- a/lib/hoptoad.rb
+++ b/lib/hoptoad.rb
@@ -3,7 +3,7 @@ require 'hoptoad/v2'
 module Hoptoad
   class ApiVersionError < StandardError
     def initialize
-      super "Wrong API Version: Expecting v2.0"
+      super "Wrong API Version: Expecting 2.0, 2.1, or 2.2"
     end
   end
 
@@ -17,9 +17,8 @@ module Hoptoad
   private
     def self.get_version_processor(version)
       case version
-      when '2.0'; Hoptoad::V2
-      when '2.2'; Hoptoad::V2
-      else;       raise ApiVersionError
+      when /2\.[012]/; Hoptoad::V2
+      else;            raise ApiVersionError
       end
     end
 end


### PR DESCRIPTION
Small change to handle version /2.[0-2]/ of the Hoptoad/Airbrake API and say as much in the message for ApiVersionError.
