### PR TITLE
Confirm actions on index page

### DIFF
--- a/app/views/problems/_table.html.haml
+++ b/app/views/problems/_table.html.haml
@@ -48,9 +48,5 @@
   = paginate problems
   .tab-bar
     %ul
-      %li= submit_tag 'Merge', :id => 'merge_problems', :class => 'button', 'data-action' => merge_several_problems_path, :data => { :confirm => problem_confirm }
-      %li= submit_tag 'Unmerge', :id => 'unmerge_problems', :class => 'button', 'data-action' => unmerge_several_problems_path, :data => { :confirm => problem_confirm }
-      %li= submit_tag 'Resolve', :id => 'resolve_problems', :class => 'button', 'data-action' => resolve_several_problems_path, :data => { :confirm => problem_confirm }
-      %li= submit_tag 'Unresolve', :id => 'unresolve_problems', :class => 'button', 'data-action' => unresolve_several_problems_path, :data => { :confirm => problem_confirm }
-      %li= submit_tag 'Delete', :id => 'delete_problems', :class => 'button', 'data-action' => destroy_several_problems_path, :data => { :confirm => problem_confirm }
-
+      - %w(merge unmerge resolve unresolve delete).each do |action|
+        %li= submit_tag action.capitalize, :id => "#{action}_problems", :class => 'button', :data => { :action => polymorphic_path([action == 'delete' ? 'destroy' : action, 'several_problems']), :confirm => problem_confirm }


### PR DESCRIPTION
It has always bothered me that there is no "Seriously?" confirmation popup for the actions on the bottom of the problems index page (Merge, Unmerge, Resolve etc.)
I added the confirmation and refactored the buttons in the process.
