### PR TITLE
Unicorn: shut down old master upon first fork

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -3,3 +3,27 @@
 worker_processes 3 # amount of unicorn workers to spin up
 timeout 30         # restarts workers that hang for 30 seconds
 preload_app true
+
+# Taken from github: https://github.com/blog/517-unicorn
+# Though everyone uses pretty miuch the same code
+before_fork do |server, worker|
+  ##
+  # When sent a USR2, Unicorn will suffix its pidfile with .oldbin and
+  # immediately start loading up a new version of itself (loaded with a new
+  # version of our app). When this new Unicorn is completely loaded
+  # it will begin spawning workers. The first worker spawned will check to
+  # see if an .oldbin pidfile exists. If so, this means we've just booted up
+  # a new Unicorn and need to tell the old one that it can now die. To do so
+  # we send it a QUIT.
+  #
+  # Using this method we get 0 downtime deploys.
+ 
+  old_pid = "#{server.config[:pid]}.oldbin"
+  if File.exists?(old_pid) && server.pid != old_pid
+    begin
+      Process.kill("QUIT", File.read(old_pid).to_i)
+    rescue Errno::ENOENT, Errno::ESRCH
+      # someone else did our job for us
+    end
+  end
+end


### PR DESCRIPTION
After the first child forks, shut down the old master.
Previously, the old master and it's workers would jut sit there
forever.

See: https://github.com/blog/517-unicorn and
     https://github.com/sosedoff/capistrano-unicorn/blob/master/examples/rails3.rb#L30

Tested in production, works great.
