### PR TITLE
call old onerror when it's already defined

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -1171,13 +1171,16 @@ printStackTrace.implementation.prototype = {
         }
     };
 
+    var oldOnerror = window.onerror;
     window.onerror = function (message, file, line, code, error) {
         setTimeout(function () {
             var e = error || {stack: '()@' + file + ':' + line}
             e.message = message
             new Notifier().notify(e);
         }, 0);
-
+        if (oldOnerror) {
+          return oldOnerror(message, file, line, code, error);
+        }
         return true;
     };
 })();


### PR DESCRIPTION
Previously, errbit overrode window.onerror even when it's already defined.
In most cases, the old window.onerror event should be called, so I added a fix for it.
