### PR TITLE
Backtrace link to correct source path and file

### DIFF
--- a/app/helpers/backtrace_line_helper.rb
+++ b/app/helpers/backtrace_line_helper.rb
@@ -19,13 +19,13 @@ module BacktraceLineHelper
 
   def link_to_github(line, text = nil)
     return unless line.app.github_repo?
-    href = "%s#L%s" % [line.app.github_url_to_file(line.file), line.number]
+    href = "%s#L%s" % [line.app.github_url_to_file(line.decorated_path + line.file_name), line.number]
     link_to(text || line.file_name, href, :target => '_blank')
   end
 
   def link_to_bitbucket(line, text = nil)
     return unless line.app.bitbucket_repo?
-    href = "%s#cl-%s" % [line.app.bitbucket_url_to_file(line.file), line.number]
+    href = "%s#cl-%s" % [line.app.bitbucket_url_to_file(line.decorated_path + line.file_name), line.number]
     link_to(text || line.file_name, href, :target => '_blank')
   end
 


### PR DESCRIPTION
In the Backtrace tab of problem pages, links to files used the file `[PROJECT_ROOT]` text instead of the prettified file path and file name, causing links into Github or Bitbucket to be incorrect.
