### PR TITLE
no need to specify format in render call

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 module NoticesHelper
   def notice_atom_summary(notice)
-    render "notices/atom_entry.html.haml", :notice => notice
+    render "notices/atom_entry", :notice => notice
   end
 end
-


### PR DESCRIPTION
Removing it fixes deprecation warning:

```
DEPRECATION WARNING: Passing a template handler in the template name is deprecated. You can simply remove the handler name or pass render :handlers => [:haml] instead. (called from notice_atom_summary at /Users/lest/code/errbit/app/helpers/notices_helper.rb:4)
```
