### PR TITLE
Organize Procfiles

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec puma
+web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,1 @@
+web: bundle exec puma


### PR DESCRIPTION
Add a dev Procfile, so people can run puma locally:
 `foreman start --procfile=Procfile.dev`
Make the default Procfile use unicorn, so we use it on Heroku

Fix for issue #575
