### PR TITLE
Internet Explorer 6 complains about commas

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -556,11 +556,11 @@ printStackTrace.implementation.prototype = {
 
                 "userId": "{user_id}",
                 "userName": "{user_name}",
-                "userEmail": "{user_email}",
+                "userEmail": "{user_email}"
             },
             "environment": {},
 			//"session": "",
-			"params": {},
+			"params": {}
         };
 
     Util = {


### PR DESCRIPTION
Internet Explorer 6 complains and throws errors when you add commas to the end of a list.
