### PR TITLE
Allowing one to configure the secret token by giving an environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ heroku run rake db:seed
 heroku addons:add deployhooks:http --url="http://YOUR_ERRBIT_HOST/deploys.txt?api_key=YOUR_API_KEY"
 ```
 
+  * You may also want to configure a different secret token for each deploy:
+
+```bash
+heroku config:add SECRET_TOKEN=some-secret-token
+```
+
   * Enjoy!
 
 

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,5 +4,5 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Errbit::Application.config.secret_token = '6b74778101638fa9c156b3928c9492fb2481ab842538bea838d21f9c9993f649f5806449584266d413d0b2f1104162b3066a86512ed71ededd627cd41f939614'
+Errbit::Application.config.secret_token = ENV['SECRET_TOKEN'] || '6b74778101638fa9c156b3928c9492fb2481ab842538bea838d21f9c9993f649f5806449584266d413d0b2f1104162b3066a86512ed71ededd627cd41f939614'
 


### PR DESCRIPTION
This allows you to deploy your application to heroku and not have your secret token shared with every other Errbit user.
