### PR TITLE
therubyracer and libv8 updated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     kgio (2.8.1)
     launchy (2.3.0)
       addressable (~> 2.3)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     libxml-ruby (2.7.0)
     lighthouse-api (2.0)
       activeresource (>= 3.0.0)
@@ -312,7 +312,7 @@ GEM
       railties (~> 3.0)
     term-ansicolor (1.2.2)
       tins (~> 0.8)
-    therubyracer (0.12.0)
+    therubyracer (0.12.1)
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)


### PR DESCRIPTION
Version 3.16.14.3 of libv8 cannot be installed on OS X Yosemite.
But the latest version of libv8 (3.16.14.7) and therubyracer (0.12.1) have no problem

Here's the output:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /Users/andrei/.rvm/rubies/ruby-2.1.4/bin/ruby -r ./siteconf20141111-22639-1mu23ay.rb extconf.rb 
creating Makefile
Compiling v8 for x64
Using python 2.7.6
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Unable to find a compiler officially supported by v8.
It is recommended to use GCC v4.4 or higher
Using compiler: g++
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Unable to find a compiler officially supported by v8.
It is recommended to use GCC v4.4 or higher
../src/cached-powers.cc:136:18: error: unused variable 'kCachedPowersLength' [-Werror,-Wunused-const-variable]
static const int kCachedPowersLength = ARRAY_SIZE(kCachedPowers);
                 ^
1 error generated.
make[1]: *** [/Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/cached-powers.o] Error 1
make: *** [x64.release] Error 2
/Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/ext/libv8/location.rb:36:in `block in verify_installation!': libv8 did not install properly, expected binary v8 archive '/Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/tools/gyp/libv8_base.a'to exist, but it was not found (Libv8::Location::Vendor::ArchiveNotFound)
    from /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/ext/libv8/location.rb:35:in `each'
    from /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/ext/libv8/location.rb:35:in `verify_installation!'
    from /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/ext/libv8/location.rb:26:in `install!'
    from extconf.rb:7:in `<main>'
GYP_GENERATORS=make \
    build/gyp/gyp --generator-output="out" build/all.gyp \
                  -Ibuild/standalone.gypi --depth=. \
                  -Dv8_target_arch=x64 \
                  -S.x64  -Dv8_enable_backtrace=1 -Dv8_can_use_vfp2_instructions=true -Darm_fpu=vfpv2 -Dv8_can_use_vfp3_instructions=true -Darm_fpu=vfpv3
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/allocation.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/atomicops_internals_x86_gcc.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum-dtoa.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3/vendor/v8/out/x64.release/obj.target/preparser_lib/src/cached-powers.o

extconf failed, exit code 1

Gem files will remain installed in /Users/andrei/.rvm/gems/ruby-2.1.4/gems/libv8-3.16.14.3 for inspection.
Results logged to /Users/andrei/.rvm/gems/ruby-2.1.4/extensions/x86_64-darwin-14/2.1.0/libv8-3.16.14.3/gem_make.out
An error occurred while installing libv8 (3.16.14.3), and Bundler cannot
continue.
Make sure that `gem install libv8 -v '3.16.14.3'` succeeds before bundling.
```
