### PR TITLE
make the icons appear for available issue trackers

### DIFF
--- a/app/assets/stylesheets/issue_tracker_icons.css.erb
+++ b/app/assets/stylesheets/issue_tracker_icons.css.erb
@@ -1,7 +1,8 @@
 /* Issue Tracker inactive, select, create and goto icons */
-<% trackers = IssueTracker.subclasses.map{|t| t.label } << 'none' %>
+<% trackers = ErrbitPlugin::Register.issue_trackers.values %>
 
-<% trackers.each do |tracker| %>
+<% trackers.each do |tracker_klass| %>
+<% tracker = tracker_klass.new(nil, nil).label %>
 div.issue_tracker.nested label.<%= tracker %> {
   background: url(<%= tracker %>_inactive.png) no-repeat;
 }


### PR DESCRIPTION
This fix is a little ugly because it requires instantiating a bunch of
useless tracker objects since the label can only be attained through an
instance method of the tracker object. It could be made much nicer if
the label were a class method instead.