### PR TITLE
serialized attributes need to be cast to string

### DIFF
--- a/app/views/notices/_user_attributes.html.haml
+++ b/app/views/notices/_user_attributes.html.haml
@@ -6,4 +6,4 @@
     - user.each do |user_key, user_value|
       %tr
         %th= user_key
-        %td= auto_link(user_value).html_safe
+        %td= auto_link(user_value.to_s).html_safe


### PR DESCRIPTION
When using the new 'store' method on the user object, values are hashes, which need to be converted to strings before calling auto_link.

This patch fixes the error below:

NoMethodError in Errs#show

Showing /var/www/html/production/errbit/app/views/notices/_user_attributes.html.haml where line #9 raised:

undefined method `html_safe' for {"primary_organization_id"=>"2989"}:BSON::OrderedHash
Extracted source (around line #9):

6:     - user.each do |user_key, user_value|
7:       %tr
8:         %th= user_key
9:         %td= auto_link(user_value).html_safe
Trace of template inclusion: app/views/errs/show.html.haml

Rails.root: /var/www/html/production/errbit

Application Trace | Framework Trace | Full Trace
app/views/notices/_user_attributes.html.haml:9:in `block in _app_views_notices__user_attributes_html_haml__1385948542441780216_47524400'
app/views/notices/_user_attributes.html.haml:6:in`each'
app/views/notices/_user_attributes.html.haml:6:in `_app_views_notices__user_attributes_html_haml__1385948542441780216_47524400'
app/views/errs/show.html.haml:68:in`_app_views_errs_show_html_haml__1589591340509044615_36489320'
