### PR TITLE
Correctly set error class for JS notifier requests

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -92,13 +92,13 @@ var Hoptoad = {
 
       var methods = ['params', 'session'];
 
-      for (var i = 0; i < 2; i++) {
-        var type = methods[i];
+      for (var i = 0; i < methods.length; i++) {
+        var method = methods[i];
 
-        if (error[type]) {
-          data += '<' + type + '>';
-          data += Hoptoad.generateVariables(error[type]);
-          data += '</' + type + '>';
+        if (error[method]) {
+          data += '<' + method + '>';
+          data += Hoptoad.generateVariables(error[method]);
+          data += '</' + method + '>';
         }
       }
 


### PR DESCRIPTION
Small bugfix for `.generateXML` method in `notifier.js`. Error class was not set correctly, as `type` variable (line 77) was being overwritten by another variable `type` (line 96). Because of this, `type` was always set to "session".
