### PR TITLE
Added minage parameter to errbit:db:clear_resolved

### DIFF
--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -23,8 +23,13 @@ namespace :errbit do
       count = 0
       Problem.resolved.each do |problem|
         if not cutoff or problem.last_notice_at <= cutoff
-          problem.destroy
-          count += 1
+          begin
+            problem.destroy
+          rescue StandardError => e
+            $stderr.puts("Failed to delete problem #{problem.id}: #{e.message}")
+          else
+            count += 1
+          end
         end
       end
       puts "=== Cleared #{count} resolved errors from the database." if count > 0


### PR DESCRIPTION
Adds an optional minage parameter to errbit:db:clear_resolved, which will only delete errors older than a certain number of days. Also handles errors during destroy by displaying an error message and continuing.

PS: I'm seeing lots of problem.destroy errors with "Validation failed - Errs is invalid.", any idea why?
