### PR TITLE
No need in pushing mongo.yml to heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,6 @@ git clone http://github.com/errbit/errbit.git
 gem install heroku
 heroku create example-errbit --stack cedar
 heroku addons:add mongolab:starter
-cp -f config/mongoid.mongolab.yml config/mongoid.yml
-git add -f config/mongoid.yml
-git commit -m "Added mongoid config for Mongolab"
 heroku addons:add sendgrid:starter
 heroku config:add HEROKU=true
 heroku config:add ERRBIT_HOST=some-hostname.example.com


### PR DESCRIPTION
Errbit is aware of MONGOLAB_URI environment variable.
