### PR TITLE
Add rails_12factor gem to prevent Heroku plugin injection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,9 @@ group :heroku, :production do
   gem 'unicorn', :require => false
 end
 
+group :heroku do
+  gem 'rails_12factor'
+end
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -291,9 +291,14 @@ GEM
       activeresource (= 3.2.21)
       activesupport (= 3.2.21)
       bundler (~> 1.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
     rails_autolink (1.1.4)
       rails (> 3.1)
       railties (= 3.2.21)
+    rails_serve_static_assets (0.0.2)
+    rails_stdout_logging (0.0.3)
     railties (3.2.21)
       actionpack (= 3.2.21)
       activesupport (= 3.2.21)
@@ -442,6 +447,7 @@ DEPENDENCIES
   quiet_assets
   rack-ssl
   rack-ssl-enforcer
+  rails_12factor
   rails_autolink
   railties (~> 3.2.21)
   ri_cal


### PR DESCRIPTION
This silences the annoying warnings on Heroku about having Rails 2.3-style plugins. It's only in the heroku group, so it should only be installed when deploying to Heroku.
