### PR TITLE
Add date filter for problems/search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,5 +125,6 @@ group :assets do
   gem 'jquery-rails', '~> 2.1.4'
   gem 'pjax_rails'
   gem 'underscore-rails'
+  gem 'pickadate-rails'
   gem 'turbo-sprockets-rails3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
     orm_adapter (0.4.0)
     oruen_redmine_client (0.0.1)
       activeresource (>= 2.3.0)
+    pickadate-rails (3.5.4.0)
+      railties (>= 3.1.0)
     pivotal-tracker (0.5.12)
       builder
       builder
@@ -389,6 +391,7 @@ DEPENDENCIES
   octokit (~> 2.0)
   omniauth-github
   oruen_redmine_client
+  pickadate-rails
   pivotal-tracker
   pjax_rails
   pry-rails

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -1,5 +1,7 @@
 // We can't use jquery > 1.9
 //= require jquery
+//= require pickadate/picker
+//= require pickadate/picker.date
 //= require underscore
 // This rails.js version is not like the original.
 // We can't upgrade to the official version

--- a/app/assets/javascripts/errbit.js
+++ b/app/assets/javascripts/errbit.js
@@ -10,6 +10,8 @@ $(function() {
 
     activateSelectableRows();
 
+    initDateSelects('.date_select');
+
     toggleProblemsCheckboxes();
 
     bindRequiredPasswordMarks();
@@ -68,6 +70,12 @@ $(function() {
 
     $('.panel').hide();
     panel.show();
+  }
+
+  function initDateSelects(element) {
+    $(element).pickadate({
+      format: 'yyyy-mm-dd'
+    });
   }
 
   window.toggleProblemsCheckboxes = function() {

--- a/app/assets/stylesheets/application.css.erb
+++ b/app/assets/stylesheets/application.css.erb
@@ -1,6 +1,8 @@
 /*
  *= require reset
  *= require jquery.alerts
+ *= require pickadate/default
+ *= require pickadate/default.date
  *= require errbit
  *= require issue_tracker_icons
  *= require notification_service_icons

--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -338,6 +338,7 @@ form input[type=submit].button {
   font-size: 1em;
   text-transform: none;
 }
+form input.date_select { width: 30% }
 form div.buttons {
   color: #666;
   background: #FFF url(<%= asset_path "images/button-bg.png" %>) 0 bottom repeat-x;

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -62,6 +62,10 @@ class Problem
     env.present? ? where(:environment => env) : scoped
   end
 
+  def self.first_notice_date
+    order_by(:first_notice_at => :asc).pluck(:first_notice_at).first
+  end
+
   def notices
     Notice.for_errs(errs).ordered
   end
@@ -116,8 +120,11 @@ class Problem
     end
   end
 
-  def self.in_date_range(date_range)
-    where(:first_notice_at.lte => date_range.end).where("$or" => [{:resolved_at => nil}, {:resolved_at.gte => date_range.begin}])
+  def self.noticed_in_date_range(date_range)
+    any_of(
+      self.between(:first_notice_at => date_range).selector,
+      self.between(:last_notice_at => date_range).selector
+    )
   end
 
 

--- a/app/views/problems/_search.html.haml
+++ b/app/views/problems/_search.html.haml
@@ -1,2 +1,8 @@
 = form_tag search_problems_path(:all_errs => all_errs, :app_id => app_id), :method => :get, :remote => true do
+  %p
     = text_field_tag :search, params[:search], :placeholder => t('.search_placeholder')
+  %p
+    = text_field_tag :from, params[:from], "data-value" => Problem.first_notice_date, :class => 'date_select'
+    %span -
+    = text_field_tag :until, params[:until], "data-value" => Date.tomorrow, :class => 'date_select'
+    = submit_tag 'search', :class => 'button'


### PR DESCRIPTION
Added two input fields with a javascript datepicker to problems/search form to filter problems by date range. first_notice_at and last_notice_at are both considered when searching:
- Problem which was first noticed at 2014-01-05 will be found if your search criteria is for example 2014-01-01 until 2014-02-01.
- Problem which was last noticed at 2014-01-05 but first noticed at 2013-12-24 will also be found if your criteria is for example 2014-01-01 until 2014-02-01.

By default the very first notice date of the very first problem is used as the beginning value of the date range. The end value is by default the date of tomorrow. So searching for something but not a date will not lead to wrong results.
