### PR TITLE
Use asset_path helper for images in css.

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -59,7 +59,7 @@ a.action  { float: right; font-size: 0.9em;}
   position: absolute;
   top: 22px;
   left: 2px;
-  background: transparent url(images/logo.png) 0 0 no-repeat;
+  background: transparent url(<%= asset_path 'images/logo.png' %>) 0 0 no-repeat;
   text-indent: -5000em;
 }
 
@@ -94,7 +94,7 @@ a.action  { float: right; font-size: 0.9em;}
   line-height: 30px;
 }
 #header #session-links #sign-out {
-  background: transparent url(images/icons/bullet-red-sm.png) 12px 50% no-repeat;
+  background: transparent url(<%= asset_path "images/icons/bullet-red-sm.png" %>) 12px 50% no-repeat;
   padding-left: 29px;
 }
 #header #session-links a:hover {
@@ -124,7 +124,7 @@ a.action  { float: right; font-size: 0.9em;}
 }
 #nav-bar li.active {
   border-color: #fff;
-  background: #FFF url(images/button-bg.png) 0 -2px repeat-x;
+  background: #FFF url(<%= asset_path "images/button-bg.png" %>) 0 -2px repeat-x;
   border-width:1px 1px 0;
   margin-bottom:-2px;
   height: 37px;
@@ -146,9 +146,9 @@ a.action  { float: right; font-size: 0.9em;}
   background: transparent 10px 6px no-repeat;
 }
 #nav-bar li a:hover { color: #666;}
-#nav-bar li.apps a { background-image: url(images/icons/briefcase.png); }
-#nav-bar li.errs a { background-image: url(images/icons/error.png); }
-#nav-bar li.users a { background-image: url(images/icons/user.png); }
+#nav-bar li.apps a { background-image: url(<%= asset_path "images/icons/briefcase.png" %>); }
+#nav-bar li.errs a { background-image: url(<%= asset_path "images/icons/error.png" %>); }
+#nav-bar li.users a { background-image: url(<%= asset_path "images/icons/user.png" %>); }
 #nav-bar li:not(.active):hover {
   box-shadow: 0 0 3px #69c;
   -moz-box-shadow: 0 0 3px #69c;
@@ -207,7 +207,7 @@ a.action  { float: right; font-size: 0.9em;}
   margin-bottom: 16px;
   text-decoration: none;
   color: #666;
-  background: #FFF url(images/button-bg.png) 0 bottom repeat-x;
+  background: #FFF url(<%= asset_path "images/button-bg.png" %>) 0 bottom repeat-x;
   border-radius: 50px;
   -moz-border-radius: 50px;
   -webkit-border-radius: 50px;
@@ -228,16 +228,16 @@ a.action  { float: right; font-size: 0.9em;}
   -webkit-box-shadow: 0 0 3px #69c;
 }
 #action-bar a.add {
-  background-image: url(images/icons/add.png);
+  background-image: url(<%= asset_path "images/icons/add.png" %>);
 }
 
 #action-bar .calendar_link {
-  background: url(images/icons/ical.png) no-repeat scroll 12px 6px transparent;
+  background: url(<%= asset_path "images/icons/ical.png" %>) no-repeat scroll 12px 6px transparent;
   padding-left: 47px;
 }
 
-#action-bar span.github a { background: url(images/icons/github.png) no-repeat 6px 5px; }
-#action-bar span.unlink_github a { background: url(images/icons/unlink_github.png) no-repeat 6px 5px; }
+#action-bar span.github a { background: url(<%= asset_path "images/icons/github.png" %>) no-repeat 6px 5px; }
+#action-bar span.unlink_github a { background: url(<%= asset_path "images/icons/unlink_github.png" %>) no-repeat 6px 5px; }
 
 /* Content */
 #content {
@@ -272,15 +272,15 @@ a.action  { float: right; font-size: 0.9em;}
   border: 1px solid #6cf;
 }
 #flash-messages li.success {
-  background: #cfc url(images/icons/success.png) 16px 50% no-repeat;
+  background: #cfc url(<%= asset_path "images/icons/success.png" %>) 16px 50% no-repeat;
   border: 1px solid #6c3;
 }
 #flash-messages li.error {
-  background: #fcc url(images/icons/error.png)   16px 50% no-repeat;
+  background: #fcc url(<%= asset_path "images/icons/error.png" %>)   16px 50% no-repeat;
   border: 1px solid #f99;
 }
 #flash-messages .alert {
-  background: #ffc url(images/icons/warning.png) 10px 7px no-repeat;
+  background: #ffc url(<%= asset_path "images/icons/warning.png" %>) 10px 7px no-repeat;
   border-color: #e4bb69;
 }
 
@@ -306,7 +306,7 @@ form label {
 }
 form label.inline { display: inline; }
 form .checkbox label { display: inline; }
-form .required label { padding-right: 20px; background: transparent url(images/icons/required.png) right 50% no-repeat; }
+form .required label { padding-right: 20px; background: transparent url(<%= asset_path "images/icons/required.png" %>) right 50% no-repeat; }
 form .field_with_errors label { color: #900; }
 form input[type=text], form input[type=password], form input[type=email] {
   width: 96%; padding: 0.8em;
@@ -340,7 +340,7 @@ form input[type=submit].button {
 }
 form div.buttons {
   color: #666;
-  background: #FFF url(images/button-bg.png) 0 bottom repeat-x;
+  background: #FFF url(<%= asset_path "images/button-bg.png" %>) 0 bottom repeat-x;
   border-radius: 50px;
   -moz-border-radius: 50px;
   -webkit-border-radius: 50px;
@@ -367,7 +367,7 @@ form div.buttons input, form div.buttons button {
 }
 form div.buttons button.sign_in {
   padding-left: 40px;
-  background: transparent url(images/icons/right-arrow.png) 3px 3px no-repeat;
+  background: transparent url(<%= asset_path "images/icons/right-arrow.png" %>) 3px 3px no-repeat;
 }
 form strong.option {
   display: block;
@@ -621,7 +621,7 @@ td.count, td.issue_link {
   padding: 0.1em 0.7em;
   margin-top: 3px;
   color: #fff;
-  background: #cc0033 url(images/error-badge-bg.png) 0 bottom repeat-x;
+  background: #cc0033 url(<%= asset_path "images/error-badge-bg.png" %>) 0 bottom repeat-x;
   border: 1px solid #900;
   border-radius: 18px;
   -moz-border-radius: 18px;
@@ -632,7 +632,7 @@ td.count, td.issue_link {
   -webkit-opacity: 0.8
 }
 .count a.resolved {
-  background: #05B81d url(images/resolved-badge-bg.png) 0 bottom repeat-x;
+  background: #05B81d url(<%= asset_path "images/resolved-badge-bg.png" %>) 0 bottom repeat-x;
   border: 1px solid #080;
 }
 .count a:hover {
@@ -701,12 +701,12 @@ table.deploys td.when {
 
 /* Resolve Errs */
 #action-bar a.resolve {
-  background: transparent url(images/icons/thumbs-up.png) 6px 5px no-repeat;
+  background: transparent url(<%= asset_path "images/icons/thumbs-up.png" %>) 6px 5px no-repeat;
 }
 
 /* Go Up */
 #action-bar a.up {
-  background: transparent url(images/icons/up.png) 6px 5px no-repeat;
+  background: transparent url(<%= asset_path "images/icons/up.png" %>) 6px 5px no-repeat;
 }
 
 /* Notices Pagination */

--- a/app/assets/stylesheets/issue_tracker_icons.css.erb
+++ b/app/assets/stylesheets/issue_tracker_icons.css.erb
@@ -3,16 +3,16 @@
 
 <% trackers.each do |tracker| %>
 div.issue_tracker.nested label.<%= tracker %> {
-  background: url(<%= tracker %>_inactive.png) no-repeat;
+  background: url(<%= asset_path "#{ tracker }_inactive.png" %>) no-repeat;
 }
 div.issue_tracker.nested label.r_on.<%= tracker %> {
-  background: url(<%= tracker %>_create.png) no-repeat;
+  background: url(<%= asset_path "#{ tracker }_create.png" %>) no-repeat;
 }
 #action-bar a.<%= tracker %>_create {
-   background: transparent url(<%= tracker %>_create.png) 6px 5px no-repeat;
+  background: transparent url(<%= asset_path "#{ tracker }_create.png" %>) 6px 5px no-repeat;
 }
 #action-bar a.<%= tracker %>_goto {
-  background: transparent url(<%= tracker %>_goto.png) 6px 5px no-repeat;
+  background: transparent url(<%= asset_path "#{ tracker }_goto.png" %>) 6px 5px no-repeat;
 }
 <% end %>
 

--- a/app/assets/stylesheets/jquery.alerts.css.erb
+++ b/app/assets/stylesheets/jquery.alerts.css.erb
@@ -17,7 +17,7 @@
 	text-align: center;
 	line-height: 1.75em;
 	color: #666;
-	background: #CCC url(alerts/title.gif) top repeat-x;
+	background: #CCC url(<%= asset_path "alerts/title.gif" %>) top repeat-x;
 	border: solid 1px #FFF;
 	border-bottom: solid 1px #999;
 	cursor: default;
@@ -26,21 +26,21 @@
 }
 
 #popup_content {
-	background: 16px 16px no-repeat url(alerts/info.gif);
+	background: 16px 16px no-repeat url(<%= asset_path "alerts/info.gif" %>);
 	padding: 1em 1.75em;
 	margin: 0em;
 }
 
 #popup_content.alert {
-	background-image: url(alerts/info.gif);
+	background-image: url(<%= asset_path "alerts/info.gif" %>);
 }
 
 #popup_content.confirm {
-	background-image: url(alerts/important.gif);
+	background-image: url(<%= asset_path "alerts/important.gif" %>);
 }
 
 #popup_content.prompt {
-	background-image: url(alerts/help.gif);
+	background-image: url(<%= asset_path "alerts/help.gif" %>);
 }
 
 #popup_message {

--- a/app/assets/stylesheets/notification_service_icons.css.erb
+++ b/app/assets/stylesheets/notification_service_icons.css.erb
@@ -3,16 +3,16 @@
 
 <% notification_services.each do |notification_service| %>
 div.notification_service.nested label.<%= notification_service %> {
-  background: url(<%= notification_service %>_inactive.png) no-repeat;
+  background: url(<%= asset_path "#{ notification_service }_inactive.png" %>) no-repeat;
 }
 div.notification_service.nested label.r_on.<%= notification_service %> {
-  background: url(<%= notification_service %>_create.png) no-repeat;
+  background: url(<%= asset_path "#{ notification_service }_create.png" %>) no-repeat;
 }
 #action-bar a.<%= notification_service %>_create {
-  background: transparent url(<%= notification_service %>_create.png) 6px 5px no-repeat;
+  background: transparent url(<%= asset_path "#{ notification_service }_create.png" %>) 6px 5px no-repeat;
 }
 #action-bar a.<%= notification_service %>_goto {
-  background: transparent url(<%= notification_service %>_goto.png) 6px 5px no-repeat;
+  background: transparent url(<%= asset_path "#{ notification_service }_goto.png" %>) 6px 5px no-repeat;
 }
 <% end %>
 


### PR DESCRIPTION
This means that in a production environment the images will use a digested filename.  We can therefore safely set far-future expires headers for them.
