### PR TITLE
Fixes the backtrace url_to_file for redmine tracker.

### DIFF
--- a/app/models/issue_trackers/redmine_tracker.rb
+++ b/app/models/issue_trackers/redmine_tracker.rb
@@ -57,7 +57,7 @@ if defined? RedmineClient
     def url_to_file(file_path, line_number = nil)
       # alt_project_id let's users specify a different project for tickets / app files.
       project = self.alt_project_id.present? ? self.alt_project_id : self.project_id
-      url = "#{self.account}/projects/#{project}/repository/annotate/#{file_path.sub(/^\//,'')}"
+      url = "#{self.account.gsub(/\/$/, '')}/projects/#{project}/repository/revisions/#{app.repository_branch}/changes/#{file_path.sub(/\[PROJECT_ROOT\]/, '').sub(/^\//,'')}"
       line_number ? url << "#L#{line_number}" : url
     end
 


### PR DESCRIPTION
The link to repository file was broken for redmine tracker.

This commit fixes the link.

**NOTE:** I used the `changes` instead of `annotate'` because sometimes annotate does not work. One can switch in the repo view in redmine to annotate anyways. So this is a god choice I think.
