### PR TITLE
Ignore SECRET_TOKEN absense during assets:precompile

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -13,7 +13,8 @@ else
   if ENV['SECRET_TOKEN'].present?
     Errbit::Application.config.secret_token = ENV['SECRET_TOKEN']
 
-  else
+  # Do not raise an error if secret token is not available dureng assets precompilation
+  elsif ENV['RAILS_GROUPS'] != 'assets'
     raise <<-ERROR
 
   You must generate a unique secret token for your Errbit instance.


### PR DESCRIPTION
`assets:precompile` was failing for me on Heroku because environment variables are not available on assets precompile stage.

This change prevents raising an exception if ENV['SECRET_TOKEN'] is missing during assets precompile stage. It detects assets precompilation stage by checking ENV['RAILS_GROUPS'], it must be equal to `assets`.
