### PR TITLE
Update rspec to use expect consistently and to use eq over == and {} over lambda

### DIFF
--- a/spec/acceptance/sign_in_with_github_spec.rb
+++ b/spec/acceptance/sign_in_with_github_spec.rb
@@ -12,7 +12,7 @@ feature 'Sign in with GitHub' do
 
     visit '/'
     click_link 'Sign in with GitHub'
-    page.should have_content I18n.t("devise.omniauth_callbacks.success", :kind => 'GitHub')
+    expect(page).to have_content I18n.t("devise.omniauth_callbacks.success", :kind => 'GitHub')
   end
 
   scenario 'reject unrecognized user if authenticating via GitHub' do
@@ -20,6 +20,6 @@ feature 'Sign in with GitHub' do
 
     visit '/'
     click_link 'Sign in with GitHub'
-    page.should have_content 'There are no authorized users with GitHub login'
+    expect(page).to have_content 'There are no authorized users with GitHub login'
   end
 end

--- a/spec/controllers/api/v1/notices_controller_spec.rb
+++ b/spec/controllers/api/v1/notices_controller_spec.rb
@@ -22,7 +22,7 @@ describe Api::V1::NoticesController do
 
       it "should return XML if XML is requested" do
         get :index, :auth_token => @user.authentication_token, :format => "xml"
-        Nokogiri::XML(response.body).errors.should be_empty
+        expect(Nokogiri::XML(response.body).errors).to be_empty
       end
 
       it "should return JSON by default" do
@@ -34,18 +34,18 @@ describe Api::V1::NoticesController do
 
         it "should return only the notices created during the date range" do
           get :index, {:auth_token => @user.authentication_token, :start_date => "2012-08-01", :end_date => "2012-08-27"}
-          response.should be_success
+          expect(response).to be_success
           notices = JSON.load response.body
-          notices.length.should == 3
+          expect(notices.length).to eq 3
         end
 
       end
 
       it "should return all notices" do
         get :index, {:auth_token => @user.authentication_token}
-        response.should be_success
+        expect(response).to be_success
         notices = JSON.load response.body
-        notices.length.should == 4
+        expect(notices.length).to eq 4
       end
 
     end

--- a/spec/controllers/api/v1/problems_controller_spec.rb
+++ b/spec/controllers/api/v1/problems_controller_spec.rb
@@ -24,7 +24,7 @@ describe Api::V1::ProblemsController do
 
       it "should return XML if XML is requested" do
         get :index, :auth_token => @user.authentication_token, :format => "xml"
-        Nokogiri::XML(response.body).errors.should be_empty
+        expect(Nokogiri::XML(response.body).errors).to be_empty
       end
 
       it "should return JSON by default" do
@@ -38,18 +38,18 @@ describe Api::V1::ProblemsController do
 
         it "should return only the problems open during the date range" do
           get :index, {:auth_token => @user.authentication_token, :start_date => "2012-08-20", :end_date => "2012-08-27"}
-          response.should be_success
+          expect(response).to be_success
           problems = JSON.load response.body
-          problems.length.should == 2
+          expect(problems.length).to eq 2
         end
 
       end
 
       it "should return all problems" do
         get :index, {:auth_token => @user.authentication_token}
-        response.should be_success
+        expect(response).to be_success
         problems = JSON.load response.body
-        problems.length.should == 4
+        expect(problems.length).to eq 4
       end
 
     end

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -37,7 +37,7 @@ describe AppsController do
         sign_in admin
         unwatched_app && watched_app1 && watched_app2
         get :index
-        controller.apps.entries.should == App.all.sort.entries
+        expect(controller.apps.entries).to eq App.all.sort.entries
       end
     end
 
@@ -46,8 +46,8 @@ describe AppsController do
         sign_in(user)
         watched_app1 && watched_app2 && unwatched_app
         get :index
-        controller.apps.should include(watched_app1, watched_app2)
-        controller.apps.should_not include(unwatched_app)
+        expect(controller.apps).to include(watched_app1, watched_app2)
+        expect(controller.apps).to_not include(unwatched_app)
       end
     end
   end
@@ -60,17 +60,17 @@ describe AppsController do
 
       it 'finds the app' do
         get :show, :id => app.id
-        controller.app.should == app
+        expect(controller.app).to eq app
       end
 
       it "should not raise errors for app with err without notices" do
         err
-        lambda { get :show, :id => app.id }.should_not raise_error
+        expect{ get :show, :id => app.id }.to_not raise_error
       end
 
       it "should list atom feed successfully" do
         get :show, :id => app.id, :format => "atom"
-        response.should be_success
+        expect(response).to be_success
       end
 
       context "pagination" do
@@ -80,13 +80,13 @@ describe AppsController do
 
         it "should have default per_page value for user" do
           get :show, :id => app.id
-          controller.problems.to_a.size.should == User::PER_PAGE
+          expect(controller.problems.to_a.size).to eq User::PER_PAGE
         end
 
         it "should be able to override default per_page value" do
           admin.update_attribute :per_page, 10
           get :show, :id => app.id
-          controller.problems.to_a.size.should == 10
+          expect(controller.problems.to_a.size).to eq 10
         end
       end
 
@@ -98,14 +98,14 @@ describe AppsController do
         context 'and no params' do
           it 'shows only unresolved problems' do
             get :show, :id => app.id
-            controller.problems.size.should == 1
+            expect(controller.problems.size).to eq 1
           end
         end
 
         context 'and all_problems=true params' do
           it 'shows all errors' do
             get :show, :id => app.id, :all_errs => true
-            controller.problems.size.should == 2
+            expect(controller.problems.size).to eq 2
           end
         end
       end
@@ -121,35 +121,35 @@ describe AppsController do
         context 'no params' do
           it 'shows errs for all environments' do
             get :show, :id => app.id
-            controller.problems.size.should == 20
+            expect(controller.problems.size).to eq 20
           end
         end
 
         context 'environment production' do
           it 'shows errs for just production' do
             get :show, :id => app.id, :environment => 'production'
-            controller.problems.size.should == 5
+            expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment staging' do
           it 'shows errs for just staging' do
             get :show, :id => app.id, :environment => 'staging'
-            controller.problems.size.should == 5
+            expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment development' do
           it 'shows errs for just development' do
             get :show, :id => app.id, :environment => 'development'
-            controller.problems.size.should == 5
+            expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment test' do
           it 'shows errs for just test' do
             get :show, :id => app.id, :environment => 'test'
-            controller.problems.size.should == 5
+            expect(controller.problems.size).to eq 5
           end
         end
       end
@@ -160,15 +160,15 @@ describe AppsController do
         watcher
         sign_in user
         get :show, :id => app.id
-        controller.app.should == app
+        expect(controller.app).to eq app
       end
 
       it 'does not find the app if the user is not watching it' do
         sign_in Fabricate(:user)
         app = Fabricate(:app)
-        lambda {
+        expect{
           get :show, :id => app.id
-        }.should raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound)
       end
     end
   end
@@ -181,19 +181,19 @@ describe AppsController do
     describe "GET /apps/new" do
       it 'instantiates a new app with a prebuilt watcher' do
         get :new
-        controller.app.should be_a(App)
-        controller.app.should be_new_record
-        controller.app.watchers.should_not be_empty
+        expect(controller.app).to be_a(App)
+        expect(controller.app).to be_new_record
+        expect(controller.app.watchers).to_not be_empty
       end
 
       it "should copy attributes from an existing app" do
         @app = Fabricate(:app, :name => "do not copy",
                              :github_repo => "test/example")
         get :new, :copy_attributes_from => @app.id
-        controller.app.should be_a(App)
-        controller.app.should be_new_record
-        controller.app.name.should be_blank
-        controller.app.github_repo.should == "test/example"
+        expect(controller.app).to be_a(App)
+        expect(controller.app).to be_new_record
+        expect(controller.app.name).to be_blank
+        expect(controller.app.github_repo).to eq "test/example"
       end
     end
 
@@ -201,7 +201,7 @@ describe AppsController do
       it 'finds the correct app' do
         app = Fabricate(:app)
         get :edit, :id => app.id
-        controller.app.should == app
+        expect(controller.app).to eq app
       end
     end
 
@@ -213,17 +213,17 @@ describe AppsController do
 
       context "when the create is successful" do
         before do
-          @app.should_receive(:save).and_return(true)
+          expect(@app).to receive(:save).and_return(true)
         end
 
         it "should redirect to the app page" do
           post :create, :app => {}
-          response.should redirect_to(app_path(@app))
+          expect(response).to redirect_to(app_path(@app))
         end
 
         it "should display a message" do
           post :create, :app => {}
-          request.flash[:success].should match(/success/)
+          expect(request.flash[:success]).to match(/success/)
         end
       end
     end
@@ -236,12 +236,12 @@ describe AppsController do
       context "when the update is successful" do
         it "should redirect to the app page" do
           put :update, :id => @app.id, :app => {}
-          response.should redirect_to(app_path(@app))
+          expect(response).to redirect_to(app_path(@app))
         end
 
         it "should display a message" do
           put :update, :id => @app.id, :app => {}
-          request.flash[:success].should match(/success/)
+          expect(request.flash[:success]).to match(/success/)
         end
       end
 
@@ -249,14 +249,14 @@ describe AppsController do
         it "should redirect to app page" do
           id = @app.id
           put :update, :id => id, :app => {:name => "new name"}
-          response.should redirect_to(app_path(id))
+          expect(response).to redirect_to(app_path(id))
         end
       end
 
       context "when the update is unsuccessful" do
         it "should render the edit page" do
           put :update, :id => @app.id, :app => { :name => '' }
-          response.should render_template(:edit)
+          expect(response).to render_template(:edit)
         end
       end
 
@@ -268,19 +268,19 @@ describe AppsController do
         it "should parse legal csv values" do
           put :update, :id => @app.id, :app => { :email_at_notices => '1,   4,      7,8,  10' }
           @app.reload
-          @app.email_at_notices.should == [1, 4, 7, 8, 10]
+          expect(@app.email_at_notices).to eq [1, 4, 7, 8, 10]
         end
         context "failed parsing of CSV" do
           it "should set the default value" do
             @app = Fabricate(:app, :email_at_notices => [1, 2, 3, 4])
             put :update, :id => @app.id, :app => { :email_at_notices => 'asdf, -1,0,foobar,gd00,0,abc' }
             @app.reload
-            @app.email_at_notices.should == Errbit::Config.email_at_notices
+            expect(@app.email_at_notices).to eq Errbit::Config.email_at_notices
           end
 
           it "should display a message" do
             put :update, :id => @app.id, :app => { :email_at_notices => 'qwertyuiop' }
-            request.flash[:error].should match(/Couldn't parse/)
+            expect(request.flash[:error]).to match(/Couldn't parse/)
           end
         end
       end
@@ -295,7 +295,7 @@ describe AppsController do
           end
 
           it "should not create issue tracker" do
-            @app.issue_tracker_configured?.should == false
+            expect(@app.issue_tracker_configured?).to eq false
           end
         end
 
@@ -310,11 +310,13 @@ describe AppsController do
               @app.reload
 
               tracker = @app.issue_tracker
-              tracker.should be_a(tracker_klass)
+              expect(tracker).to be_a(tracker_klass)
               tracker_klass::Fields.each do |field, field_info|
                 case field
-                when :ticket_properties; tracker.send(field.to_sym).should == 'card_type = defect'
-                else tracker.send(field.to_sym).should == 'test_value'
+                when :ticket_properties
+                  expect(tracker.send(field.to_sym)).to eq 'card_type = defect'
+                else
+                  expect(tracker.send(field.to_sym)).to eq 'test_value'
                 end
               end
             end
@@ -326,7 +328,7 @@ describe AppsController do
               put :update, :id => @app.id, :app => {:issue_tracker_attributes => params}
 
               @app.reload
-              @app.issue_tracker_configured?.should == false
+              expect(@app.issue_tracker_configured?).to eq false
             end
           end
         end
@@ -340,22 +342,22 @@ describe AppsController do
 
       it "should find the app" do
         delete :destroy, :id => @app.id
-        controller.app.should == @app
+        expect(controller.app).to eq @app
       end
 
       it "should destroy the app" do
-        @app.should_receive(:destroy)
+        expect(@app).to receive(:destroy)
         delete :destroy, :id => @app.id
       end
 
       it "should display a message" do
         delete :destroy, :id => @app.id
-        request.flash[:success].should match(/success/)
+        expect(request.flash[:success]).to match(/success/)
       end
 
       it "should redirect to the apps page" do
         delete :destroy, :id => @app.id
-        response.should redirect_to(apps_path)
+        expect(response).to redirect_to(apps_path)
       end
     end
   end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -22,11 +22,11 @@ describe CommentsController do
       end
 
       it "should create the comment" do
-        problem.comments.size.should == 1
+        expect(problem.comments.size).to eq 1
       end
 
       it "should redirect to problem page" do
-        response.should redirect_to( app_problem_path(problem.app, problem) )
+        expect(response).to redirect_to( app_problem_path(problem.app, problem) )
       end
     end
   end
@@ -48,11 +48,11 @@ describe CommentsController do
       end
 
       it "should delete the comment" do
-        problem.comments.detect{|c| c.id.to_s == comment.id }.should == nil
+        expect(problem.comments.detect{|c| c.id.to_s == comment.id }).to be nil
       end
 
       it "should redirect to problem page" do
-        response.should redirect_to( app_problem_path(problem.app, problem) )
+        expect(response).to redirect_to( app_problem_path(problem.app, problem) )
       end
     end
   end

--- a/spec/controllers/deploys_controller_spec.rb
+++ b/spec/controllers/deploys_controller_spec.rb
@@ -16,13 +16,13 @@ describe DeploysController do
     end
 
     it 'finds the app via the api key' do
-      App.should_receive(:find_by_api_key!).with('APIKEY').and_return(@app)
+      expect(App).to receive(:find_by_api_key!).with('APIKEY').and_return(@app)
       post :create, :deploy => @params, :api_key => 'APIKEY'
     end
 
     it 'creates a deploy' do
       App.stub(:find_by_api_key!).and_return(@app)
-      @app.deploys.should_receive(:create!).
+      expect(@app.deploys).to receive(:create!).
         with({
           :username     => 'john.doe',
           :environment  => 'production',
@@ -37,8 +37,8 @@ describe DeploysController do
     it 'sends an email notification when configured to do so' do
       post :create, :deploy => @params, :api_key => 'APIKEY'
       email = ActionMailer::Base.deliveries.last
-      email.to.should include(@app.watchers.first.email)
-      email.subject.should == "[#{@app.name}] Deployed to production by john.doe"
+      expect(email.to).to include(@app.watchers.first.email)
+      expect(email.subject).to eq "[#{@app.name}] Deployed to production by john.doe"
     end
 
   end
@@ -51,12 +51,12 @@ describe DeploysController do
     end
 
     it "should render successfully" do
-      response.should be_success
+      expect(response).to be_success
     end
 
     it "should contain info about existing deploy" do
-      response.body.should match(@deploy.short_revision)
-      response.body.should match(@deploy.app.name)
+      expect(response.body).to match(@deploy.short_revision)
+      expect(response.body).to match(@deploy.app.name)
     end
   end
 

--- a/spec/controllers/devise_sessions_controller_spec.rb
+++ b/spec/controllers/devise_sessions_controller_spec.rb
@@ -13,13 +13,13 @@ describe Devise::SessionsController do
 
     it 'redirects to app index page if there are no apps for the user' do
       post :create, { :user => { 'email' => user.email, 'password' => user.password } }
-      response.should redirect_to(root_path)
+      expect(response).to redirect_to(root_path)
     end
 
     it 'redirects to app page if there is app for the user' do
       Fabricate(:user_watcher, :app => app, :user => user)
       post :create, { :user => { 'email' => user.email, 'password' => user.password } }
-      response.should redirect_to(app_path(app))
+      expect(response).to redirect_to(app_path(app))
     end
   end
 end

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -11,39 +11,39 @@ describe NoticesController do
   context 'notices API' do
     context "with all params" do
       before do
-        ErrorReport.should_receive(:new).with(xml).and_return(error_report)
+        expect(ErrorReport).to receive(:new).with(xml).and_return(error_report)
       end
 
       context "with xml pass in raw_port" do
         before do
-          request.should_receive(:raw_post).and_return(xml)
+          expect(request).to receive(:raw_post).and_return(xml)
           post :create, :format => :xml
         end
 
         it "generates a notice from raw xml [POST]" do
-          response.should be_success
+          expect(response).to be_success
           # Same RegExp from Airbrake::Sender#send_to_airbrake (https://github.com/airbrake/airbrake/blob/master/lib/airbrake/sender.rb#L53)
           # Inspired by https://github.com/airbrake/airbrake/blob/master/test/sender_test.rb
-          response.body.should match(%r{<id[^>]*>#{notice.id}</id>})
-          response.body.should match(%r{<url[^>]*>(.+)#{locate_path(notice.id)}</url>})
+          expect(response.body).to match(%r{<id[^>]*>#{notice.id}</id>})
+          expect(response.body).to match(%r{<url[^>]*>(.+)#{locate_path(notice.id)}</url>})
         end
 
       end
 
       it "generates a notice from xml in a data param [POST]" do
         post :create, :data => xml, :format => :xml
-        response.should be_success
+        expect(response).to be_success
         # Same RegExp from Airbrake::Sender#send_to_airbrake (https://github.com/airbrake/airbrake/blob/master/lib/airbrake/sender.rb#L53)
         # Inspired by https://github.com/airbrake/airbrake/blob/master/test/sender_test.rb
-        response.body.should match(%r{<id[^>]*>#{notice.id}</id>})
-        response.body.should match(%r{<url[^>]*>(.+)#{locate_path(notice.id)}</url>})
+        expect(response.body).to match(%r{<id[^>]*>#{notice.id}</id>})
+        expect(response.body).to match(%r{<url[^>]*>(.+)#{locate_path(notice.id)}</url>})
       end
 
       it "generates a notice from xml [GET]" do
         get :create, :data => xml, :format => :xml
-        response.should be_success
-        response.body.should match(%r{<id[^>]*>#{notice.id}</id>})
-        response.body.should match(%r{<url[^>]*>(.+)#{locate_path(notice.id)}</url>})
+        expect(response).to be_success
+        expect(response.body).to match(%r{<id[^>]*>#{notice.id}</id>})
+        expect(response.body).to match(%r{<url[^>]*>(.+)#{locate_path(notice.id)}</url>})
       end
       context "with an invalid API_KEY" do
         let(:error_report) { double(:valid? => false) }
@@ -74,7 +74,7 @@ describe NoticesController do
         problem = Fabricate(:problem, :app => app, :environment => "production")
         notice = Fabricate(:notice, :err => Fabricate(:err, :problem => problem))
         get :locate, :id => notice.id
-        response.should redirect_to(app_problem_path(problem.app, problem))
+        expect(response).to redirect_to(app_problem_path(problem.app, problem))
       end
     end
   end

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -27,13 +27,13 @@ describe ProblemsController do
 
         it "should have default per_page value for user" do
           get :index
-          controller.problems.to_a.size.should == User::PER_PAGE
+          expect(controller.problems.to_a.size).to eq User::PER_PAGE
         end
 
         it "should be able to override default per_page value" do
           @user.update_attribute :per_page, 10
           get :index
-          controller.problems.to_a.size.should == 10
+          expect(controller.problems.to_a.size).to eq 10
         end
       end
 
@@ -48,35 +48,35 @@ describe ProblemsController do
         context 'no params' do
           it 'shows problems for all environments' do
             get :index
-            controller.problems.size.should == 21
+            expect(controller.problems.size).to eq 21
           end
         end
 
         context 'environment production' do
           it 'shows problems for just production' do
             get :index, :environment => 'production'
-            controller.problems.size.should == 6
+            expect(controller.problems.size).to eq 6
           end
         end
 
         context 'environment staging' do
           it 'shows problems for just staging' do
             get :index, :environment => 'staging'
-            controller.problems.size.should == 5
+            expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment development' do
           it 'shows problems for just development' do
             get :index, :environment => 'development'
-            controller.problems.size.should == 5
+            expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment test' do
           it 'shows problems for just test' do
             get :index, :environment => 'test'
-            controller.problems.size.should == 5
+            expect(controller.problems.size).to eq 5
           end
         end
       end
@@ -89,8 +89,8 @@ describe ProblemsController do
         watched_unresolved_err = Fabricate(:err, :problem => Fabricate(:problem, :app => Fabricate(:user_watcher, :user => user).app, :resolved => false))
         watched_resolved_err = Fabricate(:err, :problem => Fabricate(:problem, :app => Fabricate(:user_watcher, :user => user).app, :resolved => true))
         get :index
-        controller.problems.should include(watched_unresolved_err.problem)
-        controller.problems.should_not include(unwatched_err.problem, watched_resolved_err.problem)
+        expect(controller.problems).to include(watched_unresolved_err.problem)
+        expect(controller.problems).to_not include(unwatched_err.problem, watched_resolved_err.problem)
       end
     end
   end
@@ -102,11 +102,11 @@ describe ProblemsController do
         problems = Kaminari.paginate_array((1..30).to_a)
         3.times { problems << Fabricate(:err).problem }
         3.times { problems << Fabricate(:err, :problem => Fabricate(:problem, :resolved => true)).problem }
-        Problem.should_receive(:ordered_by).and_return(
+        expect(Problem).to receive(:ordered_by).and_return(
           double('proxy', :page => double('other_proxy', :per => problems))
         )
         get :index, :all_errs => true
-        controller.problems.should == problems
+        expect(controller.problems).to eq problems
       end
     end
 
@@ -117,8 +117,8 @@ describe ProblemsController do
         watched_unresolved_problem = Fabricate(:problem, :app => Fabricate(:user_watcher, :user => user).app, :resolved => false)
         watched_resolved_problem = Fabricate(:problem, :app => Fabricate(:user_watcher, :user => user).app, :resolved => true)
         get :index, :all_errs => true
-        controller.problems.should include(watched_resolved_problem, watched_unresolved_problem)
-        controller.problems.should_not include(unwatched_problem)
+        expect(controller.problems).to include(watched_resolved_problem, watched_unresolved_problem)
+        expect(controller.problems).to_not include(unwatched_problem)
       end
     end
   end
@@ -133,17 +133,17 @@ describe ProblemsController do
 
       it "finds the app" do
         get :show, :app_id => app.id, :id => err.problem.id
-        controller.app.should == app
+        expect(controller.app).to eq app
       end
 
       it "finds the problem" do
         get :show, :app_id => app.id, :id => err.problem.id
-        controller.problem.should == err.problem
+        expect(controller.problem).to eq err.problem
       end
 
       it "successfully render page" do
         get :show, :app_id => app.id, :id => err.problem.id
-        response.should be_success
+        expect(response).to be_success
       end
 
       context 'pagination' do
@@ -155,14 +155,14 @@ describe ProblemsController do
 
         it "paginates the notices 1 at a time, starting with the most recent" do
           get :show, :app_id => app.id, :id => err.problem.id
-          assigns(:notices).entries.count.should == 1
-          assigns(:notices).should include(notices.last)
+          expect(assigns(:notices).entries.count).to eq 1
+          expect(assigns(:notices)).to include(notices.last)
         end
 
         it "paginates the notices 1 at a time, based on then notice param" do
           get :show, :app_id => app.id, :id => err.problem.id, :notice => 3
-          assigns(:notices).entries.count.should == 1
-          assigns(:notices).should include(notices.first)
+          expect(assigns(:notices).entries.count).to eq 1
+          expect(assigns(:notices)).to include(notices.first)
         end
       end
 
@@ -179,13 +179,13 @@ describe ProblemsController do
 
       it 'finds the problem if the user is watching the app' do
         get :show, :app_id => @watched_app.to_param, :id => @watched_err.problem.id
-        controller.problem.should == @watched_err.problem
+        expect(controller.problem).to eq @watched_err.problem
       end
 
       it 'raises a DocumentNotFound error if the user is not watching the app' do
-        lambda {
+        expect {
           get :show, :app_id => @unwatched_err.problem.app_id, :id => @unwatched_err.problem.id
-        }.should raise_error(Mongoid::Errors::DocumentNotFound)
+        }.to raise_error(Mongoid::Errors::DocumentNotFound)
       end
     end
   end
@@ -201,32 +201,32 @@ describe ProblemsController do
     end
 
     it 'finds the app and the problem' do
-      App.should_receive(:find).with(@problem.app.id.to_s).and_return(@problem.app)
-      @problem.app.problems.should_receive(:find).and_return(@problem.problem)
+      expect(App).to receive(:find).with(@problem.app.id.to_s).and_return(@problem.app)
+      expect(@problem.app.problems).to receive(:find).and_return(@problem.problem)
       put :resolve, :app_id => @problem.app.id, :id => @problem.problem.id
-      controller.app.should == @problem.app
-      controller.problem.should == @problem.problem
+      expect(controller.app).to eq @problem.app
+      expect(controller.problem).to eq @problem.problem
     end
 
     it "should resolve the issue" do
-      @problem.problem.should_receive(:resolve!).and_return(true)
+      expect(@problem.problem).to receive(:resolve!).and_return(true)
       put :resolve, :app_id => @problem.app.id, :id => @problem.problem.id
     end
 
     it "should display a message" do
       put :resolve, :app_id => @problem.app.id, :id => @problem.problem.id
-      request.flash[:success].should match(/Great news/)
+      expect(request.flash[:success]).to match(/Great news/)
     end
 
     it "should redirect to the app page" do
       put :resolve, :app_id => @problem.app.id, :id => @problem.problem.id
-      response.should redirect_to(app_path(@problem.app))
+      expect(response).to redirect_to(app_path(@problem.app))
     end
 
     it "should redirect back to problems page" do
       request.env["Referer"] = problems_path
       put :resolve, :app_id => @problem.app.id, :id => @problem.problem.id
-      response.should redirect_to(problems_path)
+      expect(response).to redirect_to(problems_path)
     end
   end
 
@@ -255,7 +255,7 @@ describe ProblemsController do
         end
 
         it "should redirect to problem page" do
-          response.should redirect_to( app_problem_path(problem.app, problem) )
+          expect(response).to redirect_to( app_problem_path(problem.app, problem) )
         end
       end
     end
@@ -268,11 +268,11 @@ describe ProblemsController do
       end
 
       it "should redirect to problem page" do
-        response.should redirect_to( app_problem_path(problem.app, problem) )
+        expect(response).to redirect_to( app_problem_path(problem.app, problem) )
       end
 
       it "should set flash error message telling issue tracker of the app doesn't exist" do
-        flash[:error].should == "This app has no issue tracker setup."
+        expect(flash[:error]).to eq "This app has no issue tracker setup."
       end
     end
 
@@ -288,11 +288,11 @@ describe ProblemsController do
         end
 
         it "should redirect to problem page" do
-          response.should redirect_to( app_problem_path(err.app, err.problem) )
+          expect(response).to redirect_to( app_problem_path(err.app, err.problem) )
         end
 
         it "should notify of connection error" do
-          flash[:error].should include("There was an error during issue creation:")
+          expect(flash[:error]).to include("There was an error during issue creation:")
         end
       end
     end
@@ -312,11 +312,11 @@ describe ProblemsController do
       end
 
       it "should redirect to problem page" do
-        response.should redirect_to( app_problem_path(err.app, err.problem) )
+        expect(response).to redirect_to( app_problem_path(err.app, err.problem) )
       end
 
       it "should clear issue link" do
-        err.problem.issue_link.should be_nil
+        expect(err.problem.issue_link).to be_nil
       end
     end
 
@@ -329,7 +329,7 @@ describe ProblemsController do
       end
 
       it "should redirect to problem page" do
-        response.should redirect_to( app_problem_path(err.app, err.problem) )
+        expect(response).to redirect_to( app_problem_path(err.app, err.problem) )
       end
     end
   end
@@ -344,11 +344,11 @@ describe ProblemsController do
     context "POST /problems/merge_several" do
       it "should require at least two problems" do
         post :merge_several, :problems => [@problem1.id.to_s]
-        request.flash[:notice].should eql I18n.t('controllers.problems.flash.need_two_errors_merge')
+        expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.need_two_errors_merge')
       end
 
       it "should merge the problems" do
-        ProblemMerge.should_receive(:new).and_return(double(:merge => true))
+        expect(ProblemMerge).to receive(:new).and_return(double(:merge => true))
         post :merge_several, :problems => [@problem1.id.to_s, @problem2.id.to_s]
       end
     end
@@ -357,16 +357,16 @@ describe ProblemsController do
 
       it "should require at least one problem" do
         post :unmerge_several, :problems => []
-        request.flash[:notice].should eql I18n.t('controllers.problems.flash.no_select_problem')
+        expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.no_select_problem')
       end
 
       it "should unmerge a merged problem" do
         merged_problem = Problem.merge!(@problem1, @problem2)
-        merged_problem.errs.length.should == 2
-        lambda {
+        expect(merged_problem.errs.length).to eq 2
+        expect{
           post :unmerge_several, :problems => [merged_problem.id.to_s]
-          merged_problem.reload.errs.length.should == 1
-        }.should change(Problem, :count).by(1)
+          expect(merged_problem.reload.errs.length).to eq 1
+        }.to change(Problem, :count).by(1)
       end
 
     end
@@ -375,23 +375,23 @@ describe ProblemsController do
 
       it "should require at least one problem" do
         post :resolve_several, :problems => []
-        request.flash[:notice].should eql I18n.t('controllers.problems.flash.no_select_problem')
+        expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.no_select_problem')
       end
 
       it "should resolve the issue" do
         post :resolve_several, :problems => [@problem2.id.to_s]
-        @problem2.reload.resolved?.should == true
+        expect(@problem2.reload.resolved?).to eq true
       end
 
       it "should display a message about 1 err" do
         post :resolve_several, :problems => [@problem2.id.to_s]
-        flash[:success].should match(/1 err has been resolved/)
+        expect(flash[:success]).to match(/1 err has been resolved/)
       end
 
       it "should display a message about 2 errs" do
         post :resolve_several, :problems => [@problem1.id.to_s, @problem2.id.to_s]
-        flash[:success].should match(/2 errs have been resolved/)
-        controller.selected_problems.should == [@problem1, @problem2]
+        expect(flash[:success]).to match(/2 errs have been resolved/)
+        expect(controller.selected_problems).to eq [@problem1, @problem2]
       end
     end
 
@@ -399,20 +399,20 @@ describe ProblemsController do
 
       it "should require at least one problem" do
         post :unresolve_several, :problems => []
-        request.flash[:notice].should eql I18n.t('controllers.problems.flash.no_select_problem')
+        expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.no_select_problem')
       end
 
       it "should unresolve the issue" do
         post :unresolve_several, :problems => [@problem1.id.to_s]
-        @problem1.reload.resolved?.should == false
+        expect(@problem1.reload.resolved?).to eq false
       end
     end
 
     context "POST /problems/destroy_several" do
       it "should delete the problems" do
-        lambda {
+        expect{
           post :destroy_several, :problems => [@problem1.id.to_s]
-        }.should change(Problem, :count).by(-1)
+        }.to change(Problem, :count).by(-1)
       end
     end
   end

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -25,16 +25,16 @@ describe Users::OmniauthCallbacksController do
       stub_env_for_github_omniauth("existing_user")
       get :github
 
-      request.flash[:error].should include('already registered')
-      response.should redirect_to(user_path(@user))
+      expect(request.flash[:error]).to include('already registered')
+      expect(response).to redirect_to(user_path(@user))
     end
 
     it "should link an authorized GitHub account" do
       stub_env_for_github_omniauth("new_user")
       get :github
 
-      request.flash[:success].should include('Successfully linked')
-      response.should redirect_to(user_path(@user))
+      expect(request.flash[:success]).to include('Successfully linked')
+      expect(response).to redirect_to(user_path(@user))
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -22,20 +22,20 @@ describe UsersController do
     end
 
     it "should set a time zone" do
-      Time.zone.should.to_s == user.time_zone
+      expect(Time.zone.to_s).to match(user.time_zone)
     end
 
     context "GET /users/:other_id/edit" do
       it "redirects to the home page" do
         get :edit, :id => other_user.id
-        response.should redirect_to(root_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 
     context "GET /users/:my_id/edit" do
       it 'finds the user' do
         get :edit, :id => user.id
-        controller.user.should == user
+        expect(controller.user).to eq user
         expect(response).to render_template 'edit'
       end
 
@@ -44,7 +44,7 @@ describe UsersController do
     context "PUT /users/:other_id" do
       it "redirects to the home page" do
         put :update, :id => other_user.id
-        response.should redirect_to(root_path)
+        expect(response).to redirect_to(root_path)
       end
     end
 
@@ -52,12 +52,12 @@ describe UsersController do
       context "when the update is successful" do
         it "sets a message to display" do
           put :update, :id => user.to_param, :user => {:name => 'Kermit'}
-          request.flash[:success].should include('updated')
+          expect(request.flash[:success]).to include('updated')
         end
 
         it "redirects to the user's page" do
           put :update, :id => user.to_param, :user => {:name => 'Kermit'}
-          response.should redirect_to(user_path(user))
+          expect(response).to redirect_to(user_path(user))
         end
 
         it "should not be able to become an admin" do
@@ -70,29 +70,29 @@ describe UsersController do
 
         it "should be able to set per_page option" do
           put :update, :id => user.to_param, :user => {:per_page => 555}
-          user.reload.per_page.should == 555
+          expect(user.reload.per_page).to eq 555
         end
 
         it "should be able to set time_zone option" do
           put :update, :id => user.to_param, :user => {:time_zone => "Warsaw"}
-          user.reload.time_zone.should == "Warsaw"
+          expect(user.reload.time_zone).to eq "Warsaw"
         end
 
         it "should be able to not set github_login option" do
           put :update, :id => user.to_param, :user => {:github_login => " "}
-          user.reload.github_login.should == nil
+          expect(user.reload.github_login).to eq nil
         end
 
         it "should be able to set github_login option" do
           put :update, :id => user.to_param, :user => {:github_login => "awesome_name"}
-          user.reload.github_login.should == "awesome_name"
+          expect(user.reload.github_login).to eq "awesome_name"
         end
       end
 
       context "when the update is unsuccessful" do
         it "renders the edit page" do
           put :update, :id => user.to_param, :user => {:name => nil}
-          response.should render_template(:edit)
+          expect(response).to render_template(:edit)
         end
       end
     end
@@ -111,7 +111,7 @@ describe UsersController do
           Fabricate(:user)
         }
         get :index
-        controller.users.to_a.size.should == 2
+        expect(controller.users.to_a.size).to eq 2
       end
 
     end
@@ -119,22 +119,22 @@ describe UsersController do
     context "GET /users/:id" do
       it 'finds the user' do
         get :show, :id => user.id
-        controller.user.should == user
+        expect(controller.user).to eq user
       end
     end
 
     context "GET /users/new" do
       it 'assigns a new user' do
         get :new
-        controller.user.should be_a(User)
-        controller.user.should be_new_record
+        expect(controller.user).to be_a(User)
+        expect(controller.user).to be_new_record
       end
     end
 
     context "GET /users/:id/edit" do
       it 'finds the user' do
         get :edit, :id => user.id
-        controller.user.should == user
+        expect(controller.user).to eq user
       end
     end
 
@@ -144,24 +144,24 @@ describe UsersController do
 
         it "sets a message to display" do
           post :create, attrs
-          request.flash[:success].should include('part of the team')
+          expect(request.flash[:success]).to include('part of the team')
         end
 
         it "redirects to the user's page" do
           post :create, attrs
-          response.should redirect_to(user_path(controller.user))
+          expect(response).to redirect_to(user_path(controller.user))
         end
 
         it "should be able to create admin" do
           attrs[:user][:admin] = true
           post :create, attrs
-          response.should be_redirect
-          User.find(controller.user.to_param).admin.should be_true
+          expect(response).to be_redirect
+          expect(User.find(controller.user.to_param).admin).to be_true
         end
 
         it "should has auth token" do
           post :create, attrs
-          User.last.authentication_token.should_not be_blank
+          expect(User.last.authentication_token).to_not be_blank
         end
       end
 
@@ -170,13 +170,13 @@ describe UsersController do
           Struct.new(:admin, :attributes).new(true, {})
         }
         before do
-          User.should_receive(:new).and_return(user)
-          user.should_receive(:save).and_return(false)
+          expect(User).to receive(:new).and_return(user)
+          expect(user).to receive(:save).and_return(false)
         end
 
         it "renders the new page" do
           post :create, :user => { :username => 'foo' }
-          response.should render_template(:new)
+          expect(response).to render_template(:new)
         end
       end
     end
@@ -199,7 +199,7 @@ describe UsersController do
 
         it "renders the edit page" do
           put :update, :id => user.to_param, :user => {:name => nil}
-          response.should render_template(:edit)
+          expect(response).to render_template(:edit)
         end
       end
     end
@@ -210,24 +210,24 @@ describe UsersController do
         let(:user_destroy) { double(:destroy => true) }
 
         before {
-          UserDestroy.should_receive(:new).with(user).and_return(user_destroy)
+          expect(UserDestroy).to receive(:new).with(user).and_return(user_destroy)
           delete :destroy, :id => user.id
         }
 
         it 'should destroy user' do
           expect(request.flash[:success]).to eq I18n.t('controllers.users.flash.destroy.success', :name => user.name)
-          response.should redirect_to(users_path)
+          expect(response).to redirect_to(users_path)
         end
       end
 
       context "with trying destroy himself" do
         before {
-          UserDestroy.should_not_receive(:new)
+          expect(UserDestroy).to_not receive(:new)
           delete :destroy, :id => admin.id
         }
 
         it 'should not destroy user' do
-          response.should redirect_to(users_path)
+          expect(response).to redirect_to(users_path)
           expect(request.flash[:error]).to eq I18n.t('controllers.users.flash.destroy.error')
         end
       end

--- a/spec/controllers/watchers_controller_spec.rb
+++ b/spec/controllers/watchers_controller_spec.rb
@@ -24,11 +24,11 @@ describe WatchersController do
         end
 
         it "should delete the watcher" do
-          app.watchers.detect{|w| w.id.to_s == watcher.id }.should == nil
+          expect(app.watchers.detect{|w| w.id.to_s == watcher.id }).to be nil
         end
 
         it "should redirect to index page" do
-          response.should redirect_to(root_path)
+          expect(response).to redirect_to(root_path)
         end
       end
     end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -3,13 +3,13 @@ require 'spec_helper'
 describe NavigationHelper do
   describe '#page_count_from_end' do
     it 'returns the page number when counting from the last occurrence of a notice' do
-      page_count_from_end(1, 6).should == 6
-      page_count_from_end(6, 6).should == 1
-      page_count_from_end(2, 6).should == 5
+      expect(page_count_from_end(1, 6)).to eq 6
+      expect(page_count_from_end(6, 6)).to eq 1
+      expect(page_count_from_end(2, 6)).to eq 5
     end
 
     it 'properly handles strings for input' do
-      page_count_from_end('2', '6').should == 5
+      expect(page_count_from_end('2', '6')).to eq 5
     end
   end
 end

--- a/spec/helpers/problems_helper_spec.rb
+++ b/spec/helpers/problems_helper_spec.rb
@@ -5,8 +5,8 @@ describe ProblemsHelper do
     it 'is html safe' do
       problem = double('problem', :message => '#<NoMethodError: ...>')
       truncated = helper.truncated_problem_message(problem)
-      truncated.should be_html_safe
-      truncated.should_not include('<', '>')
+      expect(truncated).to be_html_safe
+      expect(truncated).to_not include('<', '>')
     end
   end
 
@@ -23,18 +23,18 @@ describe ProblemsHelper do
 
       it "should render image_tag with correct alt and src" do
         expected = "<img alt=\"#{email}\" class=\"gravatar\" src=\"#{base_url}?d=identicon&amp;s=48\" />"
-        helper.gravatar_tag(email, :s => 48).should eq(expected)
+        expect(helper.gravatar_tag(email, :s => 48)).to eq(expected)
       end
 
       it "should override :d" do
         expected = "<img alt=\"#{email}\" class=\"gravatar\" src=\"#{base_url}?d=retro&amp;s=48\" />"
-        helper.gravatar_tag(email, :d => 'retro', :s => 48).should eq(expected)
+        expect(helper.gravatar_tag(email, :d => 'retro', :s => 48)).to eq(expected)
       end
     end
 
     context "no email" do
       it "should not render the tag" do
-        helper.gravatar_tag(nil).should be_nil
+        expect(helper.gravatar_tag(nil)).to be_nil
       end
     end
   end
@@ -44,7 +44,7 @@ describe ProblemsHelper do
       let(:email) { nil }
 
       it "should return nil" do
-        helper.gravatar_url(email).should be_nil
+        expect(helper.gravatar_url(email)).to be_nil
       end
     end
 
@@ -53,7 +53,7 @@ describe ProblemsHelper do
       let(:email_hash) { Digest::MD5.hexdigest email }
 
       it "should return the http url" do
-        helper.gravatar_url(email).should eq("http://www.gravatar.com/avatar/#{email_hash}?d=identicon")
+        expect(helper.gravatar_url(email)).to eq("http://www.gravatar.com/avatar/#{email_hash}?d=identicon")
       end
     end
 
@@ -63,7 +63,7 @@ describe ProblemsHelper do
 
       it "should return the http url" do
         ActionController::TestRequest.any_instance.stub :ssl? => true
-        helper.gravatar_url(email).should eq("https://secure.gravatar.com/avatar/#{email_hash}?d=identicon")
+        expect(helper.gravatar_url(email)).to eq("https://secure.gravatar.com/avatar/#{email_hash}?d=identicon")
       end
     end
   end

--- a/spec/interactors/issue_creation_spec.rb
+++ b/spec/interactors/issue_creation_spec.rb
@@ -16,7 +16,7 @@ describe IssueCreation do
 
   it 'creates an issue if issue tracker is configured' do
     tracker = Fabricate(:lighthouse_tracker, :app => notice.app)
-    tracker.should_receive(:create_issue)
+    expect(tracker).to receive(:create_issue)
     issue_creation.execute
     expect(errors).to be_empty
   end

--- a/spec/interactors/problem_destroy_spec.rb
+++ b/spec/interactors/problem_destroy_spec.rb
@@ -21,28 +21,28 @@ describe ProblemDestroy do
 
     describe "#initialize" do
       it 'take a problem like args' do
-        problem_destroy.problem.should == problem
+        expect(problem_destroy.problem).to eq problem
       end
     end
 
     describe "#execute" do
       it 'destroy the problem himself' do
-        problem.should_receive(:delete).and_return(true)
+        expect(problem).to receive(:delete).and_return(true)
         problem_destroy.execute
       end
 
       it 'delete all errs associate' do
-        Err.should_receive(:delete_all).with(:_id => { '$in' => [err_1.id, err_2.id] })
+        expect(Err).to receive(:delete_all).with(:_id => { '$in' => [err_1.id, err_2.id] })
         problem_destroy.execute
       end
 
       it 'delete all comments associate' do
-        Comment.should_receive(:delete_all).with(:_id => { '$in' => [comment_1.id, comment_2.id] })
+        expect(Comment).to receive(:delete_all).with(:_id => { '$in' => [comment_1.id, comment_2.id] })
         problem_destroy.execute
       end
 
       it 'delete all notice of associate to this errs' do
-        Notice.should_receive(:delete_all).with({:err_id => { '$in' => [err_1.id, err_2.id] }})
+        expect(Notice).to receive(:delete_all).with({:err_id => { '$in' => [err_1.id, err_2.id] }})
         problem_destroy.execute
       end
     end
@@ -62,15 +62,15 @@ describe ProblemDestroy do
 
     it 'should all destroy' do
       problem_destroy.execute
-      Problem.where(:_id => problem.id).entries.should be_empty
-      Err.where(:_id => err_1.id).entries.should be_empty
-      Err.where(:_id => err_2.id).entries.should be_empty
-      Comment.where(:_id => comment_1.id).entries.should be_empty
-      Comment.where(:_id => comment_2.id).entries.should be_empty
-      Notice.where(:_id => notice_1_1.id).entries.should be_empty
-      Notice.where(:_id => notice_1_2.id).entries.should be_empty
-      Notice.where(:_id => notice_2_1.id).entries.should be_empty
-      Notice.where(:_id => notice_2_2.id).entries.should be_empty
+      expect(Problem.where(:_id => problem.id).entries).to be_empty
+      expect(Err.where(:_id => err_1.id).entries).to be_empty
+      expect(Err.where(:_id => err_2.id).entries).to be_empty
+      expect(Comment.where(:_id => comment_1.id).entries).to be_empty
+      expect(Comment.where(:_id => comment_2.id).entries).to be_empty
+      expect(Notice.where(:_id => notice_1_1.id).entries).to be_empty
+      expect(Notice.where(:_id => notice_1_2.id).entries).to be_empty
+      expect(Notice.where(:_id => notice_2_1.id).entries).to be_empty
+      expect(Notice.where(:_id => notice_2_2.id).entries).to be_empty
     end
   end
 

--- a/spec/interactors/problem_merge_spec.rb
+++ b/spec/interactors/problem_merge_spec.rb
@@ -42,7 +42,7 @@ describe ProblemMerge do
     end
 
     it 'update problem cache' do
-      ProblemUpdaterCache.should_receive(:new).with(problem).and_return(double(:update => true))
+      expect(ProblemUpdaterCache).to receive(:new).with(problem).and_return(double(:update => true))
       problem_merge.merge
     end
 

--- a/spec/interactors/resolved_problem_clearer_spec.rb
+++ b/spec/interactors/resolved_problem_clearer_spec.rb
@@ -22,7 +22,7 @@ describe ResolvedProblemClearer do
       end
       it 'not repair database' do
         Mongoid.default_session.stub(:command).and_call_original
-        Mongoid.default_session.should_not_receive(:command).with({:repairDatabase => 1})
+        expect(Mongoid.default_session).to_not receive(:command).with({:repairDatabase => 1})
         resolved_problem_clearer.execute
       end
     end
@@ -47,7 +47,7 @@ describe ResolvedProblemClearer do
 
       it 'repair database' do
         Mongoid.default_session.stub(:command).and_call_original
-        Mongoid.default_session.should_receive(:command).with({:repairDatabase => 1})
+        expect(Mongoid.default_session).to receive(:command).with({:repairDatabase => 1})
         resolved_problem_clearer.execute
       end
     end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -20,29 +20,29 @@ describe Mailer do
     end
 
     it "should send the email" do
-      ActionMailer::Base.deliveries.size.should == 1
+      expect(ActionMailer::Base.deliveries.size).to eq 1
     end
 
     it "should html-escape the notice's message for the html part" do
-      @email.should have_body_text("class &lt; ActionController::Base")
+      expect(@email).to have_body_text("class &lt; ActionController::Base")
     end
 
     it "should have inline css" do
-      @email.should have_body_text('<p class="backtrace" style="')
+      expect(@email).to have_body_text('<p class="backtrace" style="')
     end
 
     it "should have links to source files" do
-      @email.should have_body_text('<a href="http://example.com/path/to/file.js" target="_blank">path/to/file.js')
+      expect(@email).to have_body_text('<a href="http://example.com/path/to/file.js" target="_blank">path/to/file.js')
     end
 
     it "should have the error count in the subject" do
-      @email.subject.should =~ /^\(3\) /
+      expect(@email.subject).to match( /^\(3\) / )
     end
 
     context 'with a very long message' do
       let(:notice)  { Fabricate(:notice, :message => 6.times.collect{|a| "0123456789" }.join('')) }
       it "should truncate the long message" do
-        @email.subject.should =~ / \d{47}\.{3}$/
+        expect(@email.subject).to match( / \d{47}\.{3}$/ )
       end
     end
   end
@@ -63,19 +63,19 @@ describe Mailer do
     end
 
     it "should send the email" do
-      ActionMailer::Base.deliveries.size.should == 1
+      expect(ActionMailer::Base.deliveries.size).to eq 1
     end
 
     it "should be sent to comment notification recipients" do
-      @email.to.should == recipients
+      expect(@email.to).to eq recipients
     end
 
     it "should have the notices count in the body" do
-      @email.should have_body_text("This err has occurred 2 times")
+      expect(@email).to have_body_text("This err has occurred 2 times")
     end
 
     it "should have the comment body" do
-      @email.should have_body_text(comment.body)
+      expect(@email).to have_body_text(comment.body)
     end
   end
 end

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -12,22 +12,22 @@ describe App do
   context 'validations' do
     it 'requires a name' do
       app = Fabricate.build(:app, :name => nil)
-      app.should_not be_valid
-      app.errors[:name].should include("can't be blank")
+      expect(app).to_not be_valid
+      expect(app.errors[:name]).to include("can't be blank")
     end
 
     it 'requires unique names' do
       Fabricate(:app, :name => 'Errbit')
       app = Fabricate.build(:app, :name => 'Errbit')
-      app.should_not be_valid
-      app.errors[:name].should include('is already taken')
+      expect(app).to_not be_valid
+      expect(app.errors[:name]).to include('is already taken')
     end
 
     it 'requires unique api_keys' do
       Fabricate(:app, :api_key => 'APIKEY')
       app = Fabricate.build(:app, :api_key => 'APIKEY')
-      app.should_not be_valid
-      app.errors[:api_key].should include('is already taken')
+      expect(app).to_not be_valid
+      expect(app.errors[:api_key]).to include('is already taken')
     end
   end
 
@@ -36,87 +36,87 @@ describe App do
       app_0 = stub_model(App, :name => 'app', :unresolved_count => 1, :problem_count => 1)
       app_1 = stub_model(App, :name => 'app', :unresolved_count => 0, :problem_count => 1)
 
-      app_0.should < app_1
-      app_1.should > app_0
+      expect(app_0).to be < app_1
+      expect(app_1).to be > app_0
     end
 
     it 'is compared by problem count' do
       app_0 = stub_model(App, :name => 'app', :unresolved_count => 0, :problem_count => 1)
       app_1 = stub_model(App, :name => 'app', :unresolved_count => 0, :problem_count => 0)
 
-      app_0.should < app_1
-      app_1.should > app_0
+      expect(app_0).to be < app_1
+      expect(app_1).to be > app_0
     end
 
     it 'is compared by name' do
       app_0 = stub_model(App, :name => 'app_0', :unresolved_count => 0, :problem_count => 0)
       app_1 = stub_model(App, :name => 'app_1', :unresolved_count => 0, :problem_count => 0)
 
-      app_0.should < app_1
-      app_1.should > app_0
+      expect(app_0).to be < app_1
+      expect(app_1).to be > app_0
     end
   end
 
   context 'being created' do
     it 'generates a new api-key' do
       app = Fabricate.build(:app)
-      app.api_key.should be_nil
+      expect(app.api_key).to be_nil
       app.save
-      app.api_key.should_not be_nil
+      expect(app.api_key).to_not be_nil
     end
 
     it 'generates a correct api-key' do
       app = Fabricate(:app)
-      app.api_key.should match(/^[a-f0-9]{32}$/)
+      expect(app.api_key).to match(/^[a-f0-9]{32}$/)
     end
 
     it 'is fine with blank github repos' do
       app = Fabricate.build(:app, :github_repo => "")
       app.save
-      app.github_repo.should == ""
+      expect(app.github_repo).to eq ""
     end
 
     it 'doesnt touch github user/repo' do
       app = Fabricate.build(:app, :github_repo => "errbit/errbit")
       app.save
-      app.github_repo.should == "errbit/errbit"
+      expect(app.github_repo).to eq "errbit/errbit"
     end
 
     it 'removes domain from https github repos' do
       app = Fabricate.build(:app, :github_repo => "https://github.com/errbit/errbit")
       app.save
-      app.github_repo.should == "errbit/errbit"
+      expect(app.github_repo).to eq "errbit/errbit"
     end
 
     it 'normalizes public git repo as a github repo' do
       app = Fabricate.build(:app, :github_repo => "https://github.com/errbit/errbit.git")
       app.save
-      app.github_repo.should == "errbit/errbit"
+      expect(app.github_repo).to eq "errbit/errbit"
     end
 
     it 'normalizes private git repo as a github repo' do
       app = Fabricate.build(:app, :github_repo => "git@github.com:errbit/errbit.git")
       app.save
-      app.github_repo.should == "errbit/errbit"
+      expect(app.github_repo).to eq "errbit/errbit"
     end
   end
 
   context '#github_url_to_file' do
     it 'resolves to full path to file' do
       app = Fabricate(:app, :github_repo => "errbit/errbit")
-      app.github_url_to_file('path/to/file').should == "https://github.com/errbit/errbit/blob/master/path/to/file"
+      expect(app.github_url_to_file('path/to/file')).to eq "https://github.com/errbit/errbit/blob/master/path/to/file"
     end
   end
 
   context '#github_repo?' do
     it 'is true when there is a github_repo' do
       app = Fabricate(:app, :github_repo => "errbit/errbit")
-      app.github_repo?.should be_true
+      expect(app.github_repo?).to be_true
     end
 
     it 'is false when no github_repo' do
       app = Fabricate(:app)
-      app.github_repo?.should be_false
+      expect(app.github_repo?).to be_false
     end
   end
 
@@ -126,9 +126,9 @@ describe App do
       3.times { Fabricate(:user) }
       5.times { Fabricate(:watcher, :app => @app) }
       @app.notify_all_users = true
-      @app.notification_recipients.size.should == 8
+      expect(@app.notification_recipients.size).to eq 8
       @app.notify_all_users = false
-      @app.notification_recipients.size.should == 5
+      expect(@app.notification_recipients.size).to eq 5
     end
   end
 
@@ -136,19 +136,19 @@ describe App do
     it "should be true if notify on errs and there are notification recipients" do
       app = Fabricate(:app, :notify_on_errs => true, :notify_all_users => false)
       2.times { Fabricate(:watcher, :app => app) }
-      app.emailable?.should be_true
+      expect(app.emailable?).to be_true
     end
 
     it "should be false if notify on errs is disabled" do
       app = Fabricate(:app, :notify_on_errs => false, :notify_all_users => false)
       2.times { Fabricate(:watcher, :app => app) }
-      app.emailable?.should be_false
+      expect(app.emailable?).to be_false
     end
 
     it "should be false if there are no notification recipients" do
       app = Fabricate(:app, :notify_on_errs => true, :notify_all_users => false)
-      app.watchers.should be_empty
-      app.emailable?.should be_false
+      expect(app.watchers).to be_empty
+      expect(app.emailable?).to be_false
     end
   end
 
@@ -158,9 +158,9 @@ describe App do
                         Fabricate(:app, :name => "copy_app", :github_repo => "copy url")
       @copy_watcher = Fabricate(:watcher, :email => "copywatcher@example.com", :app => @copy_app)
       @app.copy_attributes_from(@copy_app.id)
-      @app.name.should == "app"
-      @app.github_repo.should == "copy url"
-      @app.watchers.first.email.should == "copywatcher@example.com"
+      expect(@app.name).to eq "app"
+      expect(@app.github_repo).to eq "copy url"
+      expect(@app.watchers.first.email).to eq "copywatcher@example.com"
     end
   end
 
@@ -178,19 +178,19 @@ describe App do
         :problem => Fabricate(:problem, :app => app),
         :fingerprint => conditions[:fingerprint]
       })
-      Err.where(:fingerprint => conditions[:fingerprint]).first.should == existing
-      app.find_or_create_err!(conditions).should == existing
+      expect(Err.where(:fingerprint => conditions[:fingerprint]).first).to eq existing
+      expect(app.find_or_create_err!(conditions)).to eq existing
     end
 
     it 'assigns the returned err to the given app' do
-      app.find_or_create_err!(conditions).app.should == app
+      expect(app.find_or_create_err!(conditions).app).to eq app
     end
 
     it 'creates a new problem if a matching one does not already exist' do
-      Err.where(conditions).first.should be_nil
-      lambda {
+      expect(Err.where(conditions).first).to be_nil
+      expect {
         app.find_or_create_err!(conditions)
-      }.should change(Problem,:count).by(1)
+      }.to change(Problem,:count).by(1)
     end
 
     context "without error_class" do
@@ -200,10 +200,10 @@ describe App do
       }
       }
       it 'save the err' do
-        Err.where(conditions).first.should be_nil
-        lambda {
+        expect(Err.where(conditions).first).to be_nil
+        expect {
           app.find_or_create_err!(conditions)
-        }.should change(Problem,:count).by(1)
+        }.to change(Problem,:count).by(1)
       end
     end
   end

--- a/spec/models/backtrace_line_normalizer_spec.rb
+++ b/spec/models/backtrace_line_normalizer_spec.rb
@@ -8,11 +8,11 @@ describe BacktraceLineNormalizer do
       let(:raw_line) { { 'number' => rand(999), 'file' => nil, 'method' => nil } }
 
       it "should replace nil file with [unknown source]" do
-        subject['file'].should == "[unknown source]"
+        expect(subject['file']).to eq "[unknown source]"
       end
 
       it "should replace nil method with [unknown method]" do
-        subject['method'].should == "[unknown method]"
+        expect(subject['method']).to eq "[unknown method]"
       end
     end
 
@@ -20,7 +20,7 @@ describe BacktraceLineNormalizer do
       let(:raw_line) { { 'number' => rand(999), 'file' => "[PROJECT_ROOT]/assets/file.js?body=1", 'method' => nil } }
 
       it "should strip query strings from files" do
-        subject['file'].should == "[PROJECT_ROOT]/assets/file.js"
+        expect(subject['file']).to eq "[PROJECT_ROOT]/assets/file.js"
       end
     end
   end

--- a/spec/models/backtrace_line_spec.rb
+++ b/spec/models/backtrace_line_spec.rb
@@ -6,7 +6,7 @@ describe BacktraceLine do
   describe "root at the start of decorated filename" do
     let(:raw_line) { { 'number' => rand(999), 'file' => '[PROJECT_ROOT]/app/controllers/pages_controller.rb', 'method' => ActiveSupport.methods.shuffle.first.to_s } }
     it "should leave leading root symbol in filepath" do
-      subject.decorated_path.should == 'app/controllers/'
+      expect(subject.decorated_path).to eq 'app/controllers/'
     end
   end
 end

--- a/spec/models/backtrace_spec.rb
+++ b/spec/models/backtrace_spec.rb
@@ -35,7 +35,7 @@ describe Backtrace do
     context "no similar backtrace" do
       before { backtrace.stub(:similar => nil) }
       it "create new backtrace" do
-        described_class.should_receive(:create).with(attributes)
+        expect(described_class).to receive(:create).with(attributes)
 
         described_class.find_or_create(attributes)
       end

--- a/spec/models/comment_observer_spec.rb
+++ b/spec/models/comment_observer_spec.rb
@@ -8,7 +8,7 @@ describe "Callback on Comment" do
       before { comment.stub(:emailable?).and_return(true) }
 
       it 'should send an email notification' do
-        Mailer.should_receive(:comment_notification).
+        expect(Mailer).to receive(:comment_notification).
           with(comment).
           and_return(double('email', :deliver => true))
         comment.save
@@ -19,7 +19,7 @@ describe "Callback on Comment" do
       before { comment.stub(:emailable?).and_return(false) }
 
       it 'should not send an email notification' do
-        Mailer.should_not_receive(:comment_notification)
+        expect(Mailer).to_not receive(:comment_notification)
         comment.save
       end
     end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -4,8 +4,8 @@ describe Comment do
   context 'validations' do
     it 'should require a body' do
       comment = Fabricate.build(:comment, :body => nil)
-      comment.should_not be_valid
-      comment.errors[:body].should include("can't be blank")
+      expect(comment).to_not be_valid
+      expect(comment.errors[:body]).to include("can't be blank")
     end
   end
 
@@ -21,7 +21,7 @@ describe Comment do
     end
 
     it 'includes app notification_recipients except user email' do
-      comment.notification_recipients.should == [watcher.address]
+      expect(comment.notification_recipients).to eq [watcher.address]
     end
   end
 
@@ -37,19 +37,19 @@ describe Comment do
     end
 
     it 'should be true if app is emailable? and there are notification recipients' do
-      comment.emailable?.should be_true
+      expect(comment.emailable?).to be_true
     end
 
     it 'should be false if app is not emailable?' do
       app.update_attribute(:notify_on_errs, false)
-      comment.notification_recipients.should be_any
-      comment.emailable?.should be_false
+      expect(comment.notification_recipients).to be_any
+      expect(comment.emailable?).to be_false
     end
 
     it 'should be false if there are no notification recipients' do
       watcher.destroy
-      app.emailable?.should be_true
-      comment.emailable?.should be_false
+      expect(app.emailable?).to be_true
+      expect(comment.emailable?).to be_false
     end
   end
 end

--- a/spec/models/deploy_observer_spec.rb
+++ b/spec/models/deploy_observer_spec.rb
@@ -4,7 +4,7 @@ describe "Callback on Deploy" do
   context 'when a Deploy is saved' do
     context 'and the app should notify on deploys' do
       it 'should send an email notification' do
-        Mailer.should_receive(:deploy_notification).
+        expect(Mailer).to receive(:deploy_notification).
           and_return(double('email', :deliver => true))
         Fabricate(:deploy, :app => Fabricate(:app_with_watcher, :notify_on_deploys => true))
       end
@@ -12,7 +12,7 @@ describe "Callback on Deploy" do
 
     context 'and the app is not set to notify on deploys' do
       it 'should not send an email notification' do
-        Mailer.should_not_receive(:deploy_notification)
+        expect(Mailer).to_not receive(:deploy_notification)
         Fabricate(:deploy, :app => Fabricate(:app_with_watcher, :notify_on_deploys => false))
       end
     end

--- a/spec/models/deploy_spec.rb
+++ b/spec/models/deploy_spec.rb
@@ -5,14 +5,14 @@ describe Deploy do
   context 'validations' do
     it 'requires a username' do
       deploy = Fabricate.build(:deploy, :username => nil)
-      deploy.should_not be_valid
-      deploy.errors[:username].should include("can't be blank")
+      expect(deploy).to_not be_valid
+      expect(deploy.errors[:username]).to include("can't be blank")
     end
 
     it 'requires an environment' do
       deploy = Fabricate.build(:deploy, :environment => nil)
-      deploy.should_not be_valid
-      deploy.errors[:environment].should include("can't be blank")
+      expect(deploy).to_not be_valid
+      expect(deploy.errors[:environment]).to include("can't be blank")
     end
   end
 
@@ -22,7 +22,7 @@ describe Deploy do
         app = Fabricate(:app, :resolve_errs_on_deploy => false)
         @problems = 3.times.map{Fabricate(:err, :problem => Fabricate(:problem, :resolved => false, :app => app))}
         Fabricate(:deploy, :app => app)
-        app.reload.problems.none?{|problem| problem.resolved?}.should == true
+        expect(app.reload.problems.none?{|problem| problem.resolved?}).to eq true
       end
     end
 
@@ -32,15 +32,15 @@ describe Deploy do
         @prod_errs = 3.times.map{Fabricate(:problem, :resolved => false, :app => app, :environment => 'production')}
         @staging_errs = 3.times.map{Fabricate(:problem, :resolved => false, :app => app, :environment => 'staging')}
         Fabricate(:deploy, :app => app, :environment => 'production')
-        @prod_errs.all?{|problem| problem.reload.resolved?}.should == true
-        @staging_errs.all?{|problem| problem.reload.resolved?}.should == false
+        expect(@prod_errs.all?{|problem| problem.reload.resolved?}).to eq true
+        expect(@staging_errs.all?{|problem| problem.reload.resolved?}).to eq false
       end
     end
 
   end
 
   it "should produce a shortened revision with 7 characters" do
-    Deploy.new(:revision => "1234567890abcdef").short_revision.should == "1234567"
+    expect(Deploy.new(:revision => "1234567890abcdef").short_revision).to eq "1234567"
   end
 end
 

--- a/spec/models/err_spec.rb
+++ b/spec/models/err_spec.rb
@@ -5,14 +5,14 @@ describe Err do
   context 'validations' do
     it 'requires a fingerprint' do
       err = Fabricate.build(:err, :fingerprint => nil)
-      err.should_not be_valid
-      err.errors[:fingerprint].should include("can't be blank")
+      expect(err).to_not be_valid
+      expect(err.errors[:fingerprint]).to include("can't be blank")
     end
 
     it 'requires a problem' do
       err = Fabricate.build(:err, :problem_id => nil, :problem => nil)
-      err.should_not be_valid
-      err.errors[:problem_id].should include("can't be blank")
+      expect(err).to_not be_valid
+      expect(err.errors[:problem_id]).to include("can't be blank")
     end
   end
 

--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -43,7 +43,7 @@ describe ErrorReport do
     describe "#backtrace" do
 
       it 'should have valid backtrace' do
-        error_report.backtrace.should be_valid
+        expect(error_report.backtrace).to be_valid
       end
     end
 
@@ -77,32 +77,32 @@ describe ErrorReport do
         its(:framework) { should == 'Rails: 3.2.11' }
 
         it 'has complete backtrace' do
-          subject.backtrace_lines.size.should == 73
-          subject.backtrace_lines.last['file'].should == '[GEM_ROOT]/bin/rake'
+          expect(subject.backtrace_lines.size).to eq 73
+          expect(subject.backtrace_lines.last['file']).to eq '[GEM_ROOT]/bin/rake'
         end
         it 'has server_environement' do
-          subject.server_environment['environment-name'].should == 'development'
+          expect(subject.server_environment['environment-name']).to eq 'development'
         end
 
         it 'has request' do
-          subject.request['url'].should == 'http://example.org/verify/cupcake=fistfight&lovebird=doomsayer'
-          subject.request['params']['controller'].should == 'application'
+          expect(subject.request['url']).to eq 'http://example.org/verify/cupcake=fistfight&lovebird=doomsayer'
+          expect(subject.request['params']['controller']).to eq 'application'
         end
 
         it 'has notifier' do
-          subject.notifier['name'].should == 'Hoptoad Notifier'
+          expect(subject.notifier['name']).to eq 'Hoptoad Notifier'
         end
 
         it 'get user_attributes' do
-          subject.user_attributes['id'].should == '123'
-          subject.user_attributes['name'].should == 'Mr. Bean'
-          subject.user_attributes['email'].should == 'mr.bean@example.com'
-          subject.user_attributes['username'].should == 'mrbean'
+          expect(subject.user_attributes['id']).to eq '123'
+          expect(subject.user_attributes['name']).to eq 'Mr. Bean'
+          expect(subject.user_attributes['email']).to eq 'mr.bean@example.com'
+          expect(subject.user_attributes['username']).to eq 'mrbean'
         end
         it 'valid env_vars' do
         # XML: <var key="SCRIPT_NAME"/>
-        subject.env_vars.should have_key('SCRIPT_NAME')
-        subject.env_vars['SCRIPT_NAME'].should be_nil # blank ends up nil
+        expect(subject.env_vars).to have_key('SCRIPT_NAME')
+        expect(subject.env_vars['SCRIPT_NAME']).to be_nil # blank ends up nil
 
         # XML representation:
         # <var key="rack.session.options">
@@ -121,14 +121,14 @@ describe ErrorReport do
           'domain'        => nil,
           'id'            => nil
         }
-        subject.env_vars.should have_key('rack_session_options')
-        subject.env_vars['rack_session_options'].should eql(expected)
+        expect(subject.env_vars).to have_key('rack_session_options')
+        expect(subject.env_vars['rack_session_options']).to eql(expected)
       end
       end
 
       it 'save a notice assignes to err' do
         error_report.generate_notice!
-        error_report.notice.err.should be_a(Err)
+        expect(error_report.notice.err).to be_a(Err)
       end
 
       it 'memoize the notice' do
@@ -161,10 +161,10 @@ describe ErrorReport do
         it 'send email' do
           notice = error_report.generate_notice!
           email = ActionMailer::Base.deliveries.last
-          email.to.should include(app.watchers.first.email)
-          email.subject.should include(notice.message.truncate(50))
-          email.subject.should include("[#{app.name}]")
-          email.subject.should include("[#{notice.environment_name}]")
+          expect(email.to).to include(app.watchers.first.email)
+          expect(email.subject).to include(notice.message.truncate(50))
+          expect(email.subject).to include("[#{app.name}]")
+          expect(email.subject).to include("[#{notice.environment_name}]")
         end
       end
 

--- a/spec/models/fingerprint_spec.rb
+++ b/spec/models/fingerprint_spec.rb
@@ -44,7 +44,7 @@ describe Fingerprint do
       end
 
       its 'fingerprints should be equal' do
-        Fingerprint.generate(notice1, 'api key').should eq Fingerprint.generate(notice2, 'api key')
+        expect(Fingerprint.generate(notice1, 'api key')).to eq Fingerprint.generate(notice2, 'api key')
       end
     end
 
@@ -57,7 +57,7 @@ describe Fingerprint do
       end
 
       its 'fingerprints should not be equal' do
-        Fingerprint.generate(notice1, 'api key').should_not eq Fingerprint.generate(notice2, 'api key')
+        expect(Fingerprint.generate(notice1, 'api key')).to_not eq Fingerprint.generate(notice2, 'api key')
       end
     end
   end

--- a/spec/models/issue_trackers/bitbucket_issues_tracker_spec.rb
+++ b/spec/models/issue_trackers/bitbucket_issues_tracker_spec.rb
@@ -32,9 +32,9 @@ EOF
     problem.reload
 
     requested = have_requested(:post, "https://#{tracker.api_token}:#{tracker.project_id}@bitbucket.org/api/1.0/repositories/test_user/test_repo/issues/")
-    WebMock.should requested.with(:title => /[production][foo#bar] FooError: Too Much Bar/)
-    WebMock.should requested.with(:content => /See this exception on Errbit/)
+    expect(WebMock).to requested.with(:title => /[production][foo#bar] FooError: Too Much Bar/)
+    expect(WebMock).to requested.with(:content => /See this exception on Errbit/)
 
-    problem.issue_link.should == @issue_link
+    expect(problem.issue_link).to eq @issue_link
   end
 end

--- a/spec/models/issue_trackers/fogbugz_tracker_spec.rb
+++ b/spec/models/issue_trackers/fogbugz_tracker_spec.rb
@@ -10,14 +10,14 @@ describe IssueTrackers::FogbugzTracker do
     @issue_link = "https://#{tracker.account}.fogbugz.com/default.asp?#{number}"
     response = "<response><token>12345</token><case><ixBug>123</ixBug></case></response>"
     http_mock = double
-    http_mock.should_receive(:new).and_return(http_mock)
-    http_mock.should_receive(:request).twice.and_return(response)
+    expect(http_mock).to receive(:new).and_return(http_mock)
+    expect(http_mock).to receive(:request).twice.and_return(response)
     Fogbugz.adapter[:http] = http_mock
 
     problem.app.issue_tracker.create_issue(problem)
     problem.reload
 
-    problem.issue_link.should == @issue_link
+    expect(problem.issue_link).to eq @issue_link
   end
 end
 

--- a/spec/models/issue_trackers/github_issues_tracker_spec.rb
+++ b/spec/models/issue_trackers/github_issues_tracker_spec.rb
@@ -38,10 +38,10 @@ EOF
     problem.reload
 
     requested = have_requested(:post, "https://#{tracker.username}:#{tracker.password}@api.github.com/repos/#{repo}/issues")
-    WebMock.should requested.with(:body => /[production][foo#bar] FooError: Too Much Bar/)
-    WebMock.should requested.with(:body => /See this exception on Errbit/)
+    expect(WebMock).to requested.with(:body => /[production][foo#bar] FooError: Too Much Bar/)
+    expect(WebMock).to requested.with(:body => /See this exception on Errbit/)
 
-    problem.issue_link.should == @issue_link
+    expect(problem.issue_link).to eq @issue_link
   end
 end
 

--- a/spec/models/issue_trackers/gitlab_issues_tracker_spec.rb
+++ b/spec/models/issue_trackers/gitlab_issues_tracker_spec.rb
@@ -24,8 +24,8 @@ describe IssueTrackers::GitlabTracker do
 
     requested_issue = have_requested(:post, "#{tracker.account}/api/v3/projects/#{tracker.project_id}/issues?private_token=#{tracker.api_token}").with(:body => /.+/, :headers => {'Accept'=>'application/json'})
     requested_note = have_requested(:post, "#{tracker.account}/api/v3/projects/#{tracker.project_id}/issues/#{issue_id}/notes?private_token=#{tracker.api_token}")
-    WebMock.should requested_issue.with(:body => /%5Bproduction%5D%5Bfoo%23bar%5D%20FooError%3A%20Too%20Much%20Bar/)
-    WebMock.should requested_issue.with(:body => /See%20this%20exception%20on%20Errbit/)
+    expect(WebMock).to requested_issue.with(:body => /%5Bproduction%5D%5Bfoo%23bar%5D%20FooError%3A%20Too%20Much%20Bar/)
+    expect(WebMock).to requested_issue.with(:body => /See%20this%20exception%20on%20Errbit/)
 
   end
 end

--- a/spec/models/issue_trackers/lighthouse_tracker_spec.rb
+++ b/spec/models/issue_trackers/lighthouse_tracker_spec.rb
@@ -16,12 +16,12 @@ describe IssueTrackers::LighthouseTracker do
     problem.reload
 
     requested = have_requested(:post, "http://#{tracker.account}.lighthouseapp.com/projects/#{tracker.project_id}/tickets.xml")
-    WebMock.should requested.with(:headers => {'X-Lighthousetoken' => tracker.api_token})
-    WebMock.should requested.with(:body => /<tag>errbit<\/tag>/)
-    WebMock.should requested.with(:body => /<title>\[#{ problem.environment }\]\[#{problem.where}\] #{problem.message.to_s.truncate(100)}<\/title>/)
-    WebMock.should requested.with(:body => /<body>.+<\/body>/m)
+    expect(WebMock).to requested.with(:headers => {'X-Lighthousetoken' => tracker.api_token})
+    expect(WebMock).to requested.with(:body => /<tag>errbit<\/tag>/)
+    expect(WebMock).to requested.with(:body => /<title>\[#{ problem.environment }\]\[#{problem.where}\] #{problem.message.to_s.truncate(100)}<\/title>/)
+    expect(WebMock).to requested.with(:body => /<body>.+<\/body>/m)
 
-    problem.issue_link.should == @issue_link.sub(/\.xml$/, '')
+    expect(problem.issue_link).to eq @issue_link.sub(/\.xml$/, '')
   end
 end
 

--- a/spec/models/issue_trackers/mingle_tracker_spec.rb
+++ b/spec/models/issue_trackers/mingle_tracker_spec.rb
@@ -17,12 +17,12 @@ describe IssueTrackers::MingleTracker do
     problem.reload
 
     requested = have_requested(:post, "#{@basic_auth}/api/v1/projects/#{tracker.project_id}/cards.xml")
-    WebMock.should requested.with(:headers => {'Content-Type' => 'application/xml'})
-    WebMock.should requested.with(:body => /FooError: Too Much Bar/)
-    WebMock.should requested.with(:body => /See this exception on Errbit/)
-    WebMock.should requested.with(:body => /<card-type-name>Defect<\/card-type-name>/)
+    expect(WebMock).to requested.with(:headers => {'Content-Type' => 'application/xml'})
+    expect(WebMock).to requested.with(:body => /FooError: Too Much Bar/)
+    expect(WebMock).to requested.with(:body => /See this exception on Errbit/)
+    expect(WebMock).to requested.with(:body => /<card-type-name>Defect<\/card-type-name>/)
 
-    problem.issue_link.should == @issue_link.sub(/\.xml$/, '')
+    expect(problem.issue_link).to eq @issue_link.sub(/\.xml$/, '')
   end
 end
 

--- a/spec/models/issue_trackers/pivotal_labs_tracker_spec.rb
+++ b/spec/models/issue_trackers/pivotal_labs_tracker_spec.rb
@@ -21,25 +21,26 @@ describe IssueTrackers::PivotalLabsTracker do
     problem.reload
 
     requested = have_requested(:post, "https://www.pivotaltracker.com/services/v3/projects/#{tracker.project_id}/stories")
-    WebMock.should requested.with(:headers => {'X-Trackertoken' => tracker.api_token})
-    WebMock.should requested.with(:body => /See this exception on Errbit/)
-    WebMock.should requested.with(:body => /<name>\[#{ problem.environment }\]\[#{problem.where}\] #{problem.message.to_s.truncate(100)}<\/name>/)
-    WebMock.should requested.with(:body => /<description>.+<\/description>/m)
+    expect(WebMock).to requested.with(:headers => {'X-Trackertoken' => tracker.api_token})
+    expect(WebMock).to requested.with(:body => /See this exception on Errbit/)
+    expect(WebMock).to requested.with(:body => /<name>\[#{ problem.environment }\]\[#{problem.where}\] #{problem.message.to_s.truncate(100)}<\/name>/)
+    expect(WebMock).to requested.with(:body => /<description>.+<\/description>/m)
 
-    problem.issue_link.should == issue_link
+    expect(problem.issue_link).to eq issue_link
   end
 
   it "raises IssueTrackers::IssueTrackerError exception when invalid params and does not set issue link for problem" do
     project_body = "<project><id>#{tracker.project_id}</id><name>TestProject</name></project>"
     stub_request(:get, "https://www.pivotaltracker.com/services/v3/projects/#{tracker.project_id}").
-                 to_return(:status => 200, :body => project_body )
+      to_return(:status => 200, :body => project_body )
     story_body = "<errors><error>Requested by can't be blank</error><error>Requested by can't be blank</error></errors>"
     stub_request(:post, "https://www.pivotaltracker.com/services/v3/projects/#{tracker.project_id}/stories").
                  to_return(:status => 422, :body => story_body )
 
-    lambda { problem.app.issue_tracker.create_issue(problem, user)
-        }.should raise_exception(IssueTrackers::IssueTrackerError, "Requested by can't be blank")
-    problem.issue_link.should be_nil
+    expect{
+            problem.app.issue_tracker.create_issue(problem, user)
+          }.to raise_exception(IssueTrackers::IssueTrackerError, "Requested by can't be blank")
+    expect(problem.issue_link).to be_nil
   end
 end
 

--- a/spec/models/issue_trackers/redmine_tracker_spec.rb
+++ b/spec/models/issue_trackers/redmine_tracker_spec.rb
@@ -19,27 +19,27 @@ describe IssueTrackers::RedmineTracker do
     problem.reload
 
     requested = have_requested(:post, "#{base_url}/issues.xml")
-    WebMock.should requested.with(:headers => {'X-Redmine-API-Key' => tracker.api_token})
-    WebMock.should requested.with(:body => /<project-id>#{tracker.project_id}<\/project-id>/)
-    WebMock.should requested.with(:body => /<subject>\[#{ problem.environment }\]\[#{problem.where}\] #{problem.message.to_s.truncate(100)}<\/subject>/)
-    WebMock.should requested.with(:body => /<description>.+<\/description>/m)
+    expect(WebMock).to requested.with(:headers => {'X-Redmine-API-Key' => tracker.api_token})
+    expect(WebMock).to requested.with(:body => /<project-id>#{tracker.project_id}<\/project-id>/)
+    expect(WebMock).to requested.with(:body => /<subject>\[#{ problem.environment }\]\[#{problem.where}\] #{problem.message.to_s.truncate(100)}<\/subject>/)
+    expect(WebMock).to requested.with(:body => /<description>.+<\/description>/m)
 
-    problem.issue_link.should == @issue_link.sub(/\.xml/, '')
+    expect(problem.issue_link).to eq @issue_link.sub(/\.xml/, '')
   end
 
   it "should generate a url where a file with line number can be viewed" do
     t = Fabricate(:redmine_tracker, :account => 'http://redmine.example.com', :project_id => "errbit")
-    t.url_to_file("/example/file").should ==
-      'http://redmine.example.com/projects/errbit/repository/revisions/master/changes/example/file'
-    t.url_to_file("/example/file", 25).should ==
-      'http://redmine.example.com/projects/errbit/repository/revisions/master/changes/example/file#L25'
+    expect(t.url_to_file("/example/file")).
+      to eq 'http://redmine.example.com/projects/errbit/repository/revisions/master/changes/example/file'
+    expect(t.url_to_file("/example/file", 25)).
+      to eq 'http://redmine.example.com/projects/errbit/repository/revisions/master/changes/example/file#L25'
   end
 
   it "should use the alt_project_id to generate a file/linenumber url, if given" do
     t = Fabricate(:redmine_tracker, :account => 'http://redmine.example.com',
                                   :project_id => "errbit",
                                   :alt_project_id => "actual_project")
-    t.url_to_file("/example/file", 25).should ==
-      'http://redmine.example.com/projects/actual_project/repository/revisions/master/changes/example/file#L25'
+    expect(t.url_to_file("/example/file", 25)).
+      to eq 'http://redmine.example.com/projects/actual_project/repository/revisions/master/changes/example/file#L25'
   end
 end

--- a/spec/models/issue_trackers/unfuddle_issues_tracker_spec.rb
+++ b/spec/models/issue_trackers/unfuddle_issues_tracker_spec.rb
@@ -83,10 +83,10 @@ EOF
     problem.reload
 
     requested = have_requested(:post,"https://#{tracker.username}:#{tracker.password}@test.unfuddle.com/api/v1/projects/#{tracker.project_id}/tickets.xml" )
-    WebMock.should requested.with(:title => /[production][foo#bar] FooError: Too Much Bar/)
-    WebMock.should requested.with(:content => /See this exception on Errbit/)
+    expect(WebMock).to requested.with(:title => /[production][foo#bar] FooError: Too Much Bar/)
+    expect(WebMock).to requested.with(:content => /See this exception on Errbit/)
 
-    problem.issue_link.should == issue_link
-    problem.issue_type.should == IssueTrackers::UnfuddleTracker::Label
+    expect(problem.issue_link).to eq issue_link
+    expect(problem.issue_type).to eq IssueTrackers::UnfuddleTracker::Label
   end
 end

--- a/spec/models/notice_observer_spec.rb
+++ b/spec/models/notice_observer_spec.rb
@@ -17,7 +17,7 @@ describe "Callback on Notice" do
     custom_thresholds.each do |threshold|
       it "sends an email notification after #{threshold} notice(s)" do
         @err.problem.stub(:notices_count).and_return(threshold)
-        Mailer.should_receive(:err_notification).
+        expect(Mailer).to receive(:err_notification).
           and_return(double('email', :deliver => true))
         Fabricate(:notice, :err => @err)
       end
@@ -38,15 +38,15 @@ describe "Callback on Notice" do
 
     it "should send email notification after 1 notice since an error has been resolved" do
       @err.problem.resolve!
-      Mailer.should_receive(:err_notification).
+      expect(Mailer).to receive(:err_notification).
         and_return(double('email', :deliver => true))
       Fabricate(:notice, :err => @err)
     end
     it 'self notify if mailer failed' do
       @err.problem.resolve!
-      Mailer.should_receive(:err_notification).
+      expect(Mailer).to receive(:err_notification).
         and_raise(ArgumentError)
-      HoptoadNotifier.should_receive(:notify)
+      expect(HoptoadNotifier).to receive(:notify)
       Fabricate(:notice, :err => @err)
     end
   end
@@ -65,7 +65,7 @@ describe "Callback on Notice" do
     end
 
     it "should create a campfire notification" do
-      app.notification_service.should_receive(:create_notification)
+      expect(app.notification_service).to receive(:create_notification)
 
       Notice.create!(:err => err, :message => 'FooError: Too Much Bar', :server_environment => {'environment-name' => 'production'},
                      :backtrace => backtrace, :notifier => { 'name' => 'Notifier', 'version' => '1', 'url' => 'http://toad.com' })
@@ -88,8 +88,8 @@ describe "Callback on Notice" do
     end
 
     it "send email" do
-      app.notification_service.should_receive(:create_notification).and_raise(ArgumentError)
-      Mailer.should_receive(:err_notification).and_return(double(:deliver => true))
+      expect(app.notification_service).to receive(:create_notification).and_raise(ArgumentError)
+      expect(Mailer).to receive(:err_notification).and_return(double(:deliver => true))
 
       Notice.create!(:err => err, :message => 'FooError: Too Much Bar', :server_environment => {'environment-name' => 'production'},
                      :backtrace => backtrace, :notifier => { 'name' => 'Notifier', 'version' => '1', 'url' => 'http://toad.com' })
@@ -110,7 +110,7 @@ describe "Callback on Notice" do
     end
 
     it "should not create a campfire notification" do
-      app.notification_service.should_not_receive(:create_notification)
+      expect(app.notification_service).to_not receive(:create_notification)
 
       Notice.create!(:err => err, :message => 'FooError: Too Much Bar', :server_environment => {'environment-name' => 'production'},
                      :backtrace => backtrace, :notifier => { 'name' => 'Notifier', 'version' => '1', 'url' => 'http://toad.com' })
@@ -130,7 +130,7 @@ describe "Callback on Notice" do
     end
 
     it 'creates a hipchat notification' do
-      app.notification_service.should_receive(:create_notification)
+      expect(app.notification_service).to receive(:create_notification)
 
       Fabricate(:notice, :err => err)
     end
@@ -150,7 +150,7 @@ describe "Callback on Notice" do
 
     it "should create a campfire notification on first notice" do
       err = Fabricate(:err, :problem => Fabricate(:problem, :app => app, :notices_count => 1))
-      app.notification_service.should_receive(:create_notification)
+      expect(app.notification_service).to receive(:create_notification)
 
       Notice.create!(:err => err, :message => 'FooError: Too Much Bar', :server_environment => {'environment-name' => 'production'},
                      :backtrace => backtrace, :notifier => { 'name' => 'Notifier', 'version' => '1', 'url' => 'http://toad.com' })
@@ -158,7 +158,7 @@ describe "Callback on Notice" do
 
     it "should create a campfire notification on second notice" do
       err = Fabricate(:err, :problem => Fabricate(:problem, :app => app, :notices_count => 1))
-      app.notification_service.should_receive(:create_notification)
+      expect(app.notification_service).to receive(:create_notification)
 
       Notice.create!(:err => err, :message => 'FooError: Too Much Bar', :server_environment => {'environment-name' => 'production'},
                      :backtrace => backtrace, :notifier => { 'name' => 'Notifier', 'version' => '1', 'url' => 'http://toad.com' })
@@ -166,7 +166,7 @@ describe "Callback on Notice" do
 
     it "should not create a campfire notification on third notice" do
       err = Fabricate(:err, :problem => Fabricate(:problem, :app => app, :notices_count => 1))
-      app.notification_service.should_receive(:create_notification)
+      expect(app.notification_service).to receive(:create_notification)
 
       Notice.create!(:err => err, :message => 'FooError: Too Much Bar', :server_environment => {'environment-name' => 'production'},
                      :backtrace => backtrace, :notifier => { 'name' => 'Notifier', 'version' => '1', 'url' => 'http://toad.com' })

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -4,20 +4,20 @@ describe Notice do
   context 'validations' do
     it 'requires a backtrace' do
       notice = Fabricate.build(:notice, :backtrace => nil)
-      notice.should_not be_valid
-      notice.errors[:backtrace].should include("can't be blank")
+      expect(notice).to_not be_valid
+      expect(notice.errors[:backtrace]).to include("can't be blank")
     end
 
     it 'requires the server_environment' do
       notice = Fabricate.build(:notice, :server_environment => nil)
-      notice.should_not be_valid
-      notice.errors[:server_environment].should include("can't be blank")
+      expect(notice).to_not be_valid
+      expect(notice.errors[:server_environment]).to include("can't be blank")
     end
 
     it 'requires the notifier' do
       notice = Fabricate.build(:notice, :notifier => nil)
-      notice.should_not be_valid
-      notice.errors[:notifier].should include("can't be blank")
+      expect(notice).to_not be_valid
+      expect(notice.errors[:notifier]).to include("can't be blank")
     end
   end
 
@@ -30,7 +30,7 @@ describe Notice do
       it "replaces . with &#46; and $ with &#36; in keys used in #{key}" do
         err = Fabricate(:err)
         notice = Fabricate(:notice, :err => err, key => @hash)
-        notice.send(key).should == @hash_sanitized
+        expect(notice.send(key)).to eq @hash_sanitized
       end
     end
   end
@@ -40,49 +40,49 @@ describe Notice do
       notice = Fabricate.build(:notice, :request => {'cgi-data' => {
         'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_7; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.648.204 Safari/534.16'
       }})
-      notice.user_agent.browser.should == 'Chrome'
-      notice.user_agent.version.to_s.should =~ /^10\.0/
+      expect(notice.user_agent.browser).to eq 'Chrome'
+      expect(notice.user_agent.version.to_s).to match( /^10\.0/ )
     end
 
     it "should be nil if HTTP_USER_AGENT is blank" do
       notice = Fabricate.build(:notice)
-      notice.user_agent.should == nil
+      expect(notice.user_agent).to eq nil
     end
   end
 
   describe "user agent string" do
     it "should be parsed and human-readable" do
       notice = Fabricate.build(:notice, :request => {'cgi-data' => {'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_7; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.648.204 Safari/534.16'}})
-      notice.user_agent_string.should == 'Chrome 10.0.648.204 (OS X 10.6.7)'
+      expect(notice.user_agent_string).to eq 'Chrome 10.0.648.204 (OS X 10.6.7)'
     end
 
     it "should be nil if HTTP_USER_AGENT is blank" do
       notice = Fabricate.build(:notice)
-      notice.user_agent_string.should == "N/A"
+      expect(notice.user_agent_string).to eq "N/A"
     end
   end
 
   describe "host" do
     it "returns host if url is valid" do
       notice = Fabricate.build(:notice, :request => {'url' => "http://example.com/resource/12"})
-      notice.host.should == 'example.com'
+      expect(notice.host).to eq 'example.com'
     end
 
     it "returns 'N/A' when url is not valid" do
       notice = Fabricate.build(:notice, :request => {'url' => "some string"})
-      notice.host.should == 'N/A'
+      expect(notice.host).to eq 'N/A'
     end
 
     it "returns 'N/A' when url is empty" do
       notice = Fabricate.build(:notice, :request => {})
-      notice.host.should == 'N/A'
+      expect(notice.host).to eq 'N/A'
     end
   end
 
   describe "request" do
     it "returns empty hash if not set" do
       notice = Notice.new
-      notice.request.should == {}
+      expect(notice.request).to eq ({})
     end
   end
 end

--- a/spec/models/notification_service/campfire_service_spec.rb
+++ b/spec/models/notification_service/campfire_service_spec.rb
@@ -13,7 +13,7 @@ describe NotificationService::CampfireService do
     campy.stub(:speak) { true }
 
     #assert
-    campy.should_receive(:speak)
+    expect(campy).to receive(:speak)
 
     notification_service.create_notification(problem)
   end

--- a/spec/models/notification_service/flowdock_service_spec.rb
+++ b/spec/models/notification_service/flowdock_service_spec.rb
@@ -7,10 +7,10 @@ describe NotificationServices::FlowdockService do
 
   it 'sends message in appropriate format' do
     Flowdock::Flow.any_instance.should_receive(:push_to_team_inbox) do |*args|
-      args.first[:content].should_not include('<3')
-      args.first[:content].should include('&lt;3')
+      expect(args.first[:content]).to_not include('<3')
+      expect(args.first[:content]).to include('&lt;3')
 
-      args.first[:project].should eq('App3')
+      expect(args.first[:project]).to eq('App3')
     end
     service.create_notification(problem)
   end

--- a/spec/models/notification_service/gtalk_service_spec.rb
+++ b/spec/models/notification_service/gtalk_service_spec.rb
@@ -12,22 +12,22 @@ describe NotificationService::GtalkService do
     gtalk = double('GtalkService')
     jid = double("jid")
     message = double("message")
-    Jabber::JID.should_receive(:new).with(notification_service.subdomain).and_return(jid)
-    Jabber::Client.should_receive(:new).with(jid).and_return(gtalk)
-    gtalk.should_receive(:connect).with(notification_service.service)
-    gtalk.should_receive(:auth).with(notification_service.api_token)
+    expect(Jabber::JID).to receive(:new).with(notification_service.subdomain).and_return(jid)
+    expect(Jabber::Client).to receive(:new).with(jid).and_return(gtalk)
+    expect(gtalk).to receive(:connect).with(notification_service.service)
+    expect(gtalk).to receive(:auth).with(notification_service.api_token)
     message_value = """#{problem.app.name.to_s}
 http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
 #{notification_service.notification_description problem}"""
 
-    Jabber::Message.should_receive(:new).with(notification_service.user_id, message_value).and_return(message)
-    Jabber::Message.should_receive(:new).with(notification_service.room_id, message_value).and_return(message)
+    expect(Jabber::Message).to receive(:new).with(notification_service.user_id, message_value).and_return(message)
+    expect(Jabber::Message).to receive(:new).with(notification_service.room_id, message_value).and_return(message)
 
-    Jabber::MUC::SimpleMUCClient.should_receive(:new).and_return(gtalk)
-    gtalk.should_receive(:join).with(notification_service.room_id + "/errbit")
+    expect(Jabber::MUC::SimpleMUCClient).to receive(:new).and_return(gtalk)
+    expect(gtalk).to receive(:join).with(notification_service.room_id + "/errbit")
 
     #assert
-    gtalk.should_receive(:send).exactly(2).times.with(message)
+    expect(gtalk).to receive(:send).exactly(2).times.with(message)
 
     notification_service.create_notification(problem)
   end
@@ -44,43 +44,43 @@ http://#{Errbit::Config.host}/apps/#{@problem.app.id.to_s}
 
       # gtalk stubbing
       @gtalk = double('GtalkService')
-      @gtalk.should_receive(:connect)
-      @gtalk.should_receive(:auth)
+      expect(@gtalk).to receive(:connect)
+      expect(@gtalk).to receive(:auth)
       jid = double("jid")
       Jabber::JID.stub(:new).with(@notification_service.subdomain).and_return(jid)
       Jabber::Client.stub(:new).with(jid).and_return(@gtalk)
     end
     it "should send a notification to all ',' separated users" do
-      Jabber::Message.should_receive(:new).with("first@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("second@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("third@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("fourth@domain.org", @error_msg)
-      Jabber::MUC::SimpleMUCClient.should_not_receive(:new)
-      @gtalk.should_receive(:send).exactly(4).times
+      expect(Jabber::Message).to receive(:new).with("first@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("second@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("third@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("fourth@domain.org", @error_msg)
+      expect(Jabber::MUC::SimpleMUCClient).to_not receive(:new)
+      expect(@gtalk).to receive(:send).exactly(4).times
 
       @notification_service.user_id = "first@domain.org,second@domain.org, third@domain.org ,   fourth@domain.org  "
       @notification_service.room_id = ""
       @notification_service.create_notification(@problem)
     end
     it "should send a notification to all ';' separated users" do
-      Jabber::Message.should_receive(:new).with("first@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("second@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("third@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("fourth@domain.org", @error_msg)
-      Jabber::MUC::SimpleMUCClient.should_not_receive(:new)
-      @gtalk.should_receive(:send).exactly(4).times
+      expect(Jabber::Message).to receive(:new).with("first@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("second@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("third@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("fourth@domain.org", @error_msg)
+      expect(Jabber::MUC::SimpleMUCClient).to_not receive(:new)
+      expect(@gtalk).to receive(:send).exactly(4).times
 
       @notification_service.user_id = "first@domain.org;second@domain.org; third@domain.org ;   fourth@domain.org  "
       @notification_service.room_id = ""
       @notification_service.create_notification(@problem)
     end
     it "should send a notification to all ' ' separated users" do
-      Jabber::Message.should_receive(:new).with("first@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("second@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("third@domain.org", @error_msg)
-      Jabber::Message.should_receive(:new).with("fourth@domain.org", @error_msg)
-      Jabber::MUC::SimpleMUCClient.should_not_receive(:new)
-      @gtalk.should_receive(:send).exactly(4).times
+      expect(Jabber::Message).to receive(:new).with("first@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("second@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("third@domain.org", @error_msg)
+      expect(Jabber::Message).to receive(:new).with("fourth@domain.org", @error_msg)
+      expect(Jabber::MUC::SimpleMUCClient).to_not receive(:new)
+      expect(@gtalk).to receive(:send).exactly(4).times
 
       @notification_service.user_id = "first@domain.org second@domain.org  third@domain.org     fourth@domain.org  "
       @notification_service.room_id = ""
@@ -100,23 +100,23 @@ http://#{Errbit::Config.host}/apps/#{@problem.app.id.to_s}
     gtalk = double('GtalkService')
     jid = double("jid")
     message = double("message")
-    Jabber::JID.should_receive(:new).with(notification_service.subdomain).and_return(jid)
-    Jabber::Client.should_receive(:new).with(jid).and_return(gtalk)
-    gtalk.should_receive(:connect)
-    gtalk.should_receive(:auth).with(notification_service.api_token)
+    expect(Jabber::JID).to receive(:new).with(notification_service.subdomain).and_return(jid)
+    expect(Jabber::Client).to receive(:new).with(jid).and_return(gtalk)
+    expect(gtalk).to receive(:connect)
+    expect(gtalk).to receive(:auth).with(notification_service.api_token)
     message_value = """#{problem.app.name.to_s}
 http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
 #{notification_service.notification_description problem}"""
 
-    Jabber::Message.should_receive(:new).with(notification_service.room_id, message_value).and_return(message)
+    expect(Jabber::Message).to receive(:new).with(notification_service.room_id, message_value).and_return(message)
 
-    Jabber::MUC::SimpleMUCClient.should_receive(:new).and_return(gtalk)
-    gtalk.should_receive(:join).with(notification_service.room_id + "/errbit")
+    expect(Jabber::MUC::SimpleMUCClient).to receive(:new).and_return(gtalk)
+    expect(gtalk).to receive(:join).with(notification_service.room_id + "/errbit")
 
     notification_service.user_id = ""
 
     #assert
-    gtalk.should_receive(:send).with(message)
+    expect(gtalk).to receive(:send).with(message)
 
     notification_service.create_notification(problem)
   end

--- a/spec/models/notification_service/hipchat_service_spec.rb
+++ b/spec/models/notification_service/hipchat_service_spec.rb
@@ -10,15 +10,15 @@ describe NotificationServices::HipchatService do
   end
 
   it 'sends message' do
-    room.should_receive(:send)
+    expect(room).to receive(:send)
     service.create_notification(problem)
   end
 
   it 'escapes html in message' do
     problem.stub(:message => '<3')
-    room.should_receive(:send) do |_, message|
-      message.should_not include('<3')
-      message.should include('&lt;3')
+    expect(room).to receive(:send) do |_, message|
+      expect(message).to_not include('<3')
+      expect(message).to include('&lt;3')
     end
     service.create_notification(problem)
   end

--- a/spec/models/notification_service/hoiio_service_spec.rb
+++ b/spec/models/notification_service/hoiio_service_spec.rb
@@ -13,7 +13,7 @@ describe NotificationService::HoiioService do
     sms.stub(:send) { true }
 
     #assert
-    sms.should_receive(:send)
+    expect(sms).to receive(:send)
 
     notification_service.create_notification(problem)
   end

--- a/spec/models/notification_service/hubot_service_spec.rb
+++ b/spec/models/notification_service/hubot_service_spec.rb
@@ -8,7 +8,7 @@ describe NotificationService::HubotService do
     problem = notice.problem
 
     # faraday stubbing
-    HTTParty.should_receive(:post).with(notification_service.api_token, :body => {:message => an_instance_of(String), :room => notification_service.room_id}).and_return(true)
+    expect(HTTParty).to receive(:post).with(notification_service.api_token, :body => {:message => an_instance_of(String), :room => notification_service.room_id}).and_return(true)
 
     notification_service.create_notification(problem)
   end

--- a/spec/models/notification_service/pushover_service_spec.rb
+++ b/spec/models/notification_service/pushover_service_spec.rb
@@ -13,7 +13,7 @@ describe NotificationService::PushoverService do
     notification.stub(:notify) { true }
 
     #assert
-    notification.should_receive(:notify)
+    expect(notification).to receive(:notify)
 
     notification_service.create_notification(problem)
   end

--- a/spec/models/notification_service/webhook_service_spec.rb
+++ b/spec/models/notification_service/webhook_service_spec.rb
@@ -6,7 +6,7 @@ describe NotificationService::WebhookService do
     notification_service = Fabricate :webhook_notification_service, :app => notice.app
     problem = notice.problem
     
-    HTTParty.should_receive(:post).with(notification_service.api_token, :body => {:problem => problem.to_json}).and_return(true)
+    expect(HTTParty).to receive(:post).with(notification_service.api_token, :body => {:problem => problem.to_json}).and_return(true)
 
     notification_service.create_notification(problem)
   end

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -5,33 +5,33 @@ describe Problem do
   context 'validations' do
     it 'requires an environment' do
       err = Fabricate.build(:problem, :environment => nil)
-      err.should_not be_valid
-      err.errors[:environment].should include("can't be blank")
+      expect(err).to_not be_valid
+      expect(err.errors[:environment]).to include("can't be blank")
     end
   end
 
   describe "Fabrication" do
     context "Fabricate(:problem)" do
       it 'should have no comment' do
-        lambda do
+        expect{
           Fabricate(:problem)
-        end.should_not change(Comment, :count)
+        }.to_not change(Comment, :count)
       end
     end
 
     context "Fabricate(:problem_with_comments)" do
       it 'should have 3 comments' do
-        lambda do
+        expect{
           Fabricate(:problem_with_comments)
-        end.should change(Comment, :count).by(3)
+        }.to change(Comment, :count).by(3)
       end
     end
 
     context "Fabricate(:problem_with_errs)" do
       it 'should have 3 errs' do
-        lambda do
+        expect{
           Fabricate(:problem_with_errs)
-        end.should change(Err, :count).by(3)
+        }.to change(Err, :count).by(3)
       end
     end
   end
@@ -40,13 +40,13 @@ describe Problem do
     it "returns the created_at timestamp of the latest notice" do
       err = Fabricate(:err)
       problem = err.problem
-      problem.should_not be_nil
+      expect(problem).to_not be_nil
 
       notice1 = Fabricate(:notice, :err => err)
-      problem.last_notice_at.should == notice1.created_at
+      expect(problem.last_notice_at).to eq notice1.created_at
 
       notice2 = Fabricate(:notice, :err => err)
-      problem.last_notice_at.should == notice2.created_at
+      expect(problem.last_notice_at).to eq notice2.created_at
     end
   end
 
@@ -54,7 +54,7 @@ describe Problem do
     it "returns the created_at timestamp of the first notice" do
       err = Fabricate(:err)
       problem = err.problem
-      problem.should_not be_nil
+      expect(problem).to_not be_nil
 
       notice1 = Fabricate(:notice, :err => err)
       expect(problem.first_notice_at.to_i).to be_within(1).of(notice1.created_at.to_i)
@@ -68,9 +68,9 @@ describe Problem do
     it "adding a notice caches its message" do
       err = Fabricate(:err)
       problem = err.problem
-      lambda {
+      expect {
         Fabricate(:notice, :err => err, :message => 'ERR 1')
-      }.should change(problem, :message).from(nil).to('ERR 1')
+      }.to change(problem, :message).from(nil).to('ERR 1')
     end
   end
 
@@ -78,7 +78,7 @@ describe Problem do
     context 'when the app has err notifications set to false' do
       it 'should not send an email notification' do
         app = Fabricate(:app_with_watcher, :notify_on_errs => false)
-        Mailer.should_not_receive(:err_notification)
+        expect(Mailer).to_not receive(:err_notification)
         Fabricate(:problem, :app => app)
       end
     end
@@ -87,24 +87,24 @@ describe Problem do
   context "#resolved?" do
     it "should start out as unresolved" do
       problem = Problem.new
-      problem.should_not be_resolved
-      problem.should be_unresolved
+      expect(problem).to_not be_resolved
+      expect(problem).to be_unresolved
     end
 
     it "should be able to be resolved" do
       problem = Fabricate(:problem)
-      problem.should_not be_resolved
+      expect(problem).to_not be_resolved
       problem.resolve!
-      problem.reload.should be_resolved
+      expect(problem.reload).to be_resolved
     end
   end
 
   context "resolve!" do
     it "marks the problem as resolved" do
       problem = Fabricate(:problem)
-      problem.should_not be_resolved
+      expect(problem).to_not be_resolved
       problem.resolve!
-      problem.should be_resolved
+      expect(problem).to be_resolved
     end
 
     it "should record the time when it was resolved" do
@@ -113,31 +113,31 @@ describe Problem do
       Timecop.freeze(expected_resolved_at) do
         problem.resolve!
       end
-      problem.resolved_at.to_s.should == expected_resolved_at.to_s
+      expect(problem.resolved_at.to_s).to eq expected_resolved_at.to_s
     end
 
     it "should not reset notice count" do
       problem = Fabricate(:problem, :notices_count => 1)
       original_notices_count = problem.notices_count
-      original_notices_count.should > 0
+      expect(original_notices_count).to be > 0
 
       problem.resolve!
-      problem.notices_count.should == original_notices_count
+      expect(problem.notices_count).to eq original_notices_count
     end
 
     it "should throw an err if it's not successful" do
       problem = Fabricate(:problem)
-      problem.should_not be_resolved
+      expect(problem).to_not be_resolved
       problem.stub(:valid?).and_return(false)
       ## update_attributes not test #valid? but #errors.any?
       # https://github.com/mongoid/mongoid/blob/master/lib/mongoid/persistence.rb#L137
       er = ActiveModel::Errors.new(problem)
       er.add_on_blank(:resolved)
       problem.stub(:errors).and_return(er)
-      problem.should_not be_valid
-      lambda {
+      expect(problem).to_not be_valid
+      expect {
         problem.resolve!
-      }.should raise_error(Mongoid::Errors::Validations)
+      }.to raise_error(Mongoid::Errors::Validations)
     end
   end
 
@@ -146,10 +146,10 @@ describe Problem do
       problem1 = Fabricate(:notice).problem
       problem2 = Fabricate(:notice).problem
       merged_problem = Problem.merge!(problem1, problem2)
-      merged_problem.errs.length.should == 2
+      expect(merged_problem.errs.length).to eq 2
 
       expect { merged_problem.unmerge! }.to change(Problem, :count).by(1)
-      merged_problem.errs(true).length.should == 1
+      expect(merged_problem.errs(true).length).to eq 1
     end
 
     it "runs smoothly for problem without errs" do
@@ -162,8 +162,8 @@ describe Problem do
       it 'only finds resolved Problems' do
         resolved = Fabricate(:problem, :resolved => true)
         unresolved = Fabricate(:problem, :resolved => false)
-        Problem.resolved.all.should include(resolved)
-        Problem.resolved.all.should_not include(unresolved)
+        expect(Problem.resolved.all).to include(resolved)
+        expect(Problem.resolved.all).to_not include(unresolved)
       end
     end
 
@@ -171,8 +171,8 @@ describe Problem do
       it 'only finds unresolved Problems' do
         resolved = Fabricate(:problem, :resolved => true)
         unresolved = Fabricate(:problem, :resolved => false)
-        Problem.unresolved.all.should_not include(resolved)
-        Problem.unresolved.all.should include(unresolved)
+        expect(Problem.unresolved.all).to_not include(resolved)
+        expect(Problem.unresolved.all).to include(unresolved)
       end
     end
 
@@ -182,12 +182,12 @@ describe Problem do
                          :message => "other", :where => 'errorclass', :environment => 'development', :app_name => 'other')
         dont_find = Fabricate(:problem, :resolved => false, :error_class => "Batman",
                               :message => 'todo', :where => 'classerror', :environment => 'development', :app_name => 'other')
-        Problem.search("theErrorClass").unresolved.should include(find)
-        Problem.search("theErrorClass").unresolved.should_not include(dont_find)
+        expect(Problem.search("theErrorClass").unresolved).to include(find)
+        expect(Problem.search("theErrorClass").unresolved).to_not include(dont_find)
       end
       it 'find on where message' do
         problem = Fabricate(:problem, :where => 'cyril')
-        Problem.search('cyril').entries.should eq [problem]
+        expect(Problem.search('cyril').entries).to eq [problem]
       end
     end
   end
@@ -200,13 +200,13 @@ describe Problem do
     end
 
     it "#notices_count returns 0 by default" do
-      @problem.notices_count.should == 0
+      expect(@problem.notices_count).to eq 0
     end
 
     it "adding a notice increases #notices_count by 1" do
-      lambda {
+      expect {
         Fabricate(:notice, :err => @err, :message => 'ERR 1')
-      }.should change(@problem.reload, :notices_count).from(0).to(1)
+      }.to change(@problem.reload, :notices_count).from(0).to(1)
     end
 
     it "removing a notice decreases #notices_count by 1" do
@@ -229,10 +229,10 @@ describe Problem do
     end
 
     it "is updated when an app is updated" do
-      lambda {
+      expect {
         app.update_attributes!(:name => "Bar App")
         problem.reload
-      }.should change(problem, :app_name).to("Bar App")
+      }.to change(problem, :app_name).to("Bar App")
     end
   end
 
@@ -251,10 +251,10 @@ describe Problem do
     it "is updated when a deploy is created" do
       problem = Fabricate(:problem, :app => @app, :environment => "production")
       next_deploy = Time.at(5.minutes.ago.localtime.to_i)
-      lambda {
+      expect {
         @deploy = Fabricate(:deploy, :app => @app, :created_at => next_deploy)
         problem.reload
-      }.should change(problem, :last_deploy_at).from(@last_deploy).to(next_deploy)
+      }.to change(problem, :last_deploy_at).from(@last_deploy).to(next_deploy)
     end
   end
 
@@ -266,21 +266,21 @@ describe Problem do
     end
 
     it "#messages should be empty by default" do
-      @problem.messages.should == {}
+      expect(@problem.messages).to eq ({})
     end
 
     it "adding a notice adds a string to #messages" do
-      lambda {
+      expect {
         Fabricate(:notice, :err => @err, :message => 'ERR 1')
-      }.should change(@problem, :messages).from({}).to({Digest::MD5.hexdigest('ERR 1') => {'value' => 'ERR 1', 'count' => 1}})
+      }.to change(@problem, :messages).from({}).to({Digest::MD5.hexdigest('ERR 1') => {'value' => 'ERR 1', 'count' => 1}})
     end
 
     it "removing a notice removes string from #messages" do
       notice1 = Fabricate(:notice, :err => @err, :message => 'ERR 1')
-      lambda {
+      expect {
         @err.notices.first.destroy
         @problem.reload
-      }.should change(@problem, :messages).from({Digest::MD5.hexdigest('ERR 1') => {'value' => 'ERR 1', 'count' => 1}}).to({})
+      }.to change(@problem, :messages).from({Digest::MD5.hexdigest('ERR 1') => {'value' => 'ERR 1', 'count' => 1}}).to({})
     end
 
     it "removing a notice from the problem with broken counter should not raise an error" do
@@ -299,21 +299,21 @@ describe Problem do
     end
 
     it "#hosts should be empty by default" do
-      @problem.hosts.should == {}
+      expect(@problem.hosts).to eq ({})
     end
 
     it "adding a notice adds a string to #hosts" do
-      lambda {
+      expect {
         Fabricate(:notice, :err => @err, :request => {'url' => "http://example.com/resource/12"})
-      }.should change(@problem, :hosts).from({}).to({Digest::MD5.hexdigest('example.com') => {'value' => 'example.com', 'count' => 1}})
+      }.to change(@problem, :hosts).from({}).to({Digest::MD5.hexdigest('example.com') => {'value' => 'example.com', 'count' => 1}})
     end
 
     it "removing a notice removes string from #hosts" do
       notice1 = Fabricate(:notice, :err => @err, :request => {'url' => "http://example.com/resource/12"})
-      lambda {
+      expect {
         @err.notices.first.destroy
         @problem.reload
-      }.should change(@problem, :hosts).from({Digest::MD5.hexdigest('example.com') => {'value' => 'example.com', 'count' => 1}}).to({})
+      }.to change(@problem, :hosts).from({Digest::MD5.hexdigest('example.com') => {'value' => 'example.com', 'count' => 1}}).to({})
     end
   end
 
@@ -325,21 +325,21 @@ describe Problem do
     end
 
     it "#user_agents should be empty by default" do
-      @problem.user_agents.should == {}
+      expect(@problem.user_agents).to eq ({})
     end
 
     it "adding a notice adds a string to #user_agents" do
-      lambda {
+      expect {
         Fabricate(:notice, :err => @err, :request => {'cgi-data' => {'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_7; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.648.204 Safari/534.16'}})
-      }.should change(@problem, :user_agents).from({}).to({Digest::MD5.hexdigest('Chrome 10.0.648.204 (OS X 10.6.7)') => {'value' => 'Chrome 10.0.648.204 (OS X 10.6.7)', 'count' => 1}})
+      }.to change(@problem, :user_agents).from({}).to({Digest::MD5.hexdigest('Chrome 10.0.648.204 (OS X 10.6.7)') => {'value' => 'Chrome 10.0.648.204 (OS X 10.6.7)', 'count' => 1}})
     end
 
     it "removing a notice removes string from #user_agents" do
       notice1 = Fabricate(:notice, :err => @err, :request => {'cgi-data' => {'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_7; en-US) AppleWebKit/534.16 (KHTML, like Gecko) Chrome/10.0.648.204 Safari/534.16'}})
-      lambda {
+      expect {
         @err.notices.first.destroy
         @problem.reload
-      }.should change(@problem, :user_agents).from({
+      }.to change(@problem, :user_agents).from({
         Digest::MD5.hexdigest('Chrome 10.0.648.204 (OS X 10.6.7)') => {'value' => 'Chrome 10.0.648.204 (OS X 10.6.7)', 'count' => 1}
       }).to({})
     end
@@ -352,21 +352,21 @@ describe Problem do
     end
 
     it "#comments_count returns 0 by default" do
-      @problem.comments_count.should == 0
+      expect(@problem.comments_count).to eq 0
     end
 
     it "adding a comment increases #comments_count by 1" do
-      lambda {
+      expect {
         Fabricate(:comment, :err => @problem)
-      }.should change(@problem, :comments_count).from(0).to(1)
+      }.to change(@problem, :comments_count).from(0).to(1)
     end
 
     it "removing a comment decreases #comments_count by 1" do
       comment1 = Fabricate(:comment, :err => @problem)
-      lambda {
+      expect {
         @problem.reload.comments.first.destroy
         @problem.reload
-      }.should change(@problem, :comments_count).from(1).to(0)
+      }.to change(@problem, :comments_count).from(1).to(0)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,38 +5,38 @@ describe User do
   context 'validations' do
     it 'require that a name is present' do
       user = Fabricate.build(:user, :name => nil)
-      user.should_not be_valid
-      user.errors[:name].should include("can't be blank")
+      expect(user).to_not be_valid
+      expect(user.errors[:name]).to include("can't be blank")
     end
 
     it 'requires password without github login' do
       user = Fabricate.build(:user, :password => nil)
-      user.should_not be_valid
-      user.errors[:password].should include("can't be blank")
+      expect(user).to_not be_valid
+      expect(user.errors[:password]).to include("can't be blank")
     end
 
     it "doesn't require password with github login" do
       user = Fabricate.build(:user, :password => nil, :github_login => 'nashby')
-      user.should be_valid
+      expect(user).to be_valid
     end
 
     it 'requires uniq github login' do
       user1 = Fabricate(:user, :github_login => 'nashby')
-      user1.should be_valid
+      expect(user1).to be_valid
 
       user2 = Fabricate.build(:user, :github_login => 'nashby')
       user2.save
-      user2.should_not be_valid
-      user2.errors[:github_login].should include("is already taken")
+      expect(user2).to_not be_valid
+      expect(user2.errors[:github_login]).to include("is already taken")
     end
 
     it 'allows blank / null github_login' do
       user1 = Fabricate(:user, :github_login => ' ')
-      user1.should be_valid
+      expect(user1).to be_valid
 
       user2 = Fabricate.build(:user, :github_login => ' ')
       user2.save
-      user2.should be_valid
+      expect(user2).to be_valid
     end
   end
 
@@ -45,8 +45,8 @@ describe User do
     it 'has many watchers' do
       user = Fabricate(:user)
       watcher = Fabricate(:user_watcher, :user => user)
-      user.watchers.should_not be_empty
-      user.watchers.should include(watcher)
+      expect(user.watchers).to_not be_empty
+      expect(user.watchers).to include(watcher)
     end
 
     it "has many apps through watchers" do
@@ -54,8 +54,8 @@ describe User do
       watched_app  = Fabricate(:app)
       unwatched_app = Fabricate(:app)
       watcher = Fabricate(:user_watcher, :app => watched_app, :user => user)
-      user.apps.all.should include(watched_app)
-      user.apps.all.should_not include(unwatched_app)
+      expect(user.apps.all).to include(watched_app)
+      expect(user.apps.all).to_not include(unwatched_app)
     end
 
   end

--- a/spec/models/watcher_spec.rb
+++ b/spec/models/watcher_spec.rb
@@ -5,18 +5,18 @@ describe Watcher do
   context 'validations' do
     it 'requires an email address or an associated user' do
       watcher = Fabricate.build(:watcher, :email => nil, :user => nil)
-      watcher.should_not be_valid
-      watcher.errors[:base].should include("You must specify either a user or an email address")
+      expect(watcher).to_not be_valid
+      expect(watcher.errors[:base]).to include("You must specify either a user or an email address")
 
       watcher.email = 'watcher@example.com'
-      watcher.should be_valid
+      expect(watcher).to be_valid
 
       watcher.email = nil
-      watcher.should_not be_valid
+      expect(watcher).to_not be_valid
 
       watcher.user = Fabricate(:user)
       watcher.watcher_type = 'user'
-      watcher.should be_valid
+      expect(watcher).to be_valid
     end
   end
 
@@ -24,12 +24,12 @@ describe Watcher do
     it "returns the user's email address if there is a user" do
       user = Fabricate(:user, :email => 'foo@bar.com')
       watcher = Fabricate(:user_watcher, :user => user)
-      watcher.address.should == 'foo@bar.com'
+      expect(watcher.address).to eq 'foo@bar.com'
     end
 
     it "returns the email if there is no user" do
       watcher = Fabricate(:watcher, :email => 'widgets@acme.com')
-      watcher.address.should == 'widgets@acme.com'
+      expect(watcher.address).to eq 'widgets@acme.com'
     end
   end
 

--- a/spec/views/apps/edit.html.haml_spec.rb
+++ b/spec/views/apps/edit.html.haml_spec.rb
@@ -14,7 +14,7 @@ describe "apps/edit.html.haml" do
 
     it "should confirm the 'destroy' link" do
       render
-      action_bar.should have_selector('a.button[data-confirm="%s"]' % I18n.t('apps.confirm_delete'))
+      expect(action_bar).to have_selector('a.button[data-confirm="%s"]' % I18n.t('apps.confirm_delete'))
     end
 
   end
@@ -28,7 +28,7 @@ describe "apps/edit.html.haml" do
 
     it 'see the error' do
       render
-      rendered.should match(/You must specify your/)
+      expect(rendered).to match(/You must specify your/)
     end
   end
 

--- a/spec/views/apps/index.html.haml_spec.rb
+++ b/spec/views/apps/index.html.haml_spec.rb
@@ -10,7 +10,7 @@ describe "apps/index.html.haml" do
   describe "deploy column" do
     it "should show the first 7 characters of the revision in parentheses" do
       render
-      rendered.should match(/\(1234567\)/)
+      expect(rendered).to match(/\(1234567\)/)
     end
   end
 end

--- a/spec/views/apps/new.html.haml_spec.rb
+++ b/spec/views/apps/new.html.haml_spec.rb
@@ -15,7 +15,7 @@ describe "apps/new.html.haml" do
     it "should confirm the 'cancel' link" do
       render
 
-      action_bar.should have_selector('a.button', :text => 'cancel')
+      expect(action_bar).to have_selector('a.button', :text => 'cancel')
     end
 
   end
@@ -29,7 +29,7 @@ describe "apps/new.html.haml" do
 
     it 'see the error' do
       render
-      rendered.should match(/You must specify your/)
+      expect(rendered).to match(/You must specify your/)
     end
   end
 

--- a/spec/views/apps/show.html.haml_spec.rb
+++ b/spec/views/apps/show.html.haml_spec.rb
@@ -20,7 +20,7 @@ describe "apps/show.html.haml" do
     it "should confirm the 'cancel' link" do
       render
 
-      action_bar.should have_selector('a.button', :text => 'all errs')
+      expect(action_bar).to have_selector('a.button', :text => 'all errs')
     end
 
   end
@@ -28,7 +28,7 @@ describe "apps/show.html.haml" do
   context "without errs" do
     it 'see no errs' do
       render
-      rendered.should match(/No errs have been/)
+      expect(rendered).to match(/No errs have been/)
     end
   end
 

--- a/spec/views/notices/_summary.html.haml_spec.rb
+++ b/spec/views/notices/_summary.html.haml_spec.rb
@@ -6,7 +6,7 @@ describe "notices/_summary.html.haml" do
   it "renders application framework" do
     render "notices/summary", :notice => notice, :problem => notice.problem
 
-    rendered.should have_content('Rails 3.2.11')
+    expect(rendered).to have_content('Rails 3.2.11')
   end
 end
 

--- a/spec/views/notices/_user_attributes.html.haml_spec.rb
+++ b/spec/views/notices/_user_attributes.html.haml_spec.rb
@@ -11,7 +11,7 @@ describe "notices/_user_attributes.html.haml" do
       assign :app, notice.err.app
 
       render "notices/user_attributes", :user => notice.user_attributes
-      rendered.should have_link('http://example.com')
+      expect(rendered).to have_link('http://example.com')
     end
   end
 end

--- a/spec/views/problems/index.atom.builder_spec.rb
+++ b/spec/views/problems/index.atom.builder_spec.rb
@@ -8,7 +8,7 @@ describe "problems/index.atom.builder" do
       :message => 'foo',
       :new_record => false, :app => app), Problem.new(:new_record => false, :app => app)])
     render
-    rendered.should match('foo')
+    expect(rendered).to match('foo')
   end
 
 end

--- a/spec/views/problems/index.html.haml_spec.rb
+++ b/spec/views/problems/index.html.haml_spec.rb
@@ -17,7 +17,7 @@ describe "problems/index.html.haml" do
 
     it 'should works' do
       render
-      rendered.should have_selector('div#problem_table.problem_table')
+      expect(rendered).to have_selector('div#problem_table.problem_table')
     end
   end
 

--- a/spec/views/problems/show.html.haml_spec.rb
+++ b/spec/views/problems/show.html.haml_spec.rb
@@ -28,26 +28,26 @@ describe "problems/show.html.haml" do
 
     it "should confirm the 'resolve' link by default" do
       render
-      action_bar.should have_selector('a.resolve[data-confirm="%s"]' % I18n.t('problems.confirm.resolve_one'))
+      expect(action_bar).to have_selector('a.resolve[data-confirm="%s"]' % I18n.t('problems.confirm.resolve_one'))
     end
 
     it "should confirm the 'resolve' link if configuration is unset" do
       Errbit::Config.stub(:confirm_err_actions).and_return(nil)
       render
-      action_bar.should have_selector('a.resolve[data-confirm="%s"]' % I18n.t('problems.confirm.resolve_one'))
+      expect(action_bar).to have_selector('a.resolve[data-confirm="%s"]' % I18n.t('problems.confirm.resolve_one'))
     end
 
     it "should not confirm the 'resolve' link if configured not to" do
       Errbit::Config.stub(:confirm_err_actions).and_return(false)
       render
-      action_bar.should have_selector('a.resolve[data-confirm="null"]')
+      expect(action_bar).to have_selector('a.resolve[data-confirm="null"]')
     end
 
     it "should link 'up' to HTTP_REFERER if is set" do
       url = 'http://localhost:3000/problems'
       controller.request.env['HTTP_REFERER'] = url
       render
-      action_bar.should have_selector("span a.up[href='#{url}']", :text => 'up')
+      expect(action_bar).to have_selector("span a.up[href='#{url}']", :text => 'up')
     end
 
     it "should link 'up' to app_problems_path if HTTP_REFERER isn't set'" do
@@ -57,7 +57,7 @@ describe "problems/show.html.haml" do
       view.stub(:app).and_return(problem.app)
       render
 
-      action_bar.should have_selector("span a.up[href='#{app_problems_path(problem.app)}']", :text => 'up')
+      expect(action_bar).to have_selector("span a.up[href='#{app_problems_path(problem.app)}']", :text => 'up')
     end
 
     context 'create issue links' do
@@ -70,7 +70,7 @@ describe "problems/show.html.haml" do
         view.stub(:app).and_return(problem.app)
         render
 
-        action_bar.should have_selector("span a.github_create.create-issue", :text => 'create issue')
+        expect(action_bar).to have_selector("span a.github_create.create-issue", :text => 'create issue')
       end
 
       it 'should allow creating issue for github if application has a github tracker' do
@@ -80,7 +80,7 @@ describe "problems/show.html.haml" do
         view.stub(:app).and_return(problem.app)
         render
 
-        action_bar.should have_selector("span a.github_create.create-issue", :text => 'create issue')
+        expect(action_bar).to have_selector("span a.github_create.create-issue", :text => 'create issue')
       end
 
       context "without issue tracker associate on app" do
@@ -139,9 +139,9 @@ describe "problems/show.html.haml" do
       view.stub(:app).and_return(problem.app)
       render
 
-      view.content_for(:comments).should include('Test comment')
-      view.content_for(:comments).should have_selector('img[src^="http://www.gravatar.com/avatar"]')
-      view.content_for(:comments).should include('Add a comment')
+      expect(view.content_for(:comments)).to include('Test comment')
+      expect(view.content_for(:comments)).to have_selector('img[src^="http://www.gravatar.com/avatar"]')
+      expect(view.content_for(:comments)).to include('Add a comment')
     end
 
     context "with issue tracker" do
@@ -149,7 +149,7 @@ describe "problems/show.html.haml" do
         problem = Fabricate(:problem)
         with_issue_tracker(PivotalLabsTracker, problem)
         render
-        view.view_flow.get(:comments).should be_blank
+        expect(view.view_flow.get(:comments)).to be_blank
       end
 
       it 'should display existing comments' do
@@ -158,9 +158,9 @@ describe "problems/show.html.haml" do
         with_issue_tracker(PivotalLabsTracker, problem)
         render
 
-        view.content_for(:comments).should include('Test comment')
-        view.content_for(:comments).should have_selector('img[src^="http://www.gravatar.com/avatar"]')
-        view.content_for(:comments).should_not include('Add a comment')
+        expect(view.content_for(:comments)).to include('Test comment')
+        expect(view.content_for(:comments)).to have_selector('img[src^="http://www.gravatar.com/avatar"]')
+        expect(view.content_for(:comments)).to_not include('Add a comment')
       end
     end
   end

--- a/spec/views/users/show.html.haml_spec.rb
+++ b/spec/views/users/show.html.haml_spec.rb
@@ -16,14 +16,14 @@ describe 'users/show.html.haml' do
     it 'shows github login' do
       user.github_login = 'test_user'
       render
-      rendered.should match(/GitHub/)
-      rendered.should match(/test_user/)
+      expect(rendered).to match(/GitHub/)
+      expect(rendered).to match(/test_user/)
     end
 
     it 'does not show github if blank' do
       user.github_login = ' '
       render
-      rendered.should_not match(/GitHub/)
+      expect(rendered).to_not match(/GitHub/)
     end
   end
 
@@ -31,8 +31,8 @@ describe 'users/show.html.haml' do
     context 'viewing another user page' do
       it "doesn't show and github linking buttons if user is not current user" do
         render
-        view.content_for(:action_bar).should_not include('Link GitHub account')
-        view.content_for(:action_bar).should_not include('Unlink GitHub account')
+        expect(view.content_for(:action_bar)).to_not include('Link GitHub account')
+        expect(view.content_for(:action_bar)).to_not include('Unlink GitHub account')
       end
     end
 
@@ -43,7 +43,7 @@ describe 'users/show.html.haml' do
 
       it 'shows link github button when no login or token' do
         render
-        view.content_for(:action_bar).should include('Link GitHub account')
+        expect(view.content_for(:action_bar)).to include('Link GitHub account')
       end
 
       it 'shows unlink github button when login and token' do
@@ -51,12 +51,12 @@ describe 'users/show.html.haml' do
         user.github_oauth_token = 'abcdef'
 
         render
-        view.content_for(:action_bar).should include('Unlink GitHub account')
+        expect(view.content_for(:action_bar)).to include('Unlink GitHub account')
       end
 
       it "should confirm the 'resolve' link by default" do
         render
-        view.content_for(:action_bar).should have_selector('a.delete[data-confirm="%s"]' % I18n.t('.users.confirm_delete'))
+        expect(view.content_for(:action_bar)).to have_selector('a.delete[data-confirm="%s"]' % I18n.t('.users.confirm_delete'))
       end
 
     end


### PR DESCRIPTION
Hi, I'd like to offer this suggestion for changes to the RSpec syntax to use expect consistently throughout the test suite.

I noticed that the rspec 'expect' was now being used in specs such as

spec/interactors/problem_updater_cache_spec.rb
spec/controllers/notices_controller_spec.rb
spec/helpers/problems_helper_spec.rb
spec/models/problem_spec.rb
spec/models/error_report_spec.rb
spec/views/users/new.html.haml_spec.rb

along with many others in over 100 places.  However both these and other specs were also still using the older .should syntax in other places, so this change would make the expect syntax usage consistent throughout the test suite. More than just a style change, it has turned turned out that using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."  I've also noticed that many of the major github gems have already made the move.  It also helps the spec and the error reporting readability be more english-like and in line with this I also changed the '==' operator to 'eq' as recommended in the post.
The only test that required an 'real' change to its test code itself was in spec/controllers/users_controller_spec.rb:24 whereby the change showed UTC not being equal to GMT:00:00:00 UTC.  As both had "UTC", just in different formats, I changed the matcher to be "match".  This seemed to preserve the integrity of the test itself.
All tests pass
