### PR TITLE
Use a SMTP server other than sendgrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ heroku addons:add sendgrid:starter
 heroku config:add HEROKU=true
 heroku config:add ERRBIT_HOST=some-hostname.example.com
 heroku config:add ERRBIT_EMAIL_FROM=example@example.com
+heroku config:add SMTP_SERVER=smtp.sendgrid.net
+heroku config:add SMTP_USERNAME=the-username-provided-by-sendgrid
+heroku config:add SMTP_PASSWORD=the-password-provided-by-sendgrid
 git push heroku master
 ```
 

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -24,12 +24,12 @@ unless defined?(Errbit::Config)
     Errbit::Config.github_access_scope = ENV['GITHUB_ACCESS_SCOPE'].split(',').map(&:strip) if ENV['GITHUB_ACCESS_SCOPE']
 
     Errbit::Config.smtp_settings = {
-      :address        => "smtp.sendgrid.net",
-      :port           => "25",
+      :address        => ENV['SMTP_SERVER'],
+      :port           => ENV['SMTP_PORT'] || 25,
       :authentication => :plain,
-      :user_name      => ENV['SENDGRID_USERNAME'],
-      :password       => ENV['SENDGRID_PASSWORD'],
-      :domain         => ENV['SENDGRID_DOMAIN']
+      :user_name      => ENV['SMTP_USERNAME'],
+      :password       => ENV['SMTP_PASSWORD'],
+      :domain         => ENV['ERRBIT_EMAIL_FROM'].split('@').last
     }
   end
 


### PR DESCRIPTION
We might not want to use sendgrid as the SMTP server.
This changes the used environment variables on heroku to let us use an other SMTP provider.
