### PR TITLE
fix for notifier.js sending invalid XML

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -366,7 +366,7 @@ printStackTrace.implementation.prototype = {
             '</notifier>' +
             '<error>' +
                 '<class>{exception_class}</class>' +
-                '<message>{exception_message}</message>' +
+                '<message><![CDATA[{exception_message}]]></message>' +
                 '<backtrace>{backtrace_lines}</backtrace>' +
             '</error>' +
             '<request>' +

--- a/spec/fixtures/hoptoad_test_notice.xml
+++ b/spec/fixtures/hoptoad_test_notice.xml
@@ -9,7 +9,7 @@
   <framework>Rails: 3.2.11</framework>
   <error>
     <class>HoptoadTestingException</class>
-    <message>HoptoadTestingException: Testing hoptoad via "rake hoptoad:test". If you can see this, it works.</message>
+    <message><![CDATA[HoptoadTestingException: Testing hoptoad via "rake hoptoad:test". If you can see this, it works & works well.]]></message>
     <backtrace>
       <line number="425" file="[GEM_ROOT]/gems/activesupport-3.0.0.rc/lib/active_support/callbacks.rb" method="_run__2115867319__process_action__262109504__callbacks"/>
       <line number="404" file="[GEM_ROOT]/gems/activesupport-3.0.0.rc/lib/active_support/callbacks.rb" method="send"/>


### PR DESCRIPTION
I'm getting a Self.Errbit error "Nokogiri::XML::SyntaxError: EntityRef: expecting ';'" when one of my apps reports an error. The following is the XML which is invalid at line 11.  This fix just wraps the message with CDATA so Nokogiri doesn't try to parse it. Also wrapped the backtrace just in case. 

```
1 <?xml version=\"1.0\" encoding=\"UTF-8\"?>
2 <notice version=\"2.0\">
3   <api-key>xxxx</api-key>
4   <notifier>
5     <name>airbrake_js</name>
6     <version>0.2.0</version>
7     <url>http://airbrake.io</url>
8   </notifier>
9   <error>
10     <class>Error</class>
11     <message>Uncaught Syntax error, unrecognized expression: [href=#bayarea?utm_source=2nd+BayREN+MF+Workshop+Invite+July&utm_campaign=July+workshop+announcement&utm_medium=email]</message>
12     <backtrace>
13       <line method=\"{anonymous}()\" file=\"[PROJECT_ROOT]/assets/vendor-8e6fab5606aee4bf5e34551808868bd7.js\" number=\"17\" />
14     </backtrace>
15   </error>
16   <request>
17     <url>https://multifamily.energyupgradeca.org/local</url>
18     <component>contents</component>
19     <action>show</action>
20     <cgi-data>
21       <var key=\"HTTP_USER_AGENT\">Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Safari/537.36</var>
22     </cgi-data>
23   </request>
24   <server-environment>
25     <project-root>https://multifamily.energyupgradeca.org</project-root>
26     <environment-name>production</environment-name>
27   </server-environment>
28 </notice>
```
