### PR TITLE
Error Email: add similar count to subject

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -12,8 +12,11 @@ class Mailer < ActionMailer::Base
     @notice   = notice
     @app      = notice.app
 
+    count = @notice.similar_count
+    count = count > 1 ? "(#{count}) " : ""
+
     mail :to      => @app.notification_recipients,
-         :subject => "[#{@app.name}][#{@notice.environment_name}] #{@notice.message.truncate(50)}"
+         :subject => "#{count}[#{@app.name}][#{@notice.environment_name}] #{@notice.message.truncate(50)}"
   end
 
   def deploy_notification(deploy)

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -10,6 +10,7 @@ describe Mailer do
     before do
       notice.backtrace.lines.last.update_attributes(:file => "[PROJECT_ROOT]/path/to/file.js")
       notice.app.update_attributes :asset_host => "http://example.com"
+      notice.problem.update_attributes :notices_count => 3
 
       @email = Mailer.err_notification(notice).deliver
     end
@@ -28,6 +29,10 @@ describe Mailer do
 
     it "should have links to source files" do
       @email.should have_body_text('<a href="http://example.com/path/to/file.js" target="_blank">path/to/file.js')
+    end
+
+    it "should have the error count in the subject" do
+      @email.subject.should =~ /^\(3\) /
     end
 
     context 'with a very long message' do


### PR DESCRIPTION
It's pretty useful when visually scanning the messages in my inbox to
see the count in the subject instead of having to open the email.

The relative importance of an email roughly scales with similar_count,
so it's a fairly important piece of info.
