### PR TITLE
ActionMailer https protocol links

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -15,6 +15,10 @@ host: errbit.example.com
 # Only set this if it isn't the default for the protocol (i.e.. 80 for HTTP, 443 for HTTPS)
 # port: 8080
 
+# The protocol for your errbit server.
+# Only set if not running default HTTP
+# protocol: https
+
 # Enforce SSL connections
 enforce_ssl: false
 

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -81,7 +81,8 @@ end
 (ActionMailer::Base.default_url_options ||= {}).tap do |default|
   options_from_config = {
     host: Errbit::Config.host,
-    port: Errbit::Config.port
+    port: Errbit::Config.port,
+    protocol: Errbit::Config.protocol
   }.select { |k, v| v }
 
   default.reverse_merge!(options_from_config)


### PR DESCRIPTION
I've got a problem that a href in emails sent by errbit didn't include https scheme. That commit resolves that issue
Setting only port to 443 was not enough giving me "400 Bad Request, The plain HTTP request was sent to HTTPS port"
