### PR TITLE
Add mention of errbit-php in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,19 @@ or you can set up the GitHub Issues tracker for your **Self.Errbit** app:
   * You can now easily post bug reports to GitHub Issues by clicking the **Create Issue** button on a **Self.Errbit** error.
 
 
+Use Errbit with applications written in other languages
+-------------------------------------------------------
+
+In theory, any Airbrake-compatible error catcher for other languages should work with Errbit.
+Solutions known to work are listed below:
+
+<table>
+  <tr>
+    <th>PHP (&gt;= 5.3)</th>
+    <td>https://github.com/flippa/errbit-php</td>
+  </tr>
+</table>
+
 TODO
 ----
 


### PR DESCRIPTION
PR as requested, to point PHP users to errbit-php. I added a section to the README that leaves this open to other languages having their clients listed here, as I assume there are error catchers for e.g. Python, Perl and Java too.
