### PR TITLE
Allow Heroku to access ENV variables during asset compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ heroku config:add HEROKU=true
 heroku config:add SECRET_TOKEN="$(bundle exec rake secret)"
 heroku config:add ERRBIT_HOST=some-hostname.example.com
 heroku config:add ERRBIT_EMAIL_FROM=example@example.com
+# This next line is required to access env variables during asset compilation. 
+# For more info, go to this link: https://devcenter.heroku.com/articles/labs-user-env-compile
+heroku labs:enable user-env-compile
 git push heroku master
 ```
 


### PR DESCRIPTION
This is required for the Devise 3.1.0 configuration introduced in this commit: https://github.com/errbit/errbit/commit/d55891c9ba2c27b40f5ea889fd8b0a92e9d9caec

If this labs addon is not added to Heroku, asset precompilation will fail. Previously, this continued to work because Heroku would compile assets at runtime, but it has been removed. See the following message:

```
       Precompiling assets failed, enabling runtime asset compilation
       Please see this article for troubleshooting help:
       http://devcenter.heroku.com/articles/rails31_heroku_cedar#troubleshooting
-----> DEPRECATIONS:
       Runtime asset compilation is being removed on Sep. 18, 2013.
       Builds will soon fail if assets fail to compile.
```

Adding a Heroku addon to solve an issue is not necessarily the best way of fixing this, but it is a way.

Thoughts?
