### PR TITLE
Remove Observers

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,6 +5,8 @@ class Comment
   after_create :increase_counter_cache
   before_destroy :decrease_counter_cache
 
+  after_create :deliver_email, :if => :emailable?
+
   field :body, :type => String
   index(:user_id => 1)
 
@@ -13,6 +15,10 @@ class Comment
   delegate   :app, :to => :err
 
   validates_presence_of :body
+
+  def deliver_email
+    Mailer.comment_notification(self).deliver
+  end
 
   def notification_recipients
     app.notification_recipients - [user.email]

--- a/app/models/comment_observer.rb
+++ b/app/models/comment_observer.rb
@@ -1,8 +1,0 @@
-class CommentObserver < Mongoid::Observer
-  observe :comment
-
-  def after_create(comment)
-    Mailer.comment_notification(comment).deliver if comment.emailable?
-  end
-
-end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -14,6 +14,7 @@ class Deploy
 
   after_create :resolve_app_errs, :if => :should_resolve_app_errs?
   after_create :store_cached_attributes_on_problems
+  after_create :deliver_email
 
   validates_presence_of :username, :environment
 
@@ -34,5 +35,12 @@ class Deploy
     def store_cached_attributes_on_problems
       Problem.where(:app_id => app.id).each(&:cache_app_attributes)
     end
+
+    def deliver_email
+      if app.notify_on_deploys? && app.notification_recipients.any?
+        Mailer.deploy_notification(self).deliver
+      end
+    end
+
 end
 

--- a/app/models/deploy_observer.rb
+++ b/app/models/deploy_observer.rb
@@ -1,9 +1,0 @@
-class DeployObserver < Mongoid::Observer
-  observe :deploy
-
-  def after_create deploy
-    return unless deploy.app.notify_on_deploys? && deploy.app.notification_recipients.any?
-
-    Mailer.deploy_notification(deploy).deliver
-  end
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,9 +29,6 @@ module Errbit
     # :all can be used as a placeholder for all plugins not explicitly named.
     # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
 
-    # Activate observers that should always be running.
-    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
-
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
@@ -53,9 +50,6 @@ module Errbit
 
     # IssueTracker subclasses use inheritance, so preloading models provides querying consistency in dev mode.
     config.mongoid.preload_models = true
-
-    # Set up observers
-    config.mongoid.observers = :deploy_observer, :comment_observer
 
     # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"

--- a/spec/models/comment_observer_spec.rb
+++ b/spec/models/comment_observer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CommentObserver do
+describe "Callback on Comment" do
   context 'when a Comment is saved' do
     let(:comment) { Fabricate.build(:comment) }
 

--- a/spec/models/deploy_observer_spec.rb
+++ b/spec/models/deploy_observer_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe DeployObserver do
+describe "Callback on Deploy" do
   context 'when a Deploy is saved' do
     context 'and the app should notify on deploys' do
       it 'should send an email notification' do


### PR DESCRIPTION
Rails 4 and Mongoid 4 dont have Observers anymore, so we
should remove them to make easier on future migrations.

review @shingara
