### PR TITLE
Add a helpful error message when non-admin users get a permission denied

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,10 @@ protected
 
 
   def require_admin!
-    redirect_to_root unless user_signed_in? && current_user.admin?
+    unless user_signed_in? && current_user.admin?
+      flash[:error] = "Sorry, you don't have permission to do that"
+      redirect_to_root
+    end
   end
 
   def redirect_to_root


### PR DESCRIPTION
We had some real confusion when non admin users tried to add apps to errbit, only to find it silently failing with no explanation. Letting the users know they don't have permission is a nice thing.
