### PR TITLE
Upgrade from Octokit 1x to 2x to resolve issues with oauth2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'pivotal-tracker'
 # Fogbugz
 gem 'ruby-fogbugz', :require => 'fogbugz'
 # Github Issues
-gem 'octokit', '~> 1.18'
+gem 'octokit', '~> 2.0'
 # Gitlab
 gem 'gitlab', '~> 3.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     erubis (2.7.0)
     execjs (2.0.2)
     fabrication (2.8.1)
-    faraday (0.8.8)
+    faraday (0.8.9)
       multipart-post (~> 1.2.0)
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
@@ -182,7 +182,7 @@ GEM
       rails (>= 3.2.0)
       railties (>= 3.2.0)
     moped (1.5.1)
-    multi_json (1.8.2)
+    multi_json (1.8.4)
     multi_xml (0.5.5)
     multipart-post (1.2.0)
     net-scp (1.1.2)
@@ -192,7 +192,6 @@ GEM
     net-ssh (2.7.0)
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
-    netrc (0.7.7)
     nokogiri (1.5.10)
     nokogiri-happymapper (0.5.8)
       nokogiri (~> 1.5)
@@ -203,13 +202,8 @@ GEM
       jwt (~> 0.1.4)
       multi_json (~> 1.0)
       rack (~> 1.2)
-    octokit (1.25.0)
-      addressable (~> 2.2)
-      faraday (~> 0.8)
-      faraday_middleware (~> 0.9)
-      hashie (~> 2.0)
-      multi_json (~> 1.3)
-      netrc (~> 0.7.7)
+    octokit (2.7.1)
+      sawyer (~> 0.5.2)
     omniauth (1.1.4)
       hashie (>= 1.2, < 3)
       rack
@@ -311,6 +305,9 @@ GEM
       json
       rest-client
     safe_yaml (0.9.7)
+    sawyer (0.5.3)
+      addressable (~> 2.3.5)
+      faraday (~> 0.8, < 0.10)
     simple_oauth (0.2.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
@@ -403,7 +400,7 @@ DEPENDENCIES
   mongoid
   mongoid-rspec
   mongoid_rails_migrations
-  octokit (~> 1.18)
+  octokit (~> 2.0)
   omniauth-github
   oruen_redmine_client
   pivotal-tracker

--- a/app/models/issue_trackers/github_issues_tracker.rb
+++ b/app/models/issue_trackers/github_issues_tracker.rb
@@ -41,7 +41,7 @@ if defined? Octokit
           body_template.result(binding).unpack('C*').pack('U*')
         )
         problem.update_attributes(
-          :issue_link => issue.html_url,
+          :issue_link => issue.rels[:html].href,
           :issue_type => Label
         )
 


### PR DESCRIPTION
I was having some issues with github and oauth2 when users had 2 factor auth enabled. I wasn't able to track down the exact cause of the errors unfortunately, however I was able to confirm 
- Things work as expected with the new octokit
- that none of the changes to octokit between the older `1.25` and the `2.7.1` affect our use of it

To reproduce the error I was experiencing simply pop a rails console

``` ruby
user_token = "xxxxx" # taken from your user model
Octokit::Client.new(access_token: user_token).organizations
# Octokit::NotFound: GET https://api.github.com/user/orgs: 404: Not Found
```

I have a hunch that it has to do with 2 factor auth but I do not yet have facts to back that up.
