### PR TITLE
Notice delete task

### DIFF
--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -3,7 +3,7 @@ require 'digest/sha1'
 namespace :errbit do
   namespace :db do
 
-    desc "Delete all of the notices" do
+    desc "Delete all of the notices that are 3 days old" do
       task :delete_notices => :environment do
         puts "Deleting Notices"
         Notice.where(:created_at.lt => 3.days.ago).destroy_all


### PR DESCRIPTION
A specific rake task to delete Notices that are 3 days old. Maybe this should take a parameter, but we've found that 3 days works well for us.

We found that we have over 5000 Notices which filled up our Monogo DB. This should keep it well under that limit.

**This will delete all information under your problem (backtrace, server environment, etc.).**

You can add this into heroku's scheduler: rake errbit:db:delete_notices
