### PR TITLE
Use https urls for gems fetched from git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'htmlentities', "~> 4.3.0"
 gem 'rack-ssl', :require => 'rack/ssl'   # force SSL
 
 # Remove this when tilt 1.3.7 is released.
-gem 'tilt', :git => 'git://github.com/rtomayko/tilt'
+gem 'tilt', :git => 'https://github.com/rtomayko/tilt.git'
 
 gem 'useragent', '~> 0.4.16'
 gem 'inherited_resources'
@@ -40,7 +40,7 @@ gem 'ruby-fogbugz', :require => 'fogbugz'
 # Github Issues
 gem 'octokit', '~> 1.0.0'
 # Gitlab
-gem 'gitlab', :git => 'git://github.com/NARKOZ/gitlab'
+gem 'gitlab', :git => 'https://github.com/NARKOZ/gitlab.git'
 
 # Bitbucket Issues
 gem 'bitbucket_rest_api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
-  remote: git://github.com/NARKOZ/gitlab
+  remote: https://github.com/NARKOZ/gitlab.git
   revision: f2ba111dba70eca5346a880c541dafaf35d3332a
   specs:
     gitlab (2.2.0)
       httparty
 
 GIT
-  remote: git://github.com/rtomayko/tilt
+  remote: https://github.com/rtomayko/tilt.git
   revision: 24ea7e9fa5a0624188069393abf033bb8b3f218c
   specs:
     tilt (1.3.6)


### PR DESCRIPTION
The port that is used by the git protocol is closed in a lot of companies. Using https urls instead allows us to get around that.
