### PR TITLE
Put colon between host and port in example mongo config

### DIFF
--- a/config/mongoid.example.yml
+++ b/config/mongoid.example.yml
@@ -33,7 +33,7 @@ production:
     default:
       database: <%= ENV['MONGOID_DATABASE'] %>
       hosts:
-        - <%=ENV["MONGOID_HOST"]%>:<%=ENV["MONGOID_PORT"]%>
+        - '<%=ENV["MONGOID_HOST"]%>:<%=ENV["MONGOID_PORT"]%>'
       username: <%= ENV['MONGOID_USERNAME'] %>
       password: <%= ENV['MONGOID_PASSWORD'] %>
   options:


### PR DESCRIPTION
I noticed this config change and thought the line looked funny... I assume there should be a colon in between rather than requiring it to be part of the ENV var.
