### PR TITLE
Do not try to clear :default rake task if it is absent

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require 'bundler'
 
 Errbit::Application.load_tasks
 
-Rake::Task[:default].clear
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
 
 namespace :spec do
   desc "Preparing test env"


### PR DESCRIPTION
When running "bundle exec rake <task> RAILS_ENV=production" - everythin failed with "Don't know how to build task 'default'". Not it's fixed.
