### PR TITLE
use charAt as array notation is not available in IE8

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -572,7 +572,7 @@ printStackTrace.implementation.prototype = {
          * Is used to generate getter and setter method names.
          */
         capitalizeFirstLetter: function (str) {
-            return str[0].toUpperCase() + str.slice(1);  
+            return str.charAt(0).toUpperCase() + str.slice(1);  
         },
         
         /*


### PR DESCRIPTION
`"foo"[0]` is not available in IE < 9. Use `charAt` instead.
