### PR TITLE
Update README to add other deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ apt-get update
 apt-get install mongodb-10gen
 ```
 
-  * Install libxml and libcurl
+  * Install libxml, libzip, libssl and libcurl
 
 ```bash
-apt-get install libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev
+apt-get install libxml2 libxml2-dev libxslt-dev libcurl4-openssl-dev libzip-dev libssl-dev
 ```
 
   * Install Bundler


### PR DESCRIPTION
When installing the app from a fresh debian install I noticed that bundler errored out due to it missing these two dependencies.
It's an obvious fix once you hit the error but just popping this here as it's a simple update.
