### PR TITLE
Fix extract_backtraces migration, account for notices without backtrace

### DIFF
--- a/db/migrate/20121003223358_extract_backtraces.rb
+++ b/db/migrate/20121003223358_extract_backtraces.rb
@@ -2,7 +2,7 @@ class ExtractBacktraces < Mongoid::Migration
   def self.up
     say "It could take long time (hours if you have many Notices)"
     Notice.unscoped.all.each do |notice|
-      backtrace = Backtrace.find_or_create(:raw => notice['backtrace'].presence || [])
+      backtrace = Backtrace.find_or_create(:raw => notice['backtrace'] || [])
       notice.backtrace = backtrace
       notice['backtrace'] = nil
       notice.save!


### PR DESCRIPTION
I got the following exception when migrating:

```
Migrating to ExtractBacktraces (20121003223358)
==  ExtractBacktraces: migrating ==============================================
-- It could take long time (hours if you have many Notices)
rake aborted!
An error has occurred, 20121003223358 and all later migrations canceled:

undefined method `each' for nil:NilClass
/app/app/models/backtrace.rb:26:in `raw='
/app/vendor/bundle/ruby/1.9.1/gems/mongoid-2.4.10/lib/mongoid/attributes/processing.rb:98:in `process_attribute'
/app/vendor/bundle/ruby/1.9.1/gems/mongoid-2.4.10/lib/mongoid/attributes/processing.rb:26:in `block in process'
/app/vendor/bundle/ruby/1.9.1/gems/mongoid-2.4.10/lib/mongoid/attributes/processing.rb:24:in `each_pair'
/app/vendor/bundle/ruby/1.9.1/gems/mongoid-2.4.10/lib/mongoid/attributes/processing.rb:24:in `process'
/app/vendor/bundle/ruby/1.9.1/gems/mongoid-2.4.10/lib/mongoid/document.rb:136:in `block in initialize'
/app/vendor/bundle/ruby/1.9.1/gems/mongoid-2.4.10/lib/mongoid/threaded/lifecycle.rb:84:in `_building'
/app/vendor/bundle/ruby/1.9.1/gems/mongoid-2.4.10/lib/mongoid/document.rb:130:in `initialize'
/app/app/models/backtrace.rb:18:in `new'
/app/app/models/backtrace.rb:18:in `find_or_create'
/app/db/migrate/20121003223358_extract_backtraces.rb:5:in `block in up'
```

Passing an empty array instead of `nil` as the `raw` argument fixed this.
