### PR TITLE
[README] To substitute mongodb by mongodb-10gen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ for you. Checkout [Airbrake](http://airbrakeapp.com) from the guys over at
 
 ```bash
 apt-get update
-apt-get install mongodb
+apt-get install mongodb-10gen
 ```
 
   * Install libxml and libcurl


### PR DESCRIPTION
Hi, I think I have found a mistake in your README.
You write:

> Install MongoDB. Follow the directions [here](http://www.mongodb.org/display/DOCS/Ubuntu+and+Debian+packages), then:
> 
> ``` bash
> apt-get update
> apt-get install mongodb
> ```

but the direction use the up-to-date packages from the 10gen repository.
