### PR TITLE
Fix pivotal tracker integration removing requested_by attribute

### DIFF
--- a/app/models/issue_trackers/pivotal_labs_tracker.rb
+++ b/app/models/issue_trackers/pivotal_labs_tracker.rb
@@ -19,8 +19,7 @@ if defined? PivotalTracker
       PivotalTracker::Client.use_ssl = true
       project = PivotalTracker::Project.find project_id.to_i
       story = project.stories.create :name => issue_title(problem),
-        :story_type => 'bug', :description => body_template.result(binding),
-        :requested_by => reported_by.name
+        :story_type => 'bug', :description => body_template.result(binding)
 
       if story.errors.present?
         raise IssueTrackers::IssueTrackerError, story.errors.first


### PR DESCRIPTION
The "requested by" attribute needs to match username in pivotal tracker (which is often not the case, and seems quite buggy on the pivotal side), and is not mandatory as the request is by default owned by the token api submitted during integration.