### PR TITLE
Add Flowdock configuration option

### DIFF
--- a/app/models/notification_services/flowdock_service.rb
+++ b/app/models/notification_services/flowdock_service.rb
@@ -21,7 +21,7 @@ if defined? Flowdock
     end
 
     def create_notification(problem)
-      flow = Flowdock::Flow.new(:api_token => api_token, :source => "Errbit", :from => {:name => "Errbit", :address => 'support@flowdock.com'})
+      flow = Flowdock::Flow.new(:api_token => api_token, :source => "Errbit", :from => {:name => "Errbit", :address => ENV['ERRBIT_EMAIL_FROM'] || 'support@flowdock.com'})
       subject = "[#{problem.environment}] #{problem.message.to_s.truncate(100)}"
       url = app_problem_url problem.app, problem
       flow.push_to_team_inbox(:subject => subject, :content => content(problem, url), :project => project_name(problem), :link => url)

--- a/docs/ENV-VARIABLES.md
+++ b/docs/ENV-VARIABLES.md
@@ -69,3 +69,9 @@ variable.
 * MONGOID_PASSWORD
 * MONGOID_DATABASE
 
+## Flowdock notification adapter
+
+If you noticed default Gravatar icon in your Flowdock notifications you
+may want to [add Errbit icon](http://gravatar.com) for email that is
+set in ERRBIT_EMAIL_FROM.
+You don't need to approve or authorize it on Flowdock because it is used only for an icon.


### PR DESCRIPTION
This is missing component to the recent [PR](https://github.com/errbit/errbit/pull/504#commitcomment-3422990).

I thought that another configuration option for flowdock email notification option brings unnecessary complexity.

Probably the simplest way for users to fix default icons in Flowdock notifications is to just add "Errbit" icon on Gravatar for already existing email from `ERRBIT_EMAIL_FROM`.

What do you think?
