### PR TITLE
fix mongoid.example config to remove port

### DIFF
--- a/config/mongoid.example.yml
+++ b/config/mongoid.example.yml
@@ -33,7 +33,7 @@ production:
     default:
       database: <%= ENV['MONGOID_DATABASE'] %>
       hosts:
-        - <%=ENV["MONGOID_HOST"]%><%=ENV["MONGOID_PORT"]%>
+        - <%=ENV["MONGOID_HOST"]%>
       username: <%= ENV['MONGOID_USERNAME'] %>
       password: <%= ENV['MONGOID_PASSWORD'] %>
   options:


### PR DESCRIPTION
We need to remove the port from the config, as if we add a colon, it will break the YML parser.

[fixes https://github.com/errbit/errbit/pull/570]
