### PR TITLE
Fix how to deploy to Heroku in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,6 @@ heroku config:add HEROKU=true
 heroku config:add SECRET_TOKEN="$(bundle exec rake secret)"
 heroku config:add ERRBIT_HOST=some-hostname.example.com
 heroku config:add ERRBIT_EMAIL_FROM=example@example.com
-# This next line is required to access env variables during asset compilation.
-# For more info, go to this link: https://devcenter.heroku.com/articles/labs-user-env-compile
-heroku labs:enable user-env-compile
 git push heroku master
 ```
 


### PR DESCRIPTION
`heroku labs:enable user-env-compile` is no longer available,
and the application on Heroku seems to works well without such configuration.
