### PR TITLE
Fix undefined method `[]' for nil:NilClass

### DIFF
--- a/app/models/backtrace_line_normalizer.rb
+++ b/app/models/backtrace_line_normalizer.rb
@@ -1,6 +1,6 @@
 class BacktraceLineNormalizer
   def initialize(raw_line)
-    @raw_line = raw_line
+    @raw_line = raw_line || {}
   end
 
   def call


### PR DESCRIPTION
This commit fixes NoMethodError: undefined method `[]' for nil:NilClass when @raw_line == nil
