### PR TITLE
README updated; Thoughtbot sold Airbrake in 2011.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Errbit may be a good fit for you if:
 * You want to add customer features to your error catcher
 * You're crazy and love managing servers
 
-If this doesn't sound like you, you should probably stick with [Airbrake](http://airbrake.io).
-The [Thoughtbot](http://thoughtbot.com) guys offer great support for it and it is much more worry-free.
-They have a free package and even offer a *"Airbrake behind your firewall"* solution.
+If this doesn't sound like you, you should probably stick with a hosted service such as
+[Airbrake](http://airbrake.io).
+
 
 Mailing List
 ------------
@@ -83,8 +83,7 @@ Installation
 
 *Note*: This app is intended for people with experience deploying and maintining
 Rails applications. If you're uncomfortable with any step below then Errbit is not
-for you. Checkout [Airbrake](http://airbrake.io) from the guys over at
-[Thoughtbot](http://thoughtbot.com), which Errbit is based on.
+for you.
 
 **Set up your local box or server(Ubuntu):**
 


### PR DESCRIPTION
This change removes reference to Thoughtbot providing support for Airbrake.

> _February 7, 2012_
> “Late last year, Airbrake was acquired by the team at Exceptional, inc.”
> — http://robots.thoughtbot.com/post/17212734809/airbrake-acquired-by-exceptional

Additionally, and anecdotally, Airbrake is less worthy of recommendation compared to when this README was written. In fact a common reason now for switching from Airbrake to Errbit is that the former cannot be relied upon to report errors.
