### PR TITLE
Add Github_URL env var to Cloud66 configuration

### DIFF
--- a/config/cloud/cloud66/files/_load_config.rb
+++ b/config/cloud/cloud66/files/_load_config.rb
@@ -17,6 +17,7 @@ unless defined?(Errbit::Config)
     Errbit::Config.use_gravatar = ENV['ERRBIT_USE_GRAVATAR']
     Errbit::Config.gravatar_default = ENV['ERRBIT_GRAVATAR_DEFAULT']
 
+    Errbit::Config.github_url = ENV['GITHUB_URL']
     Errbit::Config.github_authentication = ENV['GITHUB_AUTHENTICATION']
     Errbit::Config.github_client_id = ENV['GITHUB_CLIENT_ID']
     Errbit::Config.github_secret = ENV['GITHUB_SECRET']


### PR DESCRIPTION
## What this does
- This adds the Github URL env var to the cloud66 configuration.
- Without this you cannot add the github url to a cloud66 deploy and adding apps will fail :(
