### PR TITLE
Update readme to add instructions for heroku deploy hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ heroku addons:add cron:daily
 heroku rake errbit:db:clear_resolved
 ```
 
+  5. You may want to enable the deployment hook for heroku :
+
+```bash
+heroku addons:add deployhooks:http url="http://YOUR_ERRBIT_HOST/deploys.txt?api_key=YOUR_API_KEY"
+```
+
   5. Enjoy!
 
 


### PR DESCRIPTION
Instructions aren't really clear for that one, one has to go read the airbrake documentation to do so (and it's a bit hidden), plus airbrake documentation doesn't exactly use the correct deploy format.
