### PR TITLE
Tell to run `bundle` in the Heroku deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ cap deploy:setup deploy
 git clone http://github.com/errbit/errbit.git
 ```
   * Update `db/seeds.rb` with admin credentials for your initial login.
+  
+  * Run `bundle`
 
   * Create & configure for Heroku
 


### PR DESCRIPTION
Without running first `bundle` I get the following error when running `heroku config:add SECRET_TOKEN="$(bundle exec rake secret)"`

/Users/florent2/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/bundler-1.3.5/lib/bundler/spec_set.rb:92:in `block in materialize': Could not find i18n-0.6.1 in any of the sources (Bundler::GemNotFound)
