### PR TITLE
add mongodb as a travis service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 1.9.3
   - 1.9.2
   - 1.8.7
+services: mongodb
 
 # To stop Travis from running tests for a new commit,
 # add the following to your commit message: [ci skip]


### PR DESCRIPTION
Since august, travis [updated it's environment settings](http://about.travis-ci.org/blog/august-2012-upcoming-ci-environment-updates/).
Services like mongodb needs to be explicitely specified in order to be installed.

Adding mongodb as a service here should fix the build.
