### PR TITLE
fix #352 - truncate long messages so subject is truncated

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -10,7 +10,7 @@ class Mailer < ActionMailer::Base
     @app      = notice.app
 
     mail :to      => @app.notification_recipients,
-         :subject => "[#{@app.name}][#{@notice.environment_name}] #{@notice.message}"
+         :subject => "[#{@app.name}][#{@notice.environment_name}] #{@notice.message.truncate(50)}"
   end
 
   def deploy_notification(deploy)

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -19,6 +19,13 @@ describe Mailer do
     it "should have inline css" do
       email.should have_body_text('<p class="backtrace" style="')
     end
+
+    context 'with a very long message' do
+      let(:notice)  { Fabricate(:notice, :message => 6.times.collect{|a| "0123456789" }.join('')) }
+      it "should truncate the long message" do
+        email.subject.should =~ / \d{47}\.{3}$/
+      end
+    end
   end
 end
 


### PR DESCRIPTION
The message of the notice can be very long and mailservers will reject
emails containing such long subjects.
By truncating the message after 50 characters in the subject we avoid
these kind of problems.
