### PR TITLE
Get turbo-sprockets-rails3 back

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,4 +107,5 @@ group :assets do
   gem 'therubyracer', :platform => :ruby  # C Ruby (MRI) or Rubinius, but NOT Windows
   gem 'uglifier',     '>= 1.0.3'
   gem 'underscore-rails'
+  gem 'turbo-sprockets-rails3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,9 @@ GEM
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
+    turbo-sprockets-rails3 (0.3.6)
+      railties (> 3.2.8, < 4.0.0)
+      sprockets (>= 2.0.0)
     tzinfo (0.3.35)
     uglifier (1.2.7)
       execjs (>= 0.3.0)
@@ -372,6 +375,7 @@ DEPENDENCIES
   therubyracer
   thin
   timecop
+  turbo-sprockets-rails3
   uglifier (>= 1.0.3)
   underscore-rails
   unicorn


### PR DESCRIPTION
`turbo-sprockets-rails3` was removed upon upgrading to Rails 3.2.11 (c6ca6461aae0ca91fa30c) because of version incompatibility. But I found that it was using `turbo-sprockets-rails3` `v0.2.12` while the 0.3.x series is perfectly compatible with the newest Rails.
