### PR TITLE
Allow users of a specific GitHub organization to login

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,6 +4,16 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     github_token = env["omniauth.auth"].credentials.token
     github_user  = User.where(:github_login => github_login).first
 
+    if github_user.nil? && Errbit::Config.github_org_id
+      # See if they are a member of the organization that we have access for
+      # If they are, automatically create an account
+      client = client = Octokit::Client.new :access_token => github_token
+      org_ids = client.organizations.map { |org| org.id.to_s }
+      if org_ids.include? Errbit::Config.github_org_id
+        github_user = User.create(name: env["omniauth.auth"].extra.raw_info.name, email: env["omniauth.auth"].extra.raw_info.email)
+      end
+    end
+
     # If user is already signed in, link github details to their account
     if current_user
       # ... unless a user is already registered with same github login

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -24,6 +24,7 @@ unless defined?(Errbit::Config)
     Errbit::Config.github_authentication = ENV['GITHUB_AUTHENTICATION']
     Errbit::Config.github_client_id = ENV['GITHUB_CLIENT_ID']
     Errbit::Config.github_secret = ENV['GITHUB_SECRET']
+    Errbit::Config.github_org_id = ENV['GITHUB_ORG_ID'] if ENV['GITHUB_ORG_ID']
     Errbit::Config.github_access_scope = ENV['GITHUB_ACCESS_SCOPE'].split(',').map(&:strip) if ENV['GITHUB_ACCESS_SCOPE']
 
     Errbit::Config.smtp_settings = {


### PR DESCRIPTION
If `GITHUB_ORG_ID` is set in `ENV`, and someone attempts to login via GitHub without a prior account, one is automatically created for them.  This is both convenient and secure, by not necessitating an administrator to create accounts for every user before they can login.  It also restricts via the organization ID to prevent non-organization members from creating accounts.  After creating their account they can choose to edit their profile to an email different than their GitHub one.

Replacing #642 with this for a single squashed commit.
