### PR TITLE
Move destroy application link from show page to edit page

### DIFF
--- a/app/views/apps/edit.html.haml
+++ b/app/views/apps/edit.html.haml
@@ -1,6 +1,7 @@
 - content_for :title, 'Edit App'
 - content_for :action_bar do
   = link_to_copy_attributes_from_other_app
+  = link_to 'destroy application', app_path(@app), :method => :delete, :data => { :confirm => 'Seriously?' }, :class => 'button'
   = link_to('cancel', app_path(@app), :class => 'button')
 
 = form_for @app do |f|

--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -11,7 +11,6 @@
 - content_for :action_bar do
   - if current_user.admin?
     = link_to 'edit', edit_app_path(@app), :class => 'button'
-    = link_to 'destroy', app_path(@app), :method => :delete, :data => { :confirm => 'Seriously?' }, :class => 'button'
   - if @all_errs
     = link_to 'unresolved errs', app_path(@app), :class => 'button'
   - else

--- a/spec/views/apps/edit.html.haml_spec.rb
+++ b/spec/views/apps/edit.html.haml_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "apps/edit.html.haml" do
+  before do
+    app = stub_model(App)
+    assign :app, app
+    controller.stub(:current_user) { stub_model(User) }
+  end
+
+  describe "content_for :action_bar" do
+    def action_bar
+      view.content_for(:action_bar)
+    end
+
+    it "should confirm the 'destroy' link" do
+      render
+
+      action_bar.should have_selector('a.button[data-confirm="Seriously?"]')
+    end
+
+  end
+end
+


### PR DESCRIPTION
It's currently very easy to destroy the whole application instead of just some problems (using "destroy" vs "delete") on apps/show page. Moreover this button is currently located between "edit" (rarely used / not dangerous) and "unresolved errs" (filter / not dangerous), since it's very dangerous and used only once this might not be the best place to have it.

Actually, mistaking those buttons already happened twice to us in production...

This pull request move the destroy link to the edit page's action bar. It also adds a test to ensure that this link includes a confirmation popup (inspired by a test from problems/show).

PS : Thanks for the awesome software :+1: 
