### PR TITLE
Support GitHub Enterprise repository links

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -99,7 +99,7 @@ class App
   end
 
   def github_url
-    "https://github.com/#{github_repo}" if github_repo?
+    "#{Errbit::Config.github_url}/#{github_repo}" if github_repo?
   end
 
   def github_url_to_file(file)
@@ -196,8 +196,10 @@ class App
 
     def normalize_github_repo
       return if github_repo.blank?
+      github_host = URI.parse(Errbit::Config.github_url).host
+      github_host = Regexp.escape(github_host)
       github_repo.strip!
-      github_repo.sub!(/(git@|https?:\/\/)github\.com(\/|:)/, '')
+      github_repo.sub!(/(git@|https?:\/\/)#{github_host}(\/|:)/, '')
       github_repo.sub!(/\.git$/, '')
     end
 end

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -98,6 +98,10 @@ github_secret: 'GITHUB_SECRET'
 #   []              - No permission to create issues on any repos.
 github_access_scope: ['repo']
 
+# Change this to point to the URL of your GitHub Enterprise installation, if
+# you want to link local repositories.
+github_url: https://github.com
+
 # Configure SMTP settings. If you are running Errbit on Heroku,
 # sendgrid will be configured by default.
 # ------------------------------------------------------------------------

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -21,6 +21,7 @@ unless defined?(Errbit::Config)
     Errbit::Config.use_gravatar = ENV['ERRBIT_USE_GRAVATAR']
     Errbit::Config.gravatar_default = ENV['ERRBIT_GRAVATAR_DEFAULT']
 
+    Errbit::Config.github_url = ENV['GITHUB_URL']
     Errbit::Config.github_authentication = ENV['GITHUB_AUTHENTICATION']
     Errbit::Config.github_client_id = ENV['GITHUB_CLIENT_ID']
     Errbit::Config.github_secret = ENV['GITHUB_SECRET']
@@ -63,6 +64,10 @@ default_config = YAML.load_file(default_config_file)
 default_config.each do |k,v|
   Errbit::Config.send("#{k}=", v) if Errbit::Config.send(k) === nil
 end
+
+# Make sure the GitHub link doesn't end with a slash, so we don't have to deal
+# with it later on in the code.
+Errbit::Config.github_url.gsub!(/\/*\z/, '')
 
 # Disable GitHub oauth if gem is missing
 Errbit::Config.github_authentication = false unless defined?(OmniAuth::Strategies::GitHub)


### PR DESCRIPTION
Let companies or groups that run their own GitHub Enterprise installs be able to link their own repositories. That's the case with our company and we can't easily link the internal repositories.

I tried to solve that by adding a setting called `github_url`, which can point to the address of the local GitHub install. By default it is `https://github.com` and if that makes it into `0.3.0` it won't fail if you forgot to include it in the config.
