### PR TITLE
Fix Redmine repository links

### DIFF
--- a/app/models/issue_trackers/redmine_tracker.rb
+++ b/app/models/issue_trackers/redmine_tracker.rb
@@ -57,7 +57,7 @@ if defined? RedmineClient
     def url_to_file(file_path, line_number = nil)
       # alt_project_id let's users specify a different project for tickets / app files.
       project = self.alt_project_id.present? ? self.alt_project_id : self.project_id
-      url = "#{self.account.gsub(/\/$/, '')}/projects/#{project}/repository/revisions/#{app.repository_branch}/changes/#{file_path.sub(/\[PROJECT_ROOT\]/, '').sub(/^\//,'')}"
+      url = "#{self.account.gsub(/\/$/, '')}/projects/#{project}/repository/revisions/#{app.repository_branch}/entry/#{file_path.sub(/\[PROJECT_ROOT\]/, '').sub(/^\//,'')}"
       line_number ? url << "#L#{line_number}" : url
     end
 

--- a/spec/models/issue_trackers/redmine_tracker_spec.rb
+++ b/spec/models/issue_trackers/redmine_tracker_spec.rb
@@ -30,9 +30,9 @@ describe IssueTrackers::RedmineTracker do
   it "should generate a url where a file with line number can be viewed" do
     t = Fabricate(:redmine_tracker, :account => 'http://redmine.example.com', :project_id => "errbit")
     t.url_to_file("/example/file").should ==
-      'http://redmine.example.com/projects/errbit/repository/revisions/master/changes/example/file'
+      'http://redmine.example.com/projects/errbit/repository/revisions/master/entry/example/file'
     t.url_to_file("/example/file", 25).should ==
-      'http://redmine.example.com/projects/errbit/repository/revisions/master/changes/example/file#L25'
+      'http://redmine.example.com/projects/errbit/repository/revisions/master/entry/example/file#L25'
   end
 
   it "should use the alt_project_id to generate a file/linenumber url, if given" do
@@ -40,6 +40,6 @@ describe IssueTrackers::RedmineTracker do
                                   :project_id => "errbit",
                                   :alt_project_id => "actual_project")
     t.url_to_file("/example/file", 25).should ==
-      'http://redmine.example.com/projects/actual_project/repository/revisions/master/changes/example/file#L25'
+      'http://redmine.example.com/projects/actual_project/repository/revisions/master/entry/example/file#L25'
   end
 end


### PR DESCRIPTION
Previously the link would point to the revisions overview, where the line
number in the url makes no sense. Now it shows the file at the proper line.
One can still switch to the changes from there with one click.
