### PR TITLE
Add a line reminding Heroku deployers to edit seeds.rb before pushing and running rake db:seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ cap deploy:setup deploy
 ```bash
 git clone http://github.com/errbit/errbit.git
 ```
+  * Update `db/seeds.rb` with admin credentials for your initial login.
 
   * Create & configure for Heroku
 


### PR DESCRIPTION
I skipped this step and had to backtrack a little. Nice to remind users here.
