### PR TITLE
Tally: correct the sort order

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,7 +57,7 @@ module ApplicationHelper
     total   = (options[:total] || total_from_tallies(tallies))
     percent = 100.0 / total.to_f
     rows    = tallies.map {|value, count| [(count.to_f * percent), value]} \
-                     .sort {|a, b| a[0] <=> b[0]}
+                     .sort {|a, b| b[0] <=> a[0]}
     render "problems/tally_table", :rows => rows
   end
 


### PR DESCRIPTION
Alter tally sort order to be by popularity descending instead of ascending.
Because we should show the most popular entries at the top.
## After

![image](https://f.cloud.github.com/assets/26855/233699/9bc1950e-875c-11e2-85a9-1739e83207bb.png)
## Before

![image](https://f.cloud.github.com/assets/26855/233742/2974a8e0-875e-11e2-98fb-87be22a4391d.png)
