### PR TITLE
README.md adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ heroku run rake db:seed
   * You may want to enable the deployment hook for heroku :
 
 ```bash
-heroku addons:add deployhooks:http url="http://YOUR_ERRBIT_HOST/deploys.txt?api_key=YOUR_API_KEY"
+heroku addons:add deployhooks:http --url="http://YOUR_ERRBIT_HOST/deploys.txt?api_key=YOUR_API_KEY"
 ```
 
   * Enjoy!


### PR DESCRIPTION
According to Heroku warning: 

> non-unix style params have been deprecated, use `--url=…` for deployhooks:http
