### PR TITLE
Add show action to the api v1 for problems

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,11 +42,14 @@
 - [@nashby][]
 - [@shingara][]
 - [@tscolari][]
+- [@callumd][]
+
 
 [@anicet]: https://github.com/anicet
 [@nashby]: https://github.com/nashby
 [@shingara]: https://github.com/shingara
 [@tscolari]: https://github.com/tscolari
+[@callumd]: https://github.com/callumd
 
 ## 0.2.0 - 2013-09-11
 

--- a/app/controllers/api/v1/problems_controller.rb
+++ b/app/controllers/api/v1/problems_controller.rb
@@ -1,6 +1,17 @@
 class Api::V1::ProblemsController < ApplicationController
   respond_to :json, :xml
 
+  def show
+    result = benchmark("[api/v1/problems_controller/show] query time") do
+      Problem.find(params[:id])
+    end
+
+    respond_to do |format|
+      format.any(:html, :json) { render :json => Yajl.dump(result) } # render JSON if no extension specified on path
+      format.xml  { render :xml  => result }
+    end
+  end
+
   def index
     query = {}
     fields = %w{app_id app_name environment message where first_notice_at last_notice_at resolved resolved_at notices_count}
@@ -11,7 +22,7 @@ class Api::V1::ProblemsController < ApplicationController
       query = {:first_notice_at=>{"$lte"=>end_date}, "$or"=>[{:resolved_at=>nil}, {:resolved_at=>{"$gte"=>start_date}}]}
     end
 
-    results = benchmark("[api/v1/problems_controller] query time") do
+    results = benchmark("[api/v1/problems_controller/index] query time") do
       Problem.where(query).with(:consistency => :strong).only(fields).to_a
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Errbit::Application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :problems, :only => [:index], :defaults => { :format => 'json' }
+      resources :problems, :only => [:index, :show], :defaults => { :format => 'json' }
       resources :notices,  :only => [:index], :defaults => { :format => 'json' }
       resources :stats, :only => [], :defaults => { :format => 'json' } do
         collection do

--- a/spec/controllers/api/v1/problems_controller_spec.rb
+++ b/spec/controllers/api/v1/problems_controller_spec.rb
@@ -7,6 +7,23 @@ describe Api::V1::ProblemsController do
       @user = Fabricate(:user)
     end
 
+    describe "GET /api/v1/problems/:id" do
+      before do
+        Fabricate(:problem, :first_notice_at => Date.new(2012, 8, 01), :resolved_at => Date.new(2012, 8, 02))
+      end
+
+      it "returns JSON if JSON is requested" do
+        get :show, :auth_token => @user.authentication_token, :format => "json", :id => Problem.first.id
+        expect { JSON.load(response.body) }.not_to raise_error()#JSON::ParserError)
+      end
+
+      it "returns the correct problem" do
+        requested_problem = Problem.first
+        get :show, :auth_token => @user.authentication_token, :format => "json", :id => requested_problem.id
+        expect( response.body ).to eq(requested_problem.to_json)
+      end
+    end
+
     describe "GET /api/v1/problems" do
       before do
         Fabricate(:problem, :first_notice_at => Date.new(2012, 8, 01), :resolved_at => Date.new(2012, 8, 02))


### PR DESCRIPTION
This allows a problem id to be passed to the problem api and only
information for that problem will be returned.
