### PR TITLE
Update README LDAP instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,9 +323,13 @@ Errbit::Config.devise_modules << :ldap_authenticatable
   before authentication. You must add the following lines to `app/models/user.rb`:
 
 ```ruby
-  before_save :set_ldap_email
-  def set_ldap_email
-    self.email = Devise::LdapAdapter.get_ldap_param(self.username, "mail")
+  def ldap_before_save
+    name = Devise::LDAP::Adapter.get_ldap_param(self.username, "givenName")
+    surname = Devise::LDAP::Adapter.get_ldap_param(self.username, "sn")
+    mail = Devise::LDAP::Adapter.get_ldap_param(self.username, "mail")
+
+    self.name = (name + surname).join ' '
+    self.email = mail.first
   end
 ```
 


### PR DESCRIPTION
The instruction for the User model save hook don't work with the current versions of errbit and devise_ldap_authenticatable 0.8.1.

This updates the code to use the initialization hook provides by the devise_ldap_authenticatable gem and also set the name, so validations in errbit pass.
