### PR TITLE
FIX inline comments styles

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -887,6 +887,9 @@ table.errs tr td.message .inline_comment {
   border: 1px solid #E2E2E2;
   text-shadow: 0 1px 0 #FAFAFA;
   font-style: normal;
+  word-wrap: break-word;
+  text-overflow: ellipsis;
+  width: 300px;
 }
 table.errs tr:hover td.message .inline_comment {
   background-color: #D5E0FA;


### PR DESCRIPTION
On error list page, comments with especially long words (typically :
urls) break layout.

![errbit](https://cloud.githubusercontent.com/assets/54562/3902666/ce4bf102-22c1-11e4-9a87-f7021785396b.png)

Fixed it by using the same forced width and wrapping settings than on
error message.