### PR TITLE
Fix gemfile for Rails 4 assets.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,13 +104,11 @@ end
 
 # Gems used only for assets and not required
 # in production environments by default.
-group :assets do
-  gem 'execjs'
-  gem 'therubyracer', :platform => :ruby  # C Ruby (MRI) or Rubinius, but NOT Windows
-  gem 'uglifier',     '>= 1.0.3'
-  # We can't upgrade because not compatible to jquery >= 1.9.
-  # To do that, we need fix the rails.js
-  gem 'jquery-rails', '~> 2.1.4'
-  gem 'pjax_rails'
-  gem 'underscore-rails'
-end
+gem 'execjs'
+gem 'therubyracer', :platform => :ruby  # C Ruby (MRI) or Rubinius, but NOT Windows
+gem 'uglifier',     '>= 1.0.3'
+# We can't upgrade because not compatible to jquery >= 1.9.
+# To do that, we need fix the rails.js
+gem 'jquery-rails', '~> 2.1.4'
+gem 'pjax_rails'
+gem 'underscore-rails'


### PR DESCRIPTION
Assets won't compile correctly on Heroku with jQuery not found. This is because of Rails 4 removing the assets group from the Gemfile (see this commit https://github.com/rails/rails/commit/49c4af43ec5819d8f5c1a91f9b84296c927ce6e7). This fixes it.
