### PR TITLE
Prevent rake 0.9.2.2 from failing when clearing default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require 'bundler'
 
 Errbit::Application.load_tasks
 
-Rake::Task[:default].clear
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
 
 namespace :spec do
   desc "Preparing test env"


### PR DESCRIPTION
rake 0.9.2 would (apparently) wouldn't fail if you tried to clear
a task that wasn't defined.  

This closes issue #179 where trying to run the db:seed rake task 
would fail with the error Don't know how to build task 'default'

Tested on ruby-1.9.2-p290 and ruby-1.9.3-p125 only, rake 0.9.2.2
