### PR TITLE
Campfire notification link

### DIFF
--- a/app/models/notification_services/campfire_service.rb
+++ b/app/models/notification_services/campfire_service.rb
@@ -23,7 +23,7 @@ if defined? Campy
     end
 
     def url
-      "http://#{account}.campfirenow.com/"
+      "http://#{subdomain}.campfirenow.com/"
     end
 
     def create_notification(problem)


### PR DESCRIPTION
Previously we were just linking to the Campfire domain. What we want to be doing on the main apps listing page is linking to the account's Campfire instance.
