### PR TITLE
Test if backtrace is associated with notice before migration runs

### DIFF
--- a/db/migrate/20121003223358_extract_backtraces.rb
+++ b/db/migrate/20121003223358_extract_backtraces.rb
@@ -6,7 +6,7 @@ class ExtractBacktraces < Mongoid::Migration
       notice.backtrace = backtrace
       notice['backtrace'] = nil
       notice.save!
-    end
+    end unless Notice.reflect_on_association(:backtrace).present?
     say "run `db.repairDatabase()` (in mongodb console) to recover deleted space"
   end
 


### PR DESCRIPTION
Just an idea for this issue : https://github.com/errbit/errbit/issues/538
