### PR TITLE
Gitlab Issues integration update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'ruby-fogbugz', :require => 'fogbugz'
 # Github Issues
 gem 'octokit', '~> 1.18'
 # Gitlab
-gem 'gitlab', :git => 'https://github.com/NARKOZ/gitlab.git'
+gem 'gitlab', '~> 3.0.0'
 
 # Bitbucket Issues
 gem 'bitbucket_rest_api', :require => false

--- a/app/models/issue_trackers/gitlab_tracker.rb
+++ b/app/models/issue_trackers/gitlab_tracker.rb
@@ -12,12 +12,16 @@ if defined? Gitlab
       [:project_id, {
         :label       => "Ticket Project ID (use Number)",
         :placeholder => "Gitlab Project where issues will be created"
+      }],
+      [:alt_project_id, {
+        :label       => "Project Name (namespace/project)",
+        :placeholder => "Gitlab Project where issues will be created"
       }]
     ]
 
     def check_params
       if Fields.detect {|f| self[f[0]].blank?}
-        errors.add :base, 'You must specify your Gitlab URL, API token and Project ID'
+        errors.add :base, 'You must specify your Gitlab URL, API token, Project ID and Project Name'
       end
     end
 
@@ -43,7 +47,7 @@ if defined? Gitlab
     end
 
     def url
-      "#{account}/#{project_id}/issues"
+      "#{account}/#{alt_project_id}/issues"
     end
   end
 end


### PR DESCRIPTION
I finally updated the Gitlab Issues Integraiton. Sorry for such delay. Integration was working well, so this is just cosmetic update. The only problem was with tracker url. Previously gitlab accepted http://gitlab/ID/issues, while now you have to use namespace/project name http://gitlab/namespace/project/issues. I added field into configuration to use it. I also updated old dependency for gitlab gem. Unfortunately I couldnt pass bundle install on my mac, (issue with libv8), so someone pls finish Gemfile.lock. I tested it on my instance of errbit. Worked well for me.
