### PR TITLE
don't break when running all migrations if using a newer Errbit

### DIFF
--- a/db/migrate/20110422152027_move_notices_to_separate_collection.rb
+++ b/db/migrate/20110422152027_move_notices_to_separate_collection.rb
@@ -5,6 +5,10 @@ class MoveNoticesToSeparateCollection < Mongoid::Migration
     errs = mongo_db.collection("errs").find({ }, :fields => ["notices"])
     errs.each do |err|
       next unless err['notices']
+      
+      # This Err was created after the Problem->Err->Notice redesign
+      next if err['app_id'].nil? or err['problem_id']
+      
       e = Err.find(err['_id'])
       # disable email notifications
       old_notify = e.app.notify_on_errs?


### PR DESCRIPTION
### Steps to Reproduce
- Use Errbit with a fresh database
- Create a few problems
- _Then_ run migrations
### What happens
- The first migration throws an exception
### Fix
- Don't apply the first migration to errs created after notices were split into a separate table
