### PR TITLE
Fixes notifier.js sending invalid XML in backtrace lines

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -972,8 +972,8 @@ printStackTrace.implementation.prototype = {
                     //        '" number="' + matches[3] + '" />');
                     
                     backtrace.push({
-                        'function': matches[1],
-                        file: file,
+                        'function': Util.escape(matches[1]),
+                        file: Util.escape(file),
                         line: matches[3]
                     });
                 }


### PR DESCRIPTION
Similar to #514, backtrace lines were not being properly escaped and could cause invalid XML if for instance you're using the console and the backtrace contains `<anonymous>`.
