### PR TITLE
Redmine now includes a optional tracker_id field

### DIFF
--- a/app/models/issue_tracker.rb
+++ b/app/models/issue_tracker.rb
@@ -17,6 +17,7 @@ class IssueTracker
   field :ticket_properties, :type => String
   field :subdomain, :type => String
   field :milestone_id, :type => String
+  field :tracker_id, :type => String
 
   # Is there any better way to enhance the props? Putting them into the subclass leads to
   # an error while rendering the form fields -.-

--- a/spec/models/issue_trackers/redmine_tracker_spec.rb
+++ b/spec/models/issue_trackers/redmine_tracker_spec.rb
@@ -27,6 +27,33 @@ describe IssueTrackers::RedmineTracker do
     expect(problem.issue_link).to eq @issue_link.sub(/\.xml/, '')
   end
 
+  it "should create an issue on Redmine with specific tracker_id, if given" do
+    notice = Fabricate(:notice)
+    tracker = Fabricate(:redmine_tracker, :app => notice.app, :project_id => 10, :tracker_id => 5)
+    problem = notice.problem
+    number = 5
+    @issue_link = "#{tracker.account}/issues/#{number}.xml?project_id=#{tracker.project_id}"
+    body = "<issue><subject>my subject</subject><id>#{number}</id></issue>"
+
+    # Build base url with account URL, and username/password basic auth
+    base_url = tracker.account.gsub 'http://', "http://#{tracker.username}:#{tracker.password}@"
+
+    stub_request(:post, "#{base_url}/issues.xml").
+                 to_return(:status => 201, :headers => {'Location' => @issue_link}, :body => body )
+
+    problem.app.issue_tracker.create_issue(problem)
+    problem.reload
+
+    requested = have_requested(:post, "#{base_url}/issues.xml")
+    expect(WebMock).to requested.with(:headers => {'X-Redmine-API-Key' => tracker.api_token})
+    expect(WebMock).to requested.with(:body => /<project-id>#{tracker.project_id}<\/project-id>/)
+    expect(WebMock).to requested.with(:body => /<subject>\[#{ problem.environment }\]\[#{problem.where}\] #{problem.message.to_s.truncate(100)}<\/subject>/)
+    expect(WebMock).to requested.with(:body => /<description>.+<\/description>/m)
+    expect(WebMock).to requested.with(:body => /<tracker-id>#{tracker.tracker_id}<\/tracker-id>/)
+
+    expect(problem.issue_link).to eq @issue_link.sub(/\.xml/, '')
+  end
+
   it "should generate a url where a file with line number can be viewed" do
     t = Fabricate(:redmine_tracker, :account => 'http://redmine.example.com', :project_id => "errbit")
     expect(t.url_to_file("/example/file")).


### PR DESCRIPTION
By defining a tracker_id, you can make sure that
the ticket will be created with the right "type".

If it is not filled, then it fallbacks to default
which is the first in the priority list that is
available to the project.

this fixes #585
