### PR TITLE
Protect against nil method in BacktraceLineNormalizer.

### DIFF
--- a/app/models/backtrace_line_normalizer.rb
+++ b/app/models/backtrace_line_normalizer.rb
@@ -13,7 +13,7 @@ class BacktraceLineNormalizer
   end
 
   def normalized_method
-    @raw_line['method'].gsub(/[0-9_]{10,}+/, "__FRAGMENT__")
+    @raw_line['method'].blank? ? "[unknown method]" : @raw_line['method'].gsub(/[0-9_]{10,}+/, "__FRAGMENT__")
   end
 
 end

--- a/spec/models/backtrace_line_normalizer_spec.rb
+++ b/spec/models/backtrace_line_normalizer_spec.rb
@@ -3,11 +3,15 @@ require 'spec_helper'
 describe BacktraceLineNormalizer do
   subject { described_class.new(raw_line).call }
 
-  describe "sanitize file" do
-    let(:raw_line) { { 'number' => rand(999), 'file' => nil, 'method' => ActiveSupport.methods.shuffle.first.to_s } }
+  describe "sanitize file and method" do
+    let(:raw_line) { { 'number' => rand(999), 'file' => nil, 'method' => nil } }
 
     it "should replace nil file with [unknown source]" do
       subject['file'].should == "[unknown source]"
+    end
+
+    it "should replace nil method with [unknown method]" do
+      subject['method'].should == "[unknown method]"
     end
 
   end


### PR DESCRIPTION
Recently upgraded errbit from a fairly old version, and had a failure in the ExtractBacktraces migration.  This change fixed it - aside from that the upgrade was 100% painless, thanks guys!

Let me know if this seems problematic in any way.
