### PR TITLE
allow long error messages to wrap

### DIFF
--- a/app/assets/stylesheets/errbit.css
+++ b/app/assets/stylesheets/errbit.css
@@ -654,7 +654,6 @@ table.errs td.message a {
     overflow: hidden;
     text-overflow: ellipsis;
     -o-text-overflow: ellipsis;
-    white-space: nowrap;
   /* ------ */
 }
 table.errs td.message em {


### PR DESCRIPTION
In 9333e10b881710c487635c57a43b5dafc2579a2e, @PjpG introduced a few styles to prevent long messages from stretching their table cells. `word-wrap: break-word` + `width: 300px` accomplish this. `white-space: nowrap` was additionally causing exception messages to be truncated at 1 line _always_; but that can make some errors difficult to read. When the relevant detail is in the second line, you'd have to click into the error just to identify it!

Removing that style preserves the original intent, but allows errors messages to wrap if they need to.
