### PR TITLE
Adding css for resolved problems to make it easy to identify solved prob...

### DIFF
--- a/app/assets/stylesheets/errbit.css
+++ b/app/assets/stylesheets/errbit.css
@@ -173,6 +173,10 @@ a.action  { float: right; font-size: 0.9em;}
   padding: 43px 24px 37px;
 }
 
+#content-title.err_show.resolved{
+  background-color: #90EE90;
+}
+
 #content-comments {
   background-color: #ffffff;
 }

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -1,5 +1,5 @@
 - content_for :page_title, problem.message
-- content_for :title_css_class, 'err_show'
+- content_for :title_css_class, "err_show #{'resolved' if problem.resolved?}"
 - content_for :title, problem.error_class || truncate(problem.message, :length => 32)
 - content_for :meta do
   %strong App:


### PR DESCRIPTION
When I receive an email about a problem, I have problems to easily see if it was resolved or not.

The only thing that mark in the show view if the problem was resolved or not is the "Resolve" button. So I added css to turn the title green if it's resolved.
