### PR TITLE
Remove Taskmapper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,10 +49,6 @@ gem 'gitlab', :git => 'https://github.com/NARKOZ/gitlab.git'
 # Bitbucket Issues
 gem 'bitbucket_rest_api', :require => false
 
-# Unfuddle
-gem "taskmapper"
-gem "taskmapper-unfuddle"
-
 # Jira
 gem 'jira-ruby', :require => 'jira'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,13 +331,6 @@ GEM
       actionpack (~> 3.0)
       activemodel (~> 3.0)
       railties (~> 3.0)
-    taskmapper (1.0.1)
-      activeresource (~> 3.0)
-      activesupport (~> 3.0)
-      hashie (~> 2.0)
-    taskmapper-unfuddle (0.8.0)
-      addressable
-      taskmapper
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     therubyracer (0.12.0)
@@ -433,8 +426,6 @@ DEPENDENCIES
   ruby-fogbugz
   rushover
   strong_parameters
-  taskmapper
-  taskmapper-unfuddle
   therubyracer
   timecop
   turbo-sprockets-rails3

--- a/app/models/issue_trackers/unfuddle_tracker.rb
+++ b/app/models/issue_trackers/unfuddle_tracker.rb
@@ -36,8 +36,8 @@ class IssueTrackers::UnfuddleTracker < IssueTracker
   end
 
   def create_issue(problem, reported_by = nil)
-    unfuddle = TaskMapper.new(:unfuddle, :username => username, :password => password, :account => account)
 
+    Unfuddle.config(account, username, password)
     begin
       issue_options = {:project_id => project_id,
         :summary => issue_title(problem),
@@ -48,9 +48,9 @@ class IssueTrackers::UnfuddleTracker < IssueTracker
 
       issue_options[:milestone_id] = milestone_id if milestone_id.present?
 
-      issue = unfuddle.project(project_id.to_i).ticket!(issue_options)
+      issue = Unfuddle::Ticket.create(issue_options)
       problem.update_attributes(
-                                :issue_link => File.join("#{url}/tickets/#{issue['id']}"),
+                                :issue_link => File.join("#{url}/tickets/#{issue.id}"),
                                 :issue_type => Label
                                 )
     rescue ActiveResource::UnauthorizedAccess

--- a/lib/issue_trackers/apis/unfuddle.rb
+++ b/lib/issue_trackers/apis/unfuddle.rb
@@ -1,0 +1,13 @@
+require 'active_resource'
+
+module Unfuddle
+  class Ticket < ActiveResource::Base
+    self.format = :xml
+  end
+
+  def self.config(account, username, password)
+    Unfuddle::Ticket.site = "https://#{account}.unfuddle.com/api/v1/projects/:project_id"
+    Unfuddle::Ticket.user = username
+    Unfuddle::Ticket.password = password
+  end
+end


### PR DESCRIPTION
Unfuddle issue tracker was the only one using Taskmapper,
Instead we can use a simple ActiveResource implementation for it.
Taskmapper, is not supported on Rails 4, and also is not thread safe. 

review @shingara
