### PR TITLE
scope the type selector to the choose section

### DIFF
--- a/app/assets/javascripts/form.js
+++ b/app/assets/javascripts/form.js
@@ -81,7 +81,7 @@ function activateTypeSelector(field_class, section_class) {
   $('div.'+field_class+' > div.'+section_class).not('.chosen').find('input')
     .attr('disabled','disabled').val('');
 
-  $('div.'+field_class+' input[name*=type]').on('click', function(){
+  $('div.'+field_class).find('.choose input[name*=type]').on('click', function(){
     // Look for section in 'data-section', and fall back to 'value'
     var chosen = $(this).data("section") || $(this).val();
     var wrapper = $(this).closest('.nested');


### PR DESCRIPTION
Formerly if any input in the sub-menus had the substring 'type' in its
name, this event handler would have been bound to clicks on the input
element. When this happens, the variable 'chosen' would generally be an
empty string and that would result in an erroneous jQuery finder:
wrapper.find('div.'+section_class+'.'+chosen) causing an unhandled
error.

It looks like the intent is to bind only to the selectable choice icons,
so that's what this commit does and as a bonus, the embedded forms can
now have an input with the word 'type' in its name.
