### PR TITLE
Reduce the padding of table content to keep rows within the main layout

### DIFF
--- a/app/assets/stylesheets/errbit.css
+++ b/app/assets/stylesheets/errbit.css
@@ -586,8 +586,8 @@ div.issue_tracker.nested label.r_on, div.issue_tracker.nested label.r_on:hover, 
 table.apps tbody tr:hover td ,table.errs tbody tr:hover td { background-color: #F2F2F2;}
 
 table.apps td.name, table.errs td.message { width: 100%; }
-table.apps td { padding: 16px 25px; }
-table.apps th { padding: 10px 25px; }
+table.apps td { padding: 16px 20px; }
+table.apps th { padding: 10px 20px; }
 
 table.apps td.issue_tracker, table.apps td.count, table.apps td.deploy {
   text-align: center;


### PR DESCRIPTION
This branch should resolve the issue of the app notification table being too wide for the content of the main area (errbit/errbit#275)
