### PR TITLE
Float tab bar at the bottom of the screen.

### DIFF
--- a/app/assets/stylesheets/errbit.css
+++ b/app/assets/stylesheets/errbit.css
@@ -252,6 +252,7 @@ a.action  { float: right; font-size: 0.9em;}
   padding: 20px 0;
   font-size: 0.8em; text-align: center;
   color: #929292;
+  margin-bottom: 40px;
 }
 
 /* Flash Messages */
@@ -508,6 +509,13 @@ a.button.active {
 /* Tab Bar */
 .tab-bar {
   margin-top: 12px;
+  margin-bottom: 0;
+  position: fixed;
+  bottom: 0;
+  width: 888px;
+  background-color: #e6e6e6;
+  border: 1px solid #ccc;
+  z-index: 1;
 }
 #content .tab-bar a.button {
   border-bottom:0;
@@ -528,7 +536,7 @@ a.button.active {
   height:31px;
 }
 .tab-bar ul {
-  padding: 9px 0 0;
+  padding: 9px 0 9px;
   line-height:0;
 }
 .tab-bar li {


### PR DESCRIPTION
When pagination is set to anything more than, say, 10, it's kinda
annoying to have to scroll down to the bottom of the page to do anything
with an error.  This is particularly the case if you're doing things to
the first couple errors, which is what I'm usually looking at.

Now the actions are always at hand.