### PR TITLE
Allow errbit's own port to be configured

### DIFF
--- a/app/models/issue_tracker.rb
+++ b/app/models/issue_tracker.rb
@@ -4,6 +4,7 @@ class IssueTracker
   include HashHelper
   include Rails.application.routes.url_helpers
   default_url_options[:host] = ActionMailer::Base.default_url_options[:host]
+  default_url_options[:port] = ActionMailer::Base.default_url_options[:port]
 
   embedded_in :app, :inverse_of => :issue_tracker
 

--- a/app/models/notification_service.rb
+++ b/app/models/notification_service.rb
@@ -3,6 +3,7 @@ class NotificationService
 
   include Rails.application.routes.url_helpers
   default_url_options[:host] = ActionMailer::Base.default_url_options[:host]
+  default_url_options[:port] = ActionMailer::Base.default_url_options[:port]
 
   field :room_id, :type => String
   field :user_id, :type => String

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -11,6 +11,10 @@
 # The host of your errbit server
 host: errbit.example.com
 
+# The port for your errbit server.
+# Only set this if it isn't the default for the protocol (i.e.. 80 for HTTP, 443 for HTTPS)
+# port: 8080
+
 # Enforce SSL connections
 enforce_ssl: false
 

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -9,6 +9,7 @@ unless defined?(Errbit::Config)
   # If Errbit is running on Heroku, config can be set from environment variables.
   if use_env
     Errbit::Config.host = ENV['ERRBIT_HOST']
+    Errbit::Config.port = ENV['ERRBIT_PORT']
     Errbit::Config.email_from = ENV['ERRBIT_EMAIL_FROM']
     #  Not really easy to use like an env because need an array and ENV return a string :(
     # Errbit::Config.email_at_notices = ENV['ERRBIT_EMAIL_AT_NOTICES']
@@ -78,7 +79,12 @@ end
 
 # Set config specific values
 (ActionMailer::Base.default_url_options ||= {}).tap do |default|
-  default.merge! :host => Errbit::Config.host if default[:host].blank?
+  options_from_config = {
+    host: Errbit::Config.host,
+    port: Errbit::Config.port
+  }.select { |k, v| v }
+
+  default.reverse_merge!(options_from_config)
 end
 
 if Rails.env.production?


### PR DESCRIPTION
This allows errbit to generate correct links in e-mail messages when errbit is served over a non-standard port.
