### PR TITLE
Treat request URL as CDATA so query string params don't result in invalid XML

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -506,7 +506,7 @@ printStackTrace.implementation.prototype = {
                 '<backtrace>{backtrace_lines}</backtrace>' +
             '</error>' +
             '<request>' +
-                '<url>{request_url}</url>' +
+                '<url><![CDATA[{request_url}]]></url>' +
                 '<component>{request_component}</component>' +
                 '<action>{request_action}</action>' +
                 '{request}' +

--- a/spec/fixtures/hoptoad_test_notice.xml
+++ b/spec/fixtures/hoptoad_test_notice.xml
@@ -87,7 +87,7 @@
     </backtrace>
   </error>
   <request>
-    <url>http://example.org/verify</url>
+    <url><![CDATA[http://example.org/verify/cupcake=fistfight&lovebird=doomsayer]]></url>
     <component>application</component>
     <action>verify</action>
     <params>

--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -84,7 +84,7 @@ describe ErrorReport do
         end
 
         it 'has request' do
-          subject.request['url'].should == 'http://example.org/verify'
+          subject.request['url'].should == 'http://example.org/verify/cupcake=fistfight&lovebird=doomsayer'
           subject.request['params']['controller'].should == 'application'
         end
 


### PR DESCRIPTION
If the request url reported contains invalid XML characters, we get

Nokog​iri::​XML::​Synta​xErro​r: En​tityR​ef: e​xpect​ing '​;'

This is similar to 6c30142fb0018dc85bedded605b3eea4f49d0c42
