### PR TITLE
Fix Gemfile.lock and 'gitlab' gem from Git

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,7 +344,7 @@ DEPENDENCIES
   execjs
   fabrication (~> 1.3.0)
   foreman
-  gitlab
+  gitlab!
   haml
   hipchat
   hoi


### PR DESCRIPTION
With a fresh clone, running `bundle install` changes `Gemfile.lock` adding a bang to `gitlab` since this gem is pinned to git version.

As a result, `cap deploy` refuses to deploy with

```
You are trying to install in deployment mode after changing
your Gemfile.
```

message, if errbit/errbit is used as a repository in `config.yml`. This fixes the problem.

P.S. Bundler version 1.2.2
