### PR TITLE
Passwords: bump max length to 1024

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -69,7 +69,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length
-  config.password_length = 6..20
+  config.password_length = 6..1024
 
   # Regex to use to validate the email address
   config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i


### PR DESCRIPTION
Why was it at 20?
Why even have a max length anyway?
