### PR TITLE
Update the Airbrake domain in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 
 Errbit is a tool for collecting and managing errors from other applications.
-It is [Airbrake](http://airbrakeapp.com) (formerly known as Hoptoad) API compliant,
+It is [Airbrake](http://airbrake.io) (formerly known as Hoptoad) API compliant,
 so if you are already using Airbrake, you can just point the `airbrake` gem to your Errbit server.
 
 
@@ -56,7 +56,7 @@ Errbit may be a good fit for you if:
 * You want to add customer features to your error catcher
 * You're crazy and love managing servers
 
-If this doesn't sound like you, you should probably stick with [Airbrake](http://airbrakeapp.com).
+If this doesn't sound like you, you should probably stick with [Airbrake](http://airbrake.io).
 The [Thoughtbot](http://thoughtbot.com) guys offer great support for it and it is much more worry-free.
 They have a free package and even offer a *"Airbrake behind your firewall"* solution.
 
@@ -78,7 +78,7 @@ Installation
 
 *Note*: This app is intended for people with experience deploying and maintining
 Rails applications. If you're uncomfortable with any step below then Errbit is not
-for you. Checkout [Airbrake](http://airbrakeapp.com) from the guys over at
+for you. Checkout [Airbrake](http://airbrake.io) from the guys over at
 [Thoughtbot](http://thoughtbot.com), which Errbit is based on.
 
 **Set up your local box or server(Ubuntu):**
@@ -459,7 +459,7 @@ Special Thanks
 * [Vasiliy Ermolovich (@nashby)](https://github.com/nashby) - Contributing and helping to resolve issues and pull requests
 * [Marcin Ciunelis (@martinciu)](https://github.com/martinciu) - Helping to improve Errbit's architecture
 * [Relevance](http://thinkrelevance.com) - For giving me Open-source Fridays to work on Errbit and all my awesome co-workers for giving feedback and inspiration.
-* [Thoughtbot](http://thoughtbot.com) - For being great open-source advocates and setting the bar with [Airbrake](http://airbrakeapp.com).
+* [Thoughtbot](http://thoughtbot.com) - For being great open-source advocates and setting the bar with [Airbrake](http://airbrake.io).
 
 See the [contributors graph](https://github.com/errbit/errbit/graphs/contributors) for further details.
 


### PR DESCRIPTION
http://airbrakeapp.com 302s to https://airbrakeapp.com, which throws a certificate error because the server offers a wildcard for *.airbrake.io. This PR updates the links to Airbrake to their new domain.

Cheers!
