### PR TITLE
report the actual url as request_url

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -856,7 +856,7 @@ printStackTrace.implementation.prototype = {
                     error = Util.merge(this.options.errorDefaults, errorWithoutDefaults),
                     
                     component = error.component || '',
-                    request_url = (error.url || '' + location.hash),
+                    request_url = (error.url || '' + location.href),
                     
                     methods = ['cgi-data', 'params', 'session'],
                     _outputData = null;


### PR DESCRIPTION
Reporting the hash turns (for me) out to be error prone as I do not get the actual host.
