### PR TITLE
Tracker labelling

### DIFF
--- a/app/models/issue_trackers/lighthouse_tracker.rb
+++ b/app/models/issue_trackers/lighthouse_tracker.rb
@@ -3,8 +3,8 @@ if defined? Lighthouse
     Label = "lighthouseapp"
     Fields = [
       [:account, {
-        :label       => "Account (subdomain)",
-        :placeholder => "example if http://example.lighthouseapp.com"
+        :label       => "Lighthouse Subdomain",
+        :placeholder => "example"
       }],
       [:api_token, {
         :label       => "API Token",
@@ -18,7 +18,7 @@ if defined? Lighthouse
 
     def check_params
       if Fields.detect {|f| self[f[0]].blank? }
-        errors.add :base, 'You must specify your Lighthouseapp account, API token and Project ID'
+        errors.add :base, 'You must specify your Lighthouseapp Subdomain, API token and Project ID'
       end
     end
 

--- a/app/models/issue_trackers/redmine_tracker.rb
+++ b/app/models/issue_trackers/redmine_tracker.rb
@@ -4,7 +4,7 @@ if defined? RedmineClient
     Fields = [
       [:account, {
         :label       => "Redmine URL",
-        :placeholder => "e.g. http://www.redmine.org/"
+        :placeholder => "http://www.redmine.org/"
       }],
       [:api_token, {
         :placeholder => "API Token for your account"

--- a/app/models/notification_services/campfire_service.rb
+++ b/app/models/notification_services/campfire_service.rb
@@ -2,16 +2,18 @@ if defined? Campy
   class NotificationServices::CampfireService < NotificationService
     Label = "campfire"
     Fields = [
-        [:subdomain, {
-            :placeholder => "Campfire Subdomain"
-        }],
-        [:api_token, {
-            :placeholder => "API Token"
-        }],
-        [:room_id, {
-            :placeholder => "Room ID",
-            :label       => "Room ID"
-        }],
+      [:subdomain, {
+        :label       => "Campfire Subdomain",
+        :placeholder => "example"
+      }],
+      [:api_token, {
+        :label       => "API Token",
+        :placeholder => "1aa1111a111111aaaa11a11a1111a11a11111a11"
+      }],
+      [:room_id, {
+        :label       => "Room ID number",
+        :placeholder => "123456"
+      }]
     ]
 
     def check_params


### PR DESCRIPTION
Hi! This is my first pull request into the project so any comments are very welcome.

In setting up Errbit for the first time recently we had some confusion when it came to the items of Lighthouse project ID and Campfire room ID (we'd used the project and room name instead, having glossed over the README).

Assuming that some other users are likely to make the same mistake, this branch labels the fields a bit more specifically, and uses the HTML Placeholder values to show example input rather than additional hint text.
