### PR TITLE
[production][apps#show] Sprockets::Helpers::RailsHelper::AssetPaths::AssetNotPrecompiledError in Apps#show 

### DIFF
--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -1,7 +1,7 @@
 - content_for :title, @app.name
 - content_for :head do
   = auto_discovery_link_tag :atom, app_path(@app, User.token_authentication_key => current_user.authentication_token, :format => "atom"), :title => "Errbit notices for #{@app.name} at #{request.host}"
-  = javascript_include_tag 'apps.show'
+  = javascript_include_tag 'apps.show.js'
 - content_for :meta do
   %strong Errors Caught:
   = @app.problems.count


### PR DESCRIPTION
```
apps.show isn't precompiled
```

I couldn't get my copy of Errbit to automatically open an issue for this.

This is happening on Heroku whenever I hit the apps#show action. I can confirm (by running `assets:precompile` locally, and by running `heroku run bash` to look for the file on Heroku) that `apps.show.js` is in fact being precompiled.

Changing like 4 of [show.html.haml](https://github.com/errbit/errbit/blob/master/app/views/apps/show.html.haml#L4) to `= javascript_include_tag 'apps.show.js'` fixes this for me. :grin:
