### PR TITLE
do not use constantize, use more verbose approach

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -102,7 +102,7 @@ class AppsController < ApplicationController
       # set the app's notification service
       if params[:app][:notification_service_attributes] && notification_type = params[:app][:notification_service_attributes][:type]
         available_notification_classes = [NotificationService] + NotificationService.subclasses
-        notification_class = available_notification_classes.detect{|c| c.name == tracker_type}
+        notification_class = available_notification_classes.detect{|c| c.name == notification_type}
         if !notification_class.nil?
           app.notification_service = notification_class.new(params[:app][:notification_service_attributes])
         end


### PR DESCRIPTION
We were doing a small code audit at Shopify when we came across these uses of `constantize`, which is potentially unsafe if not used properly.

Using constantize can lead to arbitrary code execution. Here the tracker_type was properly validated against a list of subclasses, however there are problems with this approach.
- It's not readily apparent to someone reviewing the code that constantize is used correctly.
- Even if the code is reviewed and deemed safe at this time, it would be too easy to break the validation at some time in the future and leave the call to constantize vulnerable.
- The code could too easily be copy/pasted somewhere in a way that would be vulnerable.

So for these reasons I think it's preferable to re-write this code in a way that is undoubtably safe. This PR removes the `constantize` call. The code is functionally identical, but less prone to being inadvertently broken (made vulnerable) at a later time.
