### PR TITLE
Spec: fix failing tests cause of Identity map

### DIFF
--- a/app/interactors/problem_destroy.rb
+++ b/app/interactors/problem_destroy.rb
@@ -10,6 +10,10 @@ class ProblemDestroy
     delete_errs
     delete_comments
     problem.delete
+    # Mongoid doesn't remove entries deleted with
+    # collection.remove(:field => { '$in' => array }) queries
+    # So, to be safe, we should clear the identity map
+    Mongoid::IdentityMap.clear
   end
 
   ##

--- a/spec/interactors/problem_destroy_spec.rb
+++ b/spec/interactors/problem_destroy_spec.rb
@@ -50,6 +50,7 @@ describe ProblemDestroy do
   end
 
   context "in integration way" do
+    Mongoid::identity_map_enabled = false
     let!(:problem) { Fabricate(:problem) }
     let!(:comment_1) { Fabricate(:comment, :err => problem) }
     let!(:comment_2) { Fabricate(:comment, :err => problem) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,9 @@ RSpec.configure do |config|
   config.before(:each, :type => :helper) do |config|
     init_haml_helpers
   end
+
+  # Ensure each spec runs in isolation
+  config.before(:each) { Mongoid::IdentityMap.clear }
 end
 
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
Introduction of the identity map caused some failing specs:
https://travis-ci.org/errbit/errbit/jobs/5383844

Though it seems to be less of an issue in recent runs, not sure why.
The identity map is being enabled in the testing thread so the following
test breaks:
1. get record # added to identity map
2. call delete api # (doesn't affect identity map of this process)
3. get record # still in identity map (and thus the test fails)

It was tricky disabling the Identity map in the correct context (where
the specs actually run).
