### PR TITLE
use the latest rubyracer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
     kgio (2.7.4)
     launchy (2.1.2)
       addressable (~> 2.3)
-    libv8 (3.3.10.4)
+    libv8 (3.11.8.13)
     libwebsocket (0.1.5)
       addressable
     libxml-ruby (2.3.3)
@@ -261,6 +261,7 @@ GEM
     rbx-require-relative (0.0.9)
     rdoc (3.12.1)
       json (~> 1.4)
+    ref (1.0.2)
     responders (0.9.2)
       railties (~> 3.1)
     rest-client (1.6.7)
@@ -302,8 +303,9 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    therubyracer (0.10.2)
-      libv8 (~> 3.3.10)
+    therubyracer (0.11.4)
+      libv8 (~> 3.11.8.12)
+      ref
     thin (1.4.1)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)


### PR DESCRIPTION
Trying to run errbit on free-bsd is painfull without the latest rubyracer (libv8 issues - wont compile)
