### PR TITLE
added support to change the branch name for backtrace links - default to...

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -6,6 +6,7 @@ class App
   field :api_key
   field :github_repo
   field :bitbucket_repo
+  field :repository_branch
   field :resolve_errs_on_deploy, :type => Boolean, :default => false
   field :notify_all_users, :type => Boolean, :default => false
   field :notify_on_errs, :type => Boolean, :default => true
@@ -106,6 +107,9 @@ class App
   end
   alias :notify_on_deploys? :notify_on_deploys
 
+  def repo_branch
+    self.repository_branch.present? ? self.repository_branch : 'master'
+  end
 
   def github_repo?
     self.github_repo.present?
@@ -116,7 +120,7 @@ class App
   end
 
   def github_url_to_file(file)
-    "#{github_url}/blob/master#{file}"
+    "#{github_url}/blob/#{repo_branch + file}"
   end
 
   def bitbucket_repo?
@@ -128,7 +132,7 @@ class App
   end
 
   def bitbucket_url_to_file(file)
-    "#{bitbucket_url}/src/master#{file}"
+    "#{bitbucket_url}/src/#{repo_branch + file}"
   end
 
 

--- a/app/views/apps/_fields.html.haml
+++ b/app/views/apps/_fields.html.haml
@@ -5,6 +5,9 @@
   = f.text_field :name
 
 %div
+  = f.label :repository_branch
+  = f.text_field :repository_branch, :placeholder => "master"
+%div
   = f.label :github_repo
   = f.text_field :github_repo, :placeholder => "errbit/errbit from https://github.com/errbit/errbit"
 %div


### PR DESCRIPTION
... master

This is for issue 140, I've implemented it.
#140
