### PR TITLE
Added development group to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,15 +82,17 @@ group :development, :test do
   end
 #  gem 'rpm_contrib'
 #  gem 'newrelic_rpm'
+end
+
+group :development do
   gem 'capistrano'
 
   # better errors
-  gem 'better_errors', :platform => :ruby_19
+  gem 'better_errors'    , :platform => :ruby_19
   gem 'binding_of_caller', :platform => :ruby_19
-  gem 'meta_request', :platform => :ruby_19
+  gem 'meta_request'     , :platform => :ruby_19
+  gem 'foreman'
 end
-
-gem 'foreman', :group => :development
 
 group :test do
   gem 'capybara'


### PR DESCRIPTION
Hi,

I introduced a separate group `:development` into the `Gemfile` to remove some gems from the `:test` group.

The original reason is that running `rake spec` on the master branch segfaults for me with `ruby-1.9.3-p392 [ x86_64 ]` (using RVM):

```
/var/lib/jenkins/.rvm/gems/ruby-1.9.3-p392@errbit-master/gems/better_errors-0.7.0/lib/better_errors/core_ext/exception.rb:9: [BUG] Segmentation fault
ruby 1.9.3p392 (2013-02-22 revision 39386) [x86_64-linux]
```

Some investigation lead to `better_errors` being the potential reason, as is documented in https://github.com/charliesome/better_errors/issues/61.

While removing the gem from the `:test` group does not solve the issue, the documentation of `better_errors` also recommends to just add it to the `:development` group. I also verified that the specs still pass.

If someone is interested in the stack trace, do not hesitate to ask me. 
