### PR TITLE
Small update to github_url_to_file method

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -125,7 +125,6 @@ class App
   end
 
   def github_url_to_file(file)
-    file = "/#{file}" unless file.start_with? '/'
     "#{github_url}/blob/#{repo_branch + file}"
   end
 

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -98,11 +98,6 @@ describe App do
       app = Fabricate(:app, :github_repo => "errbit/errbit")
       app.github_url_to_file('/path/to/file').should == "https://github.com/errbit/errbit/blob/master/path/to/file"
     end
-
-    it 'resolves to full path to file without leading root symbol' do
-      app = Fabricate(:app, :github_repo => "errbit/errbit")
-      app.github_url_to_file('path/to/file').should == "https://github.com/errbit/errbit/blob/master/path/to/file"
-    end
   end
 
   context '#github_repo?' do


### PR DESCRIPTION
I have broken links to github files on one of errbit'ed apps. I don't know why it so, but links have no '/' symbol in backtraces. I added a simple check for leading '/' symbol for github links.
