### PR TITLE
Add capabilities to admin to regenerate the API key of his app

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -80,6 +80,11 @@ class AppsController < ApplicationController
     end
   end
 
+  def regenerate_api_key
+    app.regenerate_api_key!
+    redirect_to edit_app_path(app)
+  end
+
   protected
 
     def initialize_subclassed_issue_tracker

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -170,6 +170,10 @@ class App
     Errbit::Config.per_app_email_at_notices ? super : Errbit::Config.email_at_notices
   end
 
+  def regenerate_api_key!
+    set(:api_key, SecureRandom.hex)
+  end
+
   protected
 
     def store_cached_attributes_on_problems

--- a/app/views/apps/_fields.html.haml
+++ b/app/views/apps/_fields.html.haml
@@ -5,6 +5,10 @@
   = f.text_field :name
 
 %div
+  %label Api Key
+  %span= app.api_key
+  = link_to t('.regenerate_api_key'), regenerate_api_key_app_path(app), :class => 'button', :method => 'post'
+%div
   = f.label :repository_branch
   = f.text_field :repository_branch, :placeholder => "master"
 %div

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,8 @@ en:
       new_app: Add a New App
       no_apps: 'No apps here.'
       click_to_create: 'Click here to create your first one'
+    fields:
+      regenerate_api_key: "Regenerate API key"
     show:
       all_deploys: "All Deploys (%{count})"
       all_errs: all errs
@@ -100,7 +102,6 @@ en:
       no_error_yet: "No errs have been caught yet, make sure you setup your app"
       no_watcher: "Sadly, no one is watching this app"
       repository: Repository
-      repository: Repository
       revision: Revision
       search_placeholder: 'Search for issues'
       show_hide: "(show/hide)"
@@ -110,3 +111,4 @@ en:
       watchers: Watchers
       when:  When
       who: Who
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Errbit::Application.routes.draw do
     end
     resources :deploys, :only => [:index]
     resources :watchers, :only => [:destroy]
+    member do
+      post :regenerate_api_key
+    end
   end
 
   namespace :api do

--- a/spec/acceptance/acceptance_helper.rb
+++ b/spec/acceptance/acceptance_helper.rb
@@ -17,3 +17,10 @@ def mock_auth(user = "test_user", token = "abcdef")
     }
   )
 end
+
+def log_in(user)
+  visit '/'
+  fill_in :user_email, :with => user.email
+  fill_in :user_password, :with => 'password'
+  click_on I18n.t('devise.sessions.new.sign_in')
+end

--- a/spec/acceptance/app_regenerate_api_key_spec.rb
+++ b/spec/acceptance/app_regenerate_api_key_spec.rb
@@ -1,0 +1,29 @@
+require 'acceptance/acceptance_helper'
+
+feature "Regeneration api_Key" do
+  let!(:app) { Fabricate(:app) }
+  let!(:admin) { Fabricate(:admin) }
+  let(:user) {
+    Fabricate(:user_watcher, :app => app).user
+  }
+
+  scenario "an admin change api_key" do
+    visit '/'
+    log_in admin
+    click_link app.name
+    click_link I18n.t('apps.show.edit')
+    expect {
+      click_link I18n.t('apps.fields.regenerate_api_key')
+    }.to change {
+      app.reload.api_key
+    }
+  end
+
+  scenario "a user cannot access to edit page" do
+    visit '/'
+    log_in user
+    click_link app.name if page.current_url != app_url(app)
+    expect(page).to_not have_button I18n.t('apps.show.edit')
+  end
+
+end

--- a/spec/acceptance/watch_unwatch_app_spec.rb
+++ b/spec/acceptance/watch_unwatch_app_spec.rb
@@ -12,12 +12,9 @@ feature 'A user can watch and unwatch an application' do
   end
 
   scenario 'log in watch a project and unwatch it' do
-    visit '/'
-    fill_in :user_email, :with => user.email
-    fill_in :user_password, :with => 'password'
-    click_on I18n.t('devise.sessions.new.sign_in')
+    log_in user
     click_on I18n.t('apps.show.unwatch')
-    expect(page).to have_content(I18n.t('apps.index.no_apps')
+    expect(page).to have_content(I18n.t('apps.index.no_apps'))
   end
 
 end

--- a/spec/fabricators/err_fabricator.rb
+++ b/spec/fabricators/err_fabricator.rb
@@ -21,3 +21,4 @@ Fabricator :backtrace_line do
   file { "/path/to/file/#{SecureRandom.hex(4)}.rb" }
   method(:method) { ActiveSupport.methods.shuffle.first }
 end
+

--- a/spec/fabricators/problem_fabricator.rb
+++ b/spec/fabricators/problem_fabricator.rb
@@ -21,4 +21,10 @@ Fabricator(:problem_with_errs, :from => :problem) do
   }
 end
 
-
+Fabricator(:problem_resolved, :from => :problem) do
+  after_create do |pr|
+    Fabricate(:notice,
+              :err => Fabricate(:err, :problem => pr))
+    pr.resolve!
+  end
+end


### PR DESCRIPTION
Now the api_key of app can be regenerate. In previous this api-key can't
be regenerate by the web front. To regenerate this api_key you need go
to the edit app page.

See #547
