### PR TITLE
throthle email notificatiions

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -102,6 +102,10 @@ class App
   end
   alias :notify_on_errs? :notify_on_errs
 
+  def notifiable?
+    notify_on_errs? && notification_recipients.any?
+  end
+
   def notify_on_deploys
     !(self[:notify_on_deploys] == false)
   end
@@ -167,6 +171,10 @@ class App
         end
       end
     end
+  end
+
+  def email_at_notices
+    Errbit::Config.per_app_email_at_notices ? read_attribute(:email_at_notices) : Errbit::Config.email_at_notices
   end
 
   protected

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -96,6 +96,18 @@ class Notice
     backtrace_lines.in_app
   end
 
+  def similar_count
+    problem.notices_count
+  end
+
+  def notifiable?
+    app.email_at_notices.include?(similar_count)
+  end
+
+  def should_notify?
+    app.notifiable? && notifiable?
+  end
+
   protected
 
   def increase_counter_cache

--- a/app/models/notice_observer.rb
+++ b/app/models/notice_observer.rb
@@ -7,16 +7,7 @@ class NoticeObserver < Mongoid::Observer
       notice.app.notification_service.create_notification(notice.problem)
     end
 
-    if notice.app.notification_recipients.any?
-      Mailer.err_notification(notice).deliver
-    end
+    Mailer.err_notification(notice).deliver if notice.should_notify?
   end
 
-  private
-
-  def should_notify? notice
-    app = notice.app
-    app.notify_on_errs? and (app.notification_recipients.any? or !app.notification_service.nil?) and
-      (app.email_at_notices or Errbit::Config.email_at_notices).include?(notice.problem.notices_count)
-  end
 end

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -261,6 +261,10 @@ describe AppsController do
       end
 
       context "changing email_at_notices" do
+        before do
+          Errbit::Config.per_app_email_at_notices = true
+        end
+
         it "should parse legal csv values" do
           put :update, :id => @app.id, :app => { :email_at_notices => '1,   4,      7,8,  10' }
           @app.reload


### PR DESCRIPTION
It used to be that email notifications are sent not on each error occurrence but on configured ones. After some change it is not like this anymore. This pull request brings this functionality back.
