### PR TITLE
Applications list is not ordered by problems count

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -12,7 +12,7 @@ class AppsController < ApplicationController
   }
 
   expose(:apps) {
-    app_scope.all.sort.to_a
+    app_scope.all.to_a.sort
   }
 
   expose(:app, :ancestor => :app_scope)

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -33,11 +33,12 @@ describe AppsController do
 
   describe "GET /apps" do
     context 'when logged in as an admin' do
-      it 'finds all apps' do
+      it 'finds all apps sorted by descending unresolved count' do
         sign_in admin
-        unwatched_app && watched_app1 && watched_app2
+        unwatched_app && watched_app1 && watched_app2 && problem
         get :index
-        expect(controller.apps.entries).to eq App.all.sort.entries
+        apps_in_expected_order = App.all.entries.sort_by { |a| -a.unresolved_count }
+        expect(controller.apps.entries).to eq apps_in_expected_order
       end
     end
 


### PR DESCRIPTION
After upgrading to an errbit version using Mongoid v3 we've observed that the applications list does not show up the applications ordered by the number of unresolved problems count. Since we have a considerable number of different applications playing together we were relying heavily on that list being ordered.

The issue comes from Mongoid v3 defining a ``sort`` method on the Criteria class masking the sort method defined in Enumerable, thus the ``<=>`` method is not used when sorting which is the one implementing the sort by unresolved problems count.

This suggested patch reverts only to sorting using the full array of App instances, which is the previous implementation.

Do you think it makes sense to revert to the previous behaviour?