### PR TITLE
fix error when only one app is present

### DIFF
--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -31,6 +31,17 @@ describe AppsController do
         assigns(:apps).should_not include(unwatched_app)
       end
     end
+
+    context 'when there is only one app' do
+      it 'sets unresolved_counts and problem_counts variables' do
+        sign_in Fabricate(:admin)
+        app = Fabricate(:app)
+        get :index
+
+        assigns(:unresolved_counts).should == {app.id => 0}
+        assigns(:problem_counts).should    == {app.id => 0}
+      end
+    end
   end
 
   describe "GET /apps/:id" do


### PR DESCRIPTION
It fixes `ActionView::Template::Error (undefined method '>' for nil:NilClass)`
error. This error was showing when there is only one app was present.
In AppsController when we were trying to sort our apps and if `apps.count == 1`
the sort method actually doesn't call block so we had empty
`@unresolved_counts`, `@problem_counts` assigns.
