### PR TITLE
Use config.protocol instead of hardcoded http

### DIFF
--- a/app/models/notification_service.rb
+++ b/app/models/notification_service.rb
@@ -54,6 +54,6 @@ class NotificationService
   end
 
   def problem_url(problem)
-    "http://#{Errbit::Config.host}/apps/#{problem.app.id}/problems/#{problem.id}"
+    "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}/problems/#{problem.id}"
   end
 end

--- a/app/models/notification_services/campfire_service.rb
+++ b/app/models/notification_services/campfire_service.rb
@@ -30,7 +30,7 @@ if defined? Campy
       # build the campfire client
       campy = Campy::Room.new(:account => subdomain, :token => api_token, :room_id => room_id)
       # post the issue to the campfire room
-      campy.speak "[errbit] #{problem.app.name} #{notification_description problem} - http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}/problems/#{problem.id.to_s}"
+      campy.speak "[errbit] #{problem.app.name} #{notification_description problem} - #{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}/problems/#{problem.id.to_s}"
     end
   end
 end

--- a/app/models/notification_services/gtalk_service.rb
+++ b/app/models/notification_services/gtalk_service.rb
@@ -47,7 +47,7 @@ class NotificationServices::GtalkService < NotificationService
 
     #has to look like this to be formatted properly in the client
     message =  """#{problem.app.name.to_s}
-http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
+#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
 #{notification_description problem}"""
 
     # post the issue to the xmpp room(s)

--- a/app/models/notification_services/hoiio_service.rb
+++ b/app/models/notification_services/hoiio_service.rb
@@ -35,7 +35,7 @@ class NotificationServices::HoiioService < NotificationService
 
     # send sms
     room_id.split(',').each do |number|
-      sms.send :dest => number, :msg => "http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s} #{notification_description problem}"
+      sms.send :dest => number, :msg => "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id.to_s} #{notification_description problem}"
     end
 
   end

--- a/app/models/notification_services/pushover_service.rb
+++ b/app/models/notification_services/pushover_service.rb
@@ -26,7 +26,7 @@ class NotificationServices::PushoverService < NotificationService
     notification = Rushover::Client.new(subdomain)
 
     # send push notification to pushover
-    notification.notify(api_token, "#{notification_description problem}", :priority => 1, :title => "Errbit Notification", :url => "http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}", :url_title => "Link to error")
+    notification.notify(api_token, "#{notification_description problem}", :priority => 1, :title => "Errbit Notification", :url => "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}", :url_title => "Link to error")
 
   end
 end

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -6,9 +6,12 @@ unless defined?(Errbit::Config)
   Errbit::Config = OpenStruct.new
   use_env = ENV['HEROKU'] || ENV['USE_ENV']
 
+  Errbit::Config.protocol = 'http'
+
   # If Errbit is running on Heroku, config can be set from environment variables.
   if use_env
     Errbit::Config.host = ENV['ERRBIT_HOST']
+    Errbit::Config.protocol = ENV['ERRBIT_PROTOCOL'] || 'http'
     Errbit::Config.port = ENV['ERRBIT_PORT']
     Errbit::Config.email_from = ENV['ERRBIT_EMAIL_FROM']
     #  Not really easy to use like an env because need an array and ENV return a string :(

--- a/spec/models/notification_service/gtalk_service_spec.rb
+++ b/spec/models/notification_service/gtalk_service_spec.rb
@@ -17,7 +17,7 @@ describe NotificationService::GtalkService do
     expect(gtalk).to receive(:connect).with(notification_service.service)
     expect(gtalk).to receive(:auth).with(notification_service.api_token)
     message_value = """#{problem.app.name.to_s}
-http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
+#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
 #{notification_service.notification_description problem}"""
 
     expect(Jabber::Message).to receive(:new).with(notification_service.user_id, message_value).and_return(message)
@@ -39,7 +39,7 @@ http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
       @notification_service = Fabricate :gtalk_notification_service, :app => @notice.app
       @problem = @notice.problem
       @error_msg = """#{@problem.app.name.to_s}
-http://#{Errbit::Config.host}/apps/#{@problem.app.id.to_s}
+#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{@problem.app.id.to_s}
 #{@notification_service.notification_description @problem}"""
 
       # gtalk stubbing
@@ -105,7 +105,7 @@ http://#{Errbit::Config.host}/apps/#{@problem.app.id.to_s}
     expect(gtalk).to receive(:connect)
     expect(gtalk).to receive(:auth).with(notification_service.api_token)
     message_value = """#{problem.app.name.to_s}
-http://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
+#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id.to_s}
 #{notification_service.notification_description problem}"""
 
     expect(Jabber::Message).to receive(:new).with(notification_service.room_id, message_value).and_return(message)

--- a/spec/models/notification_service/notification_service_spec.rb
+++ b/spec/models/notification_service/notification_service_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe NotificationService do
+
+  let(:notice) { Fabricate :notice }
+  let(:notification_service) { Fabricate :notification_service, :app => notice.app }
+  let(:problem) { notice.problem }
+
+  it "it should use http by default in #problem_url" do
+    notification_service.problem_url(problem).should start_with 'http://'
+  end
+
+  it "it should use the protocol value specified in the config in #problem_url" do
+    Errbit::Config.protocol = 'https'
+    notification_service.problem_url(problem).should start_with 'https://'
+  end
+
+end


### PR DESCRIPTION
We are running errbit using https but we've noticed the `NotificationService#problem_url` uses a hardcoded `http`.

Because errbit already specifies which protocol can be used in the config, I've modified the notification service problem url to use this value.
