### PR TITLE
Notice API: properly transform <var> tags

### DIFF
--- a/lib/hoptoad/v2.rb
+++ b/lib/hoptoad/v2.rb
@@ -18,6 +18,8 @@ module Hoptoad
           {normalize_key(node['key']) => rekey(node['__content__'])}
         elsif node.has_key?('__content__')
           rekey(node['__content__'])
+        elsif node.has_key?('key')
+          {normalize_key(node['key']) => nil}
         else
           node.inject({}) {|rekeyed, (key, val)| rekeyed.merge(normalize_key(key) => rekey(val))}
         end


### PR DESCRIPTION
`<var>` tags with blank values were ending up completely wrong in the
resulting hash. 

This: (a user with a blank name)

```
<var key="user">
   <var key="id">123</var>
   <var key="name"/>
</var>
```

Gets parsed by hoptoad_notifier into this:

```
{
   'key' => 'user',
   'var' => [{
         'key' => 'id',
         '__content__' => '123'
      },{
         'key' => 'name'
      }]
}
```

Which when passed through the "rekey" method, ended up like this:

```
{
   'user' => {
      'id' => '123',
      'key' => 'name' # bad and wrong
   }
}
```

If there were multiple blank values, they would overwrite each-other, each using the same `'key' => ...`.

Now, after these changes, it _correctly_ comes through as:

```
{
   'user' => {
      'id' => '123',
      'name' => nil # much better!
   }
}
```
