### PR TITLE
Disable all crawlers by default

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,3 @@
 # See http://www.robotstxt.org/wc/norobots.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-Agent: *
-# Disallow: /
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
I propose this change to defaults because in my opinion vast majority(all?) of Errbit installations don't want their errbit index pages to be indexed by crawlers.
