### PR TITLE
Rake task to delete unnecessary notices in batch

### DIFF
--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -1,12 +1,12 @@
 namespace :errbit do
   namespace :db do
-    
+
     desc "Updates cached attributes on Problem"
     task :update_problem_attrs => :environment do
       puts "Updating problems"
       Problem.all.each(&:cache_notice_attributes)
     end
-    
+
     desc "Updates Problem#notices_count"
     task :update_notices_count => :environment do
       puts "Updating problem.notices_count"
@@ -14,12 +14,30 @@ namespace :errbit do
         p.update_attributes(:notices_count => p.notices.count)
       end
     end
-    
+
     desc "Delete resolved errors from the database. (Useful for limited heroku databases)"
     task :clear_resolved => :environment do
       count = Problem.resolved.count
       Problem.resolved.each {|problem| problem.destroy }
       puts "=== Cleared #{count} resolved errors from the database." if count > 0
+    end
+
+    desc "Remove notices in batch"
+    task :notices_delete, [ :problem_id ] => [ :environment ] do
+      BATCH_SIZE = 1000
+      if args[:problem_id]
+        item_count = Problem.find(args[:problem_id]).notices.count
+        removed_count = 0
+        puts "Notices to remove: #{item_count}"
+        while item_count > 0
+          Problem.find(args[:problem_id]).notices.limit(BATCH_SIZE).each do |notice|
+            notice.remove
+            removed_count += 1
+          end
+          item_count -= BATCH_SIZE
+          puts "Removed #{removed_count} notices"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Hi,

Sometimes some of our apps get out of control (database are gone, or something else was happened). And errbit receives a lot of error notices.

After resolving issue with more then 10000 notices I've tried to delete the unnecessary old ones. Unfortunately I get a timeouts with my unicorns. If I choose to remove notices via rails console my code takes a lot of memory.

So I decided to create a little rake task which automatically removes all notices from database by given problem ID (and without memory consumption, because it uses batches).

**How to use it:**

For example URL for problem "app is out of control" is like this
`http://.../apps/4feb2b1fdd982357f5000001/errs/503d327fdd98230c7900006e`
`503d327fdd98230c7900006e` here is the our problem ID

We can go to the errbit server console and run here notices_delete task like this:

```
$ rake 'errbit:db:notices_delete[503d327fdd98230c7900006e]'
Notices to remove: ...
...
```
