### PR TITLE
Remove ruby version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-ruby (ENV['RUBY_VERSION'] || '2.0.0') unless ENV['CI']
 
 RAILS_VERSION = '~> 3.2.15'
 


### PR DESCRIPTION
It is not a good idea to have a ruby version on the Gemfile, specially if you are using RVM,
as rvm sets ENV[RUBY_VERSION] using the revision number: ex.: ruby-2.0.0-p247 , which does not work

review @shingara 
