### PR TITLE
Dedent all errs button so it appears for non-admins on individual app pages

### DIFF
--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -12,10 +12,10 @@
   - if current_user.admin?
     = link_to 'edit', edit_app_path(@app), :class => 'button'
     = link_to 'destroy', app_path(@app), :method => :delete, :data => { :confirm => 'Seriously?' }, :class => 'button'
-    - if @all_errs
-      = link_to 'unresolved errs', app_path(@app), :class => 'button'
-    - else
-      = link_to 'all errs', app_path(@app, :all_errs => true), :class => 'button'
+  - if @all_errs
+    = link_to 'unresolved errs', app_path(@app), :class => 'button'
+  - else
+    = link_to 'all errs', app_path(@app, :all_errs => true), :class => 'button'
 
 %h3#watchers_toggle
   Watchers


### PR DESCRIPTION
Currently, for non-admins the "Show Resolved" button appears under the "Errors" tab, but only admins can see the "all errs" button when viewing errors for a specific app within the "Apps" tab. 

This makes the button to show resolved errors visible on individual app pages for all users, as it is on the Errors tab.
