### PR TITLE
Fix URLs in GitHub authentication documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ Authentication
 If you hosted Errbit at errbit.example.com, you would fill in:
 
 <table>
-  <tr><th>URL:</th><td>http://errbit.example.com/</td></tr>
-  <tr><th>Callback URL:</th><td>http://errbit.example.com/users/auth/github</td></tr>
+  <tr><th>URL:</th><td><a href="http://errbit.example.com/">http://errbit.example.com/</a></td></tr>
+  <tr><th>Callback URL:</th><td><a href="http://errbit.example.com/users/auth/github">http://errbit.example.com/users/auth/github</a></td></tr>
 </table>
 
   * After you have registered your app, set `github_client_id` and `github_secret`


### PR DESCRIPTION
The live documentation site currently outputs dirty HTML tags due to bad Markdown parsing: 
![screen shot 2014-11-24 at 7 07 29 pm](https://cloud.githubusercontent.com/assets/2161/5175776/4a689d7a-740d-11e4-9faf-aaf0289632ef.png)

Using raw HTML links inside the `<table>` tags fixes it.
