### PR TITLE
Campfire message tweaks.

### DIFF
--- a/app/models/notification_services/campfire_service.rb
+++ b/app/models/notification_services/campfire_service.rb
@@ -25,7 +25,7 @@ if defined? Campy
       campy = Campy::Room.new(:account => subdomain, :token => api_token, :room_id => room_id)
 
       # post the issue to the campfire room
-      campy.speak "[errbit] http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s} #{notification_description problem}"
+      campy.speak "[errbit] #{problem.app.name} #{notification_description problem} - http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}/problems/#{problem.id.to_s}"
     end
   end
 end


### PR DESCRIPTION
Include app name in Campfire message, and link to problem rather than app.
