### PR TITLE
Notice XML now returns notice ID

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -5,8 +5,11 @@ class NoticesController < ApplicationController
 
   def create
     # params[:data] if the notice came from a GET request, raw_post if it came via POST
-    @notice = App.report_error!(params[:data] || request.raw_post)
-    render :xml => @notice.to_xml(:only => false, :methods => [:id])
+    notice = App.report_error!(params[:data] || request.raw_post)
+    api_xml = notice.to_xml(:only => false, :methods => [:id]) do |xml|
+      xml.url locate_url(notice.id, :host => Errbit::Config.host)
+    end
+    render :xml => api_xml
   end
 
   # Redirects a notice to the problem page. Useful when using User Information at Airbrake gem.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Errbit::Application.routes.draw do
 
   # Hoptoad Notifier Routes
   match '/notifier_api/v2/notices' => 'notices#create'
-  match '/locate/:id' => 'notices#locate'
+  match '/locate/:id' => 'notices#locate', :as => :locate
   match '/deploys.txt' => 'deploys#create'
 
   resources :notices,   :only => [:show]

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -21,6 +21,7 @@ describe NoticesController do
       # Same RegExp from Airbrake::Sender#send_to_airbrake (https://github.com/airbrake/airbrake/blob/master/lib/airbrake/sender.rb#L53)
       # Inspired by https://github.com/airbrake/airbrake/blob/master/test/sender_test.rb
       response.body.should match(%r{<id[^>]*>#{@notice.id}</id>})
+      response.body.should match(%r{<url[^>]*>(.+)#{locate_path(@notice.id)}</url>})
     end
 
     it "generates a notice from xml [GET]" do
@@ -28,6 +29,7 @@ describe NoticesController do
       get :create, :data => @xml, :format => :xml
       response.should be_success
       response.body.should match(%r{<id[^>]*>#{@notice.id}</id>})
+      response.body.should match(%r{<url[^>]*>(.+)#{locate_path(@notice.id)}</url>})
     end
 
     it "sends a notification email" do
@@ -36,6 +38,7 @@ describe NoticesController do
       post :create, :format => :xml
       response.should be_success
       response.body.should match(%r{<id[^>]*>#{@notice.id}</id>})
+      response.body.should match(%r{<url[^>]*>(.+)#{locate_path(@notice.id)}</url>})
       email = ActionMailer::Base.deliveries.last
       email.to.should include(@app.watchers.first.email)
       email.subject.should include(@notice.message)


### PR DESCRIPTION
In short, it fixes issue #227. Errbit now have the same behaviour as Airbrake on the matter of informing the user.

Already using it on production. It works! :-)
