### PR TITLE
Allow app to start w/o ERRBIT_EMAIL_FROM

### DIFF
--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -34,7 +34,8 @@ unless defined?(Errbit::Config)
       :authentication => :plain,
       :user_name      => ENV['SMTP_USERNAME']   || ENV['SENDGRID_USERNAME'],
       :password       => ENV['SMTP_PASSWORD']   || ENV['SENDGRID_PASSWORD'],
-      :domain         => ENV['SMTP_DOMAIN'] || ENV['SENDGRID_DOMAIN'] || ENV['ERRBIT_EMAIL_FROM'].split('@').last
+      :domain         => ENV['SMTP_DOMAIN'] || ENV['SENDGRID_DOMAIN'] ||
+                           (ENV['ERRBIT_EMAIL_FROM'] ? ENV['ERRBIT_EMAIL_FROM'].split('@').last : nil)
     }
   end
 


### PR DESCRIPTION
When `USE_ENV` is true, would like to be able to start the app (or execute rake tasks) without having to first provide a value for `ERRBIT_EMAIL_FROM`. If you try to do this now you get a 'NoMethodError: undefined method 'split' for nil:NilClass' error in `_load_config.rb`.

This change simply makes the initializer more tolerant of a missing `ERRBIT_EMAIL_FROM` value.
