### PR TITLE
launch a repairDatabase task on clear_resolved

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,9 @@ GIT
 
 GIT
   remote: https://github.com/rtomayko/tilt.git
-  revision: 24ea7e9fa5a0624188069393abf033bb8b3f218c
+  revision: 74618967fbed3e206453516b92b47cd9aa922903
   specs:
-    tilt (1.3.6)
+    tilt (1.4.0)
 
 GEM
   remote: http://rubygems.org/
@@ -109,7 +109,7 @@ GEM
       bcrypt-ruby (~> 3.0)
       orm_adapter (~> 0.0.3)
       warden (~> 1.1)
-    diff-lcs (1.1.3)
+    diff-lcs (1.2.4)
     email_spec (1.2.1)
       mail (~> 2.2)
       rspec (~> 2.0)
@@ -131,7 +131,7 @@ GEM
     has_scope (0.5.1)
     hashie (1.2.0)
     highline (1.6.15)
-    hike (1.2.1)
+    hike (1.2.2)
     hipchat (0.4.1)
       httparty
     hoi (0.0.6)
@@ -188,7 +188,7 @@ GEM
       bundler (>= 1.0.0)
       rails (>= 3.0.0)
       railties (>= 3.0.0)
-    multi_json (1.7.0)
+    multi_json (1.7.2)
     multi_xml (0.5.2)
     multipart-post (1.1.5)
     net-scp (1.0.4)
@@ -270,7 +270,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.10.0)
-    rake (10.0.3)
+    rake (10.0.4)
     rbx-require-relative (0.0.9)
     rdoc (3.12.2)
       json (~> 1.4)
@@ -280,19 +280,21 @@ GEM
     rest-client (1.6.7)
       mime-types (>= 1.16)
     ri_cal (0.8.8)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.2)
-      diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.1)
-    rspec-rails (2.11.0)
+    rspec (2.13.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
+    rspec-core (2.13.1)
+    rspec-expectations (2.13.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.13.1)
+    rspec-rails (2.13.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
-      rspec (~> 2.11.0)
+      rspec-core (~> 2.13.0)
+      rspec-expectations (~> 2.13.0)
+      rspec-mocks (~> 2.13.0)
     ruby-debug (0.10.4)
       columnize (>= 0.1)
       ruby-debug-base (~> 0.10.4.0)
@@ -327,7 +329,7 @@ GEM
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
       rack (>= 1.0.0)
-    thor (0.17.0)
+    thor (0.18.1)
     timecop (0.3.5)
     treetop (1.4.12)
       polyglot

--- a/app/interactors/resolved_problem_clearer.rb
+++ b/app/interactors/resolved_problem_clearer.rb
@@ -1,0 +1,32 @@
+require 'problem_destroy'
+
+class ResolvedProblemClearer
+
+  ##
+  # Clear all problem already resolved
+  #
+  def execute
+    nb_problem_resolved.tap { |nb|
+      if nb > 0
+        criteria.each do |problem|
+          ProblemDestroy.new(problem).execute
+        end
+        repair_database
+      end
+    }
+  end
+
+  private
+
+  def nb_problem_resolved
+    @count ||= criteria.count
+  end
+
+  def criteria
+    @criteria = Problem.resolved
+  end
+
+  def repair_database
+    Mongoid.config.master.command(:repairDatabase => 1)
+  end
+end

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -19,10 +19,8 @@ namespace :errbit do
 
     desc "Delete resolved errors from the database. (Useful for limited heroku databases)"
     task :clear_resolved => :environment do
-      count = Problem.resolved.count
-      Problem.resolved.each {|problem| problem.destroy }
-      Mongoid.config.master.command(:repairDatabase => 1)
-      puts "=== Cleared #{count} resolved errors from the database." if count > 0
+      require 'resolved_problem_clearer'
+      puts "=== Cleared #{ResolvedProblemClearer.new.execute} resolved errors from the database."
     end
 
     desc "Regenerate fingerprints"

--- a/spec/interactors/resolved_problem_clearer_spec.rb
+++ b/spec/interactors/resolved_problem_clearer_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe ResolvedProblemClearer do
+  let(:resolved_problem_clearer) {
+    ResolvedProblemClearer.new
+  }
+  describe "#execute" do
+    let!(:problems) {
+      [
+        Fabricate(:problem),
+        Fabricate(:problem),
+        Fabricate(:problem)
+      ]
+    }
+    context 'without problem resolved' do
+      it 'do nothing' do
+        expect {
+          expect(resolved_problem_clearer.execute).to eq 0
+        }.to_not change {
+          Problem.count
+        }
+      end
+      it 'not repair database' do
+        Mongoid.config.master.should_receive(:command).and_call_original
+        Mongoid.config.master.should_not_receive(:command).with({:repairDatabase => 1})
+        resolved_problem_clearer.execute
+      end
+    end
+
+    context "with problem resolve" do
+      before do
+        problems.first.resolve!
+        problems.second.resolve!
+      end
+      it 'delete problem resolve' do
+        expect {
+          expect(resolved_problem_clearer.execute).to eq 2
+        }.to change {
+          Problem.count
+        }.by(-2)
+        expect(Problem.where(:_id => problems.first.id).first).to be_nil
+        expect(Problem.where(:_id => problems.second.id).first).to be_nil
+      end
+
+      it 'repair database' do
+        Mongoid.config.master.should_receive(:command).and_call_original
+        Mongoid.config.master.should_receive(:command).with({:repairDatabase => 1})
+        resolved_problem_clearer.execute
+      end
+    end
+  end
+end


### PR DESCRIPTION
The task db:clear_resolved can delete a lot of data. I think it can be good to repairDatabase after to avoid a big database.

see #458
