### PR TITLE
Allow fingerprint generation to be configured

### DIFF
--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -17,6 +17,10 @@ require 'hoptoad_notifier'
 class ErrorReport
   attr_reader :error_class, :message, :request, :server_environment, :api_key, :notifier, :user_attributes, :framework
 
+  cattr_accessor :fingerprint_strategy do
+    Fingerprint
+  end
+
   def initialize(xml_or_attributes)
     @attributes = (xml_or_attributes.is_a?(String) ? Hoptoad.parse_xml!(xml_or_attributes) : xml_or_attributes).with_indifferent_access
     @attributes.each{|k, v| instance_variable_set(:"@#{k}", v) }
@@ -84,7 +88,7 @@ class ErrorReport
   private
 
   def fingerprint
-    @fingerprint ||= Fingerprint.generate(notice, api_key)
+    @fingerprint ||= fingerprint_strategy.generate(notice, api_key)
   end
 
 end

--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -47,6 +47,19 @@ describe ErrorReport do
       end
     end
 
+    describe "#fingerprint_strategy" do
+      after(:all) {
+        error_report.fingerprint_strategy = Fingerprint
+      }
+
+      it "should be possible to change how fingerprints are generated" do
+        strategy = double()
+        strategy.should_receive(:generate){ 'fingerprints' }
+        error_report.fingerprint_strategy = strategy
+        error_report.generate_notice!
+      end
+    end
+
     describe "#generate_notice!" do
       it "save a notice" do
         expect {


### PR DESCRIPTION
Legacy versions of errbit used different strategy for
generating the method signatures for duplicate duplication.

This allows custom signatures to be easily dropped in via
methods such as an initializer.

/cc @arthurnn
