### PR TITLE
Adds the ability to ignore duplicate notices

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -15,6 +15,7 @@ class App
   field :notify_on_errs, :type => Boolean, :default => true
   field :notify_on_deploys, :type => Boolean, :default => false
   field :email_at_notices, :type => Array, :default => Errbit::Config.email_at_notices
+  field :ignore_duplicate_notices, :type => Boolean, :default => false
 
   # Some legacy apps may have string as key instead of BSON::ObjectID
   # identity :type => String

--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -53,7 +53,9 @@ class ErrorReport
       :user_attributes => user_attributes,
       :framework => framework
     )
-    error.notices << @notice
+    unless app.ignore_duplicate_notices && error.notices.count > 0
+      error.notices << @notice
+    end
     @notice
   end
   attr_reader :notice

--- a/app/views/apps/_fields.html.haml
+++ b/app/views/apps/_fields.html.haml
@@ -9,6 +9,10 @@
     %label Api Key
     %span= app.api_key
     = link_to t('.regenerate_api_key'), regenerate_api_key_app_path(app), :class => 'button', :method => 'post'
+
+%div.checkbox
+  = f.label :ignore_duplicate_notices
+  = f.check_box :ignore_duplicate_notices
 %div
   = f.label :repository_branch
   = f.text_field :repository_branch, :placeholder => "master"

--- a/db/migrate/20140808164902_add_ignore_duplicate_notices_to_apps.rb
+++ b/db/migrate/20140808164902_add_ignore_duplicate_notices_to_apps.rb
@@ -1,0 +1,6 @@
+class AddIgnoreDuplicateNoticesToApps < Mongoid::Migration
+  def change
+    add_column :apps, :ignore_duplicate_notices, :boolean
+  end
+end
+

--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -61,6 +61,56 @@ describe ErrorReport do
     end
 
     describe "#generate_notice!" do
+      context "when app is flagged as ignore_duplicate_notices" do
+        before do
+          app.ignore_duplicate_notices = true
+          app.save
+        end
+        context "when the notice is for a new error" do
+          before do
+            error_report.generate_notice!
+          end
+
+          it "creates the error and the notice" do
+            expect(error_report.error.notices.count).to eq(1)
+          end
+        end
+        context "when the notice is for an exisiting error" do
+          before do
+            ErrorReport.new(xml).generate_notice!
+            error_report.generate_notice!
+          end
+
+          it "does not create an additional notification on the error" do
+            expect(error_report.error.notices.count).to eq(1)
+          end
+        end
+      end
+      context "when app is not flagged as ignore_duplicate_notices" do
+        before do
+          app.ignore_duplicate_notices = false
+          app.save
+        end
+        context "when the notice is for a new error" do
+          before do
+            error_report.generate_notice!
+          end
+
+          it "creates the error and the notice" do
+            expect(error_report.error.notices.count).to eq(1)
+          end
+        end
+        context "when the notice is for an exisiting error" do
+          before do
+            ErrorReport.new(xml).generate_notice!
+            error_report.generate_notice!
+          end
+
+          it "creates an additional notification on the error" do
+            expect(error_report.error.notices.count).to eq(2)
+          end
+        end
+      end
       it "save a notice" do
         expect {
           error_report.generate_notice!


### PR DESCRIPTION
This PR adds an option on the application edit page which allows apps to
ignore additional notifications on the same error. This is to facilitate
noisy apps that can potentially spam errbit. This will ensure that
whilst all errors are still saved we only write one notice. The default
behaviour will remain the same for existing applications this feature
will need enabled on the applications that wish to use it.
