### PR TITLE
Filter cleaner

### DIFF
--- a/app/interactors/filter_cleaner.rb
+++ b/app/interactors/filter_cleaner.rb
@@ -6,11 +6,13 @@ class FilteredProblemClearer
   # Clear all problem already resolved
   #
   def execute(args)
+    puts("Errors returned by the Query:")
     nb_problem_matching(args['query'], args['limit'].to_s).tap { |nb|
       if nb > 0
         criteria(args['query'], args['limit'].to_s).each do |problem|
-          print(problem.printable)
-          if !(args["dry"])
+          puts(problem.printable)
+          if (args["dry"]) != "true"
+            puts("Destroying problem")
             ProblemDestroy.new(problem).execute
           end
         end

--- a/app/interactors/filter_cleaner.rb
+++ b/app/interactors/filter_cleaner.rb
@@ -1,0 +1,35 @@
+require 'problem_destroy'
+
+class FilteredProblemClearer
+
+  ##
+  # Clear all problem already resolved
+  #
+  def execute(args)
+    nb_problem_matching(args['query'], args['limit']).tap { |nb|
+      if nb > 0
+        criteria(args['query'], args['limit']).each do |problem|
+          print(problem.message)
+          if (args["dry"])
+            ProblemDestroy.new(problem).execute
+          end
+        end
+        repair_database
+      end
+    }
+  end
+
+  private
+
+  def nb_problem_matching(query, limit)
+    @count ||= criteria(query, limit).count
+  end
+
+  def criteria(query, limit)
+    @criteria ||= Problem.matching(query).limit(limit)
+  end
+
+  def repair_database
+    Mongoid.default_session.command :repairDatabase => 1
+  end
+end

--- a/app/interactors/filter_cleaner.rb
+++ b/app/interactors/filter_cleaner.rb
@@ -6,11 +6,11 @@ class FilteredProblemClearer
   # Clear all problem already resolved
   #
   def execute(args)
-    nb_problem_matching(args['query'], args['limit']).tap { |nb|
+    nb_problem_matching(args['query'], args['limit'].to_s).tap { |nb|
       if nb > 0
-        criteria(args['query'], args['limit']).each do |problem|
-          print(problem.message)
-          if (args["dry"])
+        criteria(args['query'], args['limit'].to_s).each do |problem|
+          print(problem.printable)
+          if !(args["dry"])
             ProblemDestroy.new(problem).execute
           end
         end

--- a/app/interactors/filter_cleaner.rb
+++ b/app/interactors/filter_cleaner.rb
@@ -7,9 +7,9 @@ class FilteredProblemClearer
   #
   def execute(args)
     puts("Errors returned by the Query:")
-    nb_problem_matching(args['query'], args['limit'].to_s).tap { |nb|
+    nb_problem_matching(args['query'], args['limit'].to_i).tap { |nb|
       if nb > 0
-        criteria(args['query'], args['limit'].to_s).each do |problem|
+        criteria(args['query'], args['limit'].to_i).each do |problem|
           puts(problem.printable)
           if (args["dry"]) != "true"
             puts("Destroying problem")
@@ -24,7 +24,11 @@ class FilteredProblemClearer
   private
 
   def nb_problem_matching(query, limit)
-    @count ||= criteria(query, limit).count
+    matches = criteria(query, limit).count
+    if matches > limit
+      matches = limit
+    end
+    @count ||= matches
   end
 
   def criteria(query, limit)

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -47,6 +47,7 @@ class Problem
   scope :unresolved, where(:resolved => false)
   scope :ordered, order_by(:last_notice_at.desc)
   scope :for_apps, lambda {|apps| where(:app_id.in => apps.all.map(&:id))}
+  scope :matching, lambda {|query| where (:message => /#{query}/i)}
 
   validates_presence_of :last_notice_at, :first_notice_at
 

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -164,7 +164,7 @@ class Problem
   end
 
   def printable
-    return :app_name + "/" + :message
+    return app_name + "/" + message
   end
 
   private

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -47,7 +47,7 @@ class Problem
   scope :unresolved, where(:resolved => false)
   scope :ordered, order_by(:last_notice_at.desc)
   scope :for_apps, lambda {|apps| where(:app_id.in => apps.all.map(&:id))}
-  scope :matching, lambda {|query| where (:message => /#{query}/i)}
+  scope :matching, lambda {|query| where(:message => /#{query}/i)}
 
   validates_presence_of :last_notice_at, :first_notice_at
 
@@ -161,6 +161,10 @@ class Problem
       {:app_name => /#{value}/i},
       {:environment => /#{value}/i}
     )
+  end
+
+  def printable
+    return :app_name + "/" + :message
   end
 
   private

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -29,7 +29,7 @@ namespace :errbit do
     task :clear_filtered, [:query, :limit, :dry] => :environment do |t, args|
       require 'filter_cleaner'
       if !defined? args["dry"]
-        args["dry"] = true
+        args["dry"] = "true"
       end
       if !defined? args["limit"]
         args["limit"] = 100

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -25,6 +25,18 @@ namespace :errbit do
       puts "=== Cleared #{ResolvedProblemClearer.new.execute} resolved errors from the database."
     end
 
+    desc "Delete specific errors from the database. (Useful for limited heroku databases)"
+    task :clear_filtered, [:query, :limit, :dry] => :environment do |t, args|
+      require 'filter_cleaner'
+      if !defined? args["dry"]
+        args["dry"] = true
+      end
+      if !defined? args["limit"]
+        args["limit"] = 100
+      end
+      puts "=== Cleared #{FilteredProblemClearer.new.execute(args)}  matching errors from the database."
+    end
+
     desc "Regenerate fingerprints"
     task :regenerate_fingerprints => :environment do
 

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -34,8 +34,9 @@ namespace :errbit do
       if !defined? args["limit"]
         args["limit"] = 100
       end
+      affected = FilteredProblemClearer.new.execute(args)
       if  args["dry"] != "true"
-        puts "=== Cleared #{FilteredProblemClearer.new.execute(args)}  matching errors from the database."
+        puts "=== Cleared #{affected}  matching errors from the database."
       else
         puts "=== No errors were hurt during the task"
       end

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -34,7 +34,11 @@ namespace :errbit do
       if !defined? args["limit"]
         args["limit"] = 100
       end
-      puts "=== Cleared #{FilteredProblemClearer.new.execute(args)}  matching errors from the database."
+      if  args["dry"] != "true"
+        puts "=== Cleared #{FilteredProblemClearer.new.execute(args)}  matching errors from the database."
+      else
+        puts "=== No errors were hurt during the task"
+      end
     end
 
     desc "Regenerate fingerprints"


### PR DESCRIPTION
A CLI tool to search and delete errors from command line matching a query.
Example:
root@bud-errbit01:/opt/errbit# rake 'errbit:db:clear_filtered[a, 1, false]'
Errors returned by the Query:
Demo App 907422662/FooError: Too Much Bar
Destroying problem
=== Cleared 1  matching errors from the database.
root@bud-errbit01:/opt/errbit# rake 'errbit:db:clear_filtered[a, 1, true]'
Errors returned by the Query:
Demo App 587008510/wrong number of arguments (3 for 0)
=== No errors were hurt during the task
