### PR TITLE
Github Login: allow setting to blank

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,13 @@ class User
     github_account? && Errbit::Config.github_access_scope.include?('repo')
   end
 
+  def github_login=(login)
+    if login.is_a?(String) && login.strip.empty?
+      login = nil
+    end
+    self[:github_login] = login
+  end
+
   protected
 
     def destroy_watchers

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -79,6 +79,11 @@ describe UsersController do
           @user.reload.time_zone.should == "Warsaw"
         end
 
+        it "should be able to not set github_login option" do
+          put :update, :id => @user.to_param, :user => {:github_login => " "}
+          @user.reload.github_login.should == nil
+        end
+
         it "should be able to set github_login option" do
           put :update, :id => @user.to_param, :user => {:github_login => "awesome_name"}
           @user.reload.github_login.should == "awesome_name"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,15 @@ describe User do
       user2.should_not be_valid
       user2.errors[:github_login].should include("is already taken")
     end
+
+    it 'allows blank / null github_login' do
+      user1 = Fabricate(:user, :github_login => ' ')
+      user1.should be_valid
+
+      user2 = Fabricate.build(:user, :github_login => ' ')
+      user2.save
+      user2.should be_valid
+    end
   end
 
   context 'Watchers' do


### PR DESCRIPTION
Previously, creating a user without a github login would result in
`user.github_login == ''` instead of nil. This prevented creating more
than one user without a github login because of the unique index on the
field.
