### PR TITLE
ADD allow js client to add filters

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -870,6 +870,12 @@ printStackTrace.implementation.prototype = {
     // Share to global scope as Airbrake ("window.Hoptoad" for backward compatibility)
     Global = window.Airbrake = window.Hoptoad = Util.generatePublicAPI(_publicAPI, Config);
 
+    Global._filters = [];
+
+    Global.addFilter = function (cb) {
+      Global._filters.push(cb);
+    };
+
     function Notifier() {
         this.options = Util.merge({}, Config.options);
         this.xmlData = Util.merge(this.DEF_XML_DATA, Config.xmlData);
@@ -921,7 +927,7 @@ printStackTrace.implementation.prototype = {
             }
             
             return function (error) {
-                var outputData = '',
+                var outputData = '', jsonData,
 					url =  '';
 				    //
                 
@@ -934,9 +940,12 @@ printStackTrace.implementation.prototype = {
 			
                 switch (this.options['outputFormat']) {
                     case 'XML':
-	                   outputData = encodeURIComponent(this.generateXML(this.generateDataJSON(error)));
-					   url = ('https:' == document.location.protocol ? 'https://' : 'http://') + this.options.host + '/notifier_api/v2/notices';
-                        _sendGETRequest(url, outputData);
+                     jsonData = this.generateDataJSON(error);
+                     if (this.shouldSendData(jsonData)){
+                       outputData = encodeURIComponent(this.generateXML(jsonData));
+                       url = ('https:' == document.location.protocol ? 'https://' : 'http://') + this.options.host + '/notifier_api/v2/notices';
+                       _sendGETRequest(url, outputData);
+                     }
 					   break;
 
                     case 'JSON': 
@@ -945,9 +954,12 @@ printStackTrace.implementation.prototype = {
 					*   http://collect.airbrake.io/api/v3/projects/[PROJECT_ID]/notices?key=[API_KEY]
 					* url = window.location.protocol + '://' + this.options.host + '/api/v3/projects' + this.options.projectId + '/notices?key=' + this.options.key;
 					*/
- 						outputData = JSON.stringify(this.generateJSON(this.generateDataJSON(error)));  
-						url = ('https:' == document.location.protocol ? 'https://' : 'http://') + this.options.host + '/api/v3/projects/' + this.options.projectId + '/notices?key=' + this.xmlData.key;
-                        _sendPOSTRequest(url, outputData);
+                        jsonData = this.generateDataJSON(error);
+                        if (this.shouldSendData(jsonData)){
+                          outputData = JSON.stringify(this.generateJSON(jsonData));  
+                          url = ('https:' == document.location.protocol ? 'https://' : 'http://') + this.options.host + '/api/v3/projects/' + this.options.projectId + '/notices?key=' + this.xmlData.key;
+                          _sendPOSTRequest(url, outputData);
+                        }
 						break;
 
                     default:
@@ -1175,6 +1187,18 @@ printStackTrace.implementation.prototype = {
             }
 
             return true;
+        },
+
+        shouldSendData: function (jsonData) {
+          var shouldSend = true, i;
+
+          for ( i = 0; i < Global._filters.length; i++ ) {
+            if ( ! Global._filters[i](jsonData) ){
+              shouldSend = false;
+            }
+          }
+
+          return shouldSend;
         }
     };
 


### PR DESCRIPTION
A new `Airbrake.addFilter( callback )` method has been added.

Before sending any error, notifier.js will try each provided callback,
passing error data as parameter. If any returns false, error won't be
sent to errbit.

This allows users to define fine grain filters for their javascript
exceptions, like filtering out any error on scripts not coming from
their domain :

```
Airbrake.addFilter( function( error ){
  return error.request_url.match( /^https?:\/\/my\.domain\.com\// )
});
```
