### PR TITLE
Update Rack - CVE-2013-0263 and CVE-2013-0262

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       slop (>= 2.4.4, < 3)
     pry-rails (0.2.0)
       pry
-    rack (1.4.3)
+    rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
     rack-ssl (1.3.2)


### PR DESCRIPTION
Updated Rack from 1.4.3 to 1.4.5

Ref: http://rack.github.com/

https://support.cloud.engineyard.com/entries/23128773-February-8-2013-Rack-Vulnerabilities-CVE-2013-0263-CVE-2013-0262
