### PR TITLE
Handle App Version Value

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -119,6 +119,12 @@ class Notice
     end
   end
 
+  def app_version
+    if server_environment
+      server_environment['app-version'] || ''
+    end
+  end
+
   protected
 
   def decrease_counter_cache

--- a/app/views/notices/_summary.html.haml
+++ b/app/views/notices/_summary.html.haml
@@ -25,9 +25,14 @@
     %tr
       %th Tenant
       %td= tenant_graph(problem)
-    %tr
-      %th App Server
-      %td= notice.server_environment && notice.server_environment["hostname"]
+    - if notice.server_environment && notice.server_environment["hostname"]
+      %tr
+        %th App Server
+        %td= notice.server_environment && notice.server_environment["hostname"]
+    - if notice.app_version.present?
+      %tr
+        %th App Version
+        %td= notice.app_version
     - if notice.framework
       %tr
         %th Framework

--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -514,6 +514,7 @@ printStackTrace.implementation.prototype = {
             '<server-environment>' +
                 '<project-root>{project_root}</project-root>' +
                 '<environment-name>{environment}</environment-name>' +
+                '<app-version>{appVersion}</app-version>' +
             '</server-environment>' +
             '<current-user>' +
                 '<id>{user_id}</id>' +
@@ -551,10 +552,11 @@ printStackTrace.implementation.prototype = {
 				"url": "{request_url}",
                 "rootDirectory": "{project_root}",
                 "action": "{request_action}",
+                "app-version": "{appVersion}",
 
-				"userId": "{user_id}",
-				"userName": "{user_name}",
-				"userEmail": "{user_email}",
+                "userId": "{user_id}",
+                "userName": "{user_name}",
+                "userEmail": "{user_email}",
             },
             "environment": {},
 			//"session": "",
@@ -859,6 +861,9 @@ printStackTrace.implementation.prototype = {
                     stack: e.stack
                 });
             })
+        }, {
+            variable: 'appVersion',
+            namespace: 'xmlData'
         }
     ];
 


### PR DESCRIPTION
From the Airbrake API docs:

> /notice/server-environment/app-version
> 
> Optional. The version of the application that this error came from. If the App Version is set on the project, then errors older than the project's app version will be ignored. This version field uses Semantic Versioning style versioning.

It'd be cool to have this in Errbit for us using it for mobile apps.
