### PR TITLE
Return app.id in api stats

### DIFF
--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -12,6 +12,7 @@ class Api::V1::StatsController < ApplicationController
 
     stats = {
       :name => @app.name,
+      :id => @app.id,
       :last_error_time => @last_error_time,
       :unresolved_errors => @app.unresolved_count
     }


### PR DESCRIPTION
This allows for example easy linking to the errbit page for an app.
