### PR TITLE
Modify Slack to use WebHooks and fix HipChat url

### DIFF
--- a/app/models/notification_services/hipchat_service.rb
+++ b/app/models/notification_services/hipchat_service.rb
@@ -22,7 +22,7 @@ if defined? HipChat
     end
 
     def create_notification(problem)
-      url = app_problem_url problem.app, problem
+      url = problem_url(problem)
       message = <<-MSG.strip_heredoc
         <strong>#{ERB::Util.html_escape problem.app.name}</strong> error in <strong>#{ERB::Util.html_escape problem.environment}</strong> at <strong>#{ERB::Util.html_escape problem.where}</strong> (<a href="#{url}">details</a>)<br>
         &nbsp;&nbsp;#{ERB::Util.html_escape problem.message.to_s.truncate(100)}<br>

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -20,7 +20,7 @@ class NotificationServices::SlackService < NotificationService
   end
 
   def slack_escape(str)
-    str.gsub('`','\'')
+    str.to_s.gsub('`','\'')
   end
 
   def message_for_slack(problem)

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -1,32 +1,24 @@
 class NotificationServices::SlackService < NotificationService
   Label = "slack"
   Fields += [
-    [:subdomain, {
-      :placeholder => 'subdomain',
-      :label => 'Subdomain portion for Slack service'
-    }],
-    [:api_token, {
-      :placeholder => 'Slack Integration Token',
+    [:webhook_url, {
+      :placeholder => 'Slack Webhook URL',
       :label => 'Token'
-    }],
-    [:room_id, {
-      :placeholder => '#general',
-      :label => 'Room where Slack should notify'
     }]
   ]
 
   def check_params
-    if Fields.detect {|f| self[f[0]].blank? unless f[0] == :room_id }
-      errors.add :base, "You must specify your Slack subdomain and token."
+    if Fields.detect {|f| self[f[0]].blank? }
+      errors.add :base, "You must specify your Slack webhook url."
     end
   end
 
   def url
-    "https://#{subdomain}.slack.com/services/hooks/incoming-webhook?token=#{api_token}"
+    webhook_url
   end
 
   def message_for_slack(problem)
-    "[#{problem.app.name}][#{problem.environment}][#{problem.where}]: #{problem.error_class} #{problem_url(problem)}"
+    "*#{problem.app.name}* (#{problem.environment}) - *#{problem.where}*: `#{problem.error_class}: #{problem.message}` - #{problem.notices_count}) times, <#{problem_url(problem)}|view details>"
   end
 
   def post_payload(problem)


### PR DESCRIPTION
This is a breaking change, but it seems it's the right way to integrate with slack for this.. 

Using the WebHooks it means people can customize the name used to post as well as the icon. This also creates a much simpler setup, and one that looks to be supported. The current setup sort of works, but it seems to be using an old deprecated url format in Slack, and it seems to be using their API key for a WebHook call. I suspect things were setup different @ slack when this code was written!

I also dramatically improved the display of the message that gets sent, and fixed the problem_url for HipChat (currently if you set the protocol to https, the HipChat notification ignores it and you get http links anyway.)
