### PR TITLE
delegate tracker url

### DIFF
--- a/app/models/issue_tracker.rb
+++ b/app/models/issue_tracker.rb
@@ -31,4 +31,5 @@ class IssueTracker
   delegate :create_issue, :to => :tracker
   delegate :label, :to => :tracker
   delegate :comments_allowed?, :to => :tracker
+  delegate :url, :to => :tracker
 end


### PR DESCRIPTION
The apps index calls Tracker#url which doesn't exist. It should be
delegated to the underlying tracker instance.
https://github.com/errbit/errbit/blob/features/extract_issue_tracker/app/views/apps/index.html.haml#L40
