### PR TITLE
Capistrano: deploy from fixed branch

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -57,6 +57,7 @@ deployment:
     app: errbit.example.com
     db: errbit.example.com
   repository: http://github.com/errbit/errbit.git
+  branch: master
   user: deploy
   deploy_to: /var/www/apps/errbit
   # setup path to unicorn pids folder (or deploy_to/shared/pids will be used)

--- a/config/deploy.example.rb
+++ b/config/deploy.example.rb
@@ -35,8 +35,7 @@ set :copy_compression, :bz2
 
 set :scm, :git
 set :scm_verbose, true
-set(:current_branch) { `git branch`.match(/\* (\S+)\s/m)[1] || raise("Couldn't determine current branch") }
-set :branch, defer { current_branch }
+set :branch, config['branch'] || 'master'
 
 before 'deploy:assets:symlink', 'errbit:symlink_configs'
 # if unicorn is started through something like runit (the tool which restarts the process when it's stopped)


### PR DESCRIPTION
Not the 'current' branch in the local clone fo the repo.

I feel like deploying from the current branch in the local clone is a
bit presumptous. I expect most people want to deploy from one branch
while allowing for development of several feature branches.

Right now you always have to remember to check out master before
deploying or you may deploy your feature branch (which may not even be
pushed).
