### PR TITLE
WHAT&WHERE - ellipsis hiding

### DIFF
--- a/app/assets/stylesheets/errbit.css
+++ b/app/assets/stylesheets/errbit.css
@@ -648,6 +648,13 @@ table.errs td.app .environment {
 table.errs td.message a {
   display: block;
   word-wrap: break-word;
+  /* PjpG - configuration in WHAT & WHERE table's columns using ellipsis to avoid oversizing table's width */
+    width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
+    white-space: nowrap;
+  /* ------ */
 }
 table.errs td.message em {
   color: #727272;


### PR DESCRIPTION
Added ellipsis overflow and changed width of anchor tag in WHAT&WHERE columns to avoid oversizing table.
