### PR TITLE
Improve fingerprints when error messages differ only in object memory addresses

### DIFF
--- a/app/models/fingerprint.rb
+++ b/app/models/fingerprint.rb
@@ -29,7 +29,13 @@ class Fingerprint
   end
 
   def file_or_message
-    @file_or_message ||= notice.message + notice.backtrace.fingerprint
+    @file_or_message ||= unified_message + notice.backtrace.fingerprint
+  end
+
+  # filter memory addresses out of object strings
+  # example: "#<Object:0x007fa2b33d9458>" becomes "#<Object>"
+  def unified_message
+    notice.message.gsub(/(#<.+?):[0-9a-f]x[0-9a-f]+(>)/, '\1\2')
   end
 
 end


### PR DESCRIPTION
I noticed a regression in the automatic-merging of my errors after upgrading to 0.2-stable, which was caused unintendedly by 28a7ff23aa71ff1b9874dede1d236cdc1efb2145

This pull requests introduces a error message unification which converts messages like

```
NoMethodError: undefined method `foo' for #<ActiveSupport::HashWithIndifferentAccess:0x007f6bfe3287e8>
NoMethodError: undefined method `foo' for #<ActiveSupport::HashWithIndifferentAccess:0x007f6bfd9f5338>
```

to the same error string, which results in the same fingerprint.

Fingerprints of errors, which messages do not include memory addresses, are not changed, so these can be merged to their older counterparts after pulling.

See the added specs for more examples.

Cheers :beer: 
Christoph
