### PR TITLE
Just leave github issue tracker as default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,15 +28,7 @@ gem 'hoptoad_notifier', "~> 2.4"
 gem 'draper', :require => false
 
 gem 'errbit_plugin'
-gem 'errbit_bitbucket_plugin'
-gem 'errbit_fogbugz_plugin'
 gem 'errbit_github_plugin'
-gem 'errbit_gitlab_plugin'
-gem 'errbit_jira_plugin'
-gem 'errbit_lighthouse_plugin'
-gem 'errbit_pivotal_plugin'
-gem 'errbit_redmine_plugin'
-gem 'errbit_unfuddle_plugin'
 
 # Notification services
 # ---------------------------------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,6 @@ GEM
       activesupport (= 4.0.12)
       arel (~> 4.0.0)
     activerecord-deprecated_finders (1.0.3)
-    activeresource (4.0.0)
-      activemodel (~> 4.0)
-      activesupport (~> 4.0)
-      rails-observers (~> 0.1.1)
     activesupport (4.0.12)
       i18n (~> 0.6, >= 0.6.9)
       minitest (~> 4.2)
@@ -44,13 +40,6 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bitbucket_rest_api (0.1.5)
-      faraday (~> 0.8.1)
-      faraday_middleware (~> 0.9.0)
-      hashie (~> 2.0.5)
-      multi_json (~> 1.3)
-      nokogiri (>= 1.5.2)
-      simple_oauth
     bson (2.3.0)
     builder (3.1.4)
     callsite (0.0.11)
@@ -99,53 +88,23 @@ GEM
     email_spec (1.5.0)
       launchy (~> 2.1)
       mail (~> 2.2)
-    errbit_bitbucket_plugin (0.1.0)
-      bitbucket_rest_api
-      errbit_plugin
-      faraday (~> 0.8.1)
-    errbit_fogbugz_plugin (0.1.0)
-      errbit_plugin (~> 0.4, >= 0.4.0)
-      ruby-fogbugz (~> 0.1, >= 0.1)
     errbit_github_plugin (0.1.0)
       errbit_plugin
       octokit
-    errbit_gitlab_plugin (0.1.0)
-      errbit_plugin (~> 0.4, >= 0.4.0)
-      gitlab (~> 3.0.0, >= 3.0.0)
-    errbit_jira_plugin (0.2.0)
-      errbit_plugin
-      jira-ruby
-    errbit_lighthouse_plugin (0.1.0)
-      errbit_plugin (~> 0)
-      lighthouse-api (~> 2)
-    errbit_pivotal_plugin (0.2.0)
-      errbit_plugin (~> 0.4, >= 0.4.0)
-      pivotal-tracker (~> 0.5, >= 0.5.0)
     errbit_plugin (0.4.0)
-    errbit_redmine_plugin (0.3.0)
-      errbit_plugin (~> 0)
-      oruen_redmine_client (~> 0)
-    errbit_unfuddle_plugin (0.1.0)
-      errbit_plugin (~> 0.4, >= 0.4.0)
     erubis (2.7.0)
     execjs (2.0.2)
     fabrication (2.9.0)
     faraday (0.8.9)
       multipart-post (~> 1.2.0)
-    faraday_middleware (0.9.1)
-      faraday (>= 0.7.4, < 0.10)
     flowdock (0.3.1)
       httparty (~> 0.7)
       multi_json
     foreman (0.63.0)
       dotenv (>= 0.7)
       thor (>= 0.13.6)
-    gitlab (3.0.0)
-      httparty
     haml (4.0.3)
       tilt
-    happymapper (0.4.1)
-      libxml-ruby (~> 2.0)
     hashie (2.0.5)
     highline (1.6.20)
     hike (1.2.3)
@@ -163,10 +122,6 @@ GEM
       multi_xml (>= 0.5.2)
     httpauth (0.2.0)
     i18n (0.6.11)
-    jira-ruby (0.1.10)
-      activesupport
-      oauth
-      railties
     jquery-rails (2.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -180,10 +135,6 @@ GEM
     launchy (2.3.0)
       addressable (~> 2.3)
     libv8 (3.16.14.7)
-    libxml-ruby (2.7.0)
-    lighthouse-api (2.0)
-      activeresource (>= 3.0.0)
-      activesupport (>= 3.0.0)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     meta_request (0.2.8)
@@ -224,9 +175,6 @@ GEM
       net-ssh (>= 2.6.5)
     nokogiri (1.6.4.1)
       mini_portile (~> 0.6.0)
-    nokogiri-happymapper (0.5.9)
-      nokogiri (~> 1.5)
-    oauth (0.4.7)
     oauth2 (0.8.1)
       faraday (~> 0.8)
       httpauth (~> 0.1)
@@ -247,18 +195,6 @@ GEM
     optionable (0.2.0)
     origin (2.1.1)
     orm_adapter (0.4.0)
-    oruen_redmine_client (0.0.1)
-      activeresource (>= 2.3.0)
-    pivotal-tracker (0.5.12)
-      builder
-      builder
-      crack
-      happymapper (>= 0.3.2)
-      nokogiri (>= 1.4.3)
-      nokogiri (>= 1.5.5)
-      nokogiri-happymapper (>= 0.5.4)
-      rest-client (~> 1.6.0)
-      rest-client (~> 1.6.0)
     pjax_rails (0.3.4)
       jquery-rails
     poltergeist (1.5.1)
@@ -295,15 +231,8 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.0.12)
       sprockets-rails (~> 2.0)
-    rails-observers (0.1.2)
-      activemodel (~> 4.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
     rails_autolink (1.1.6)
       rails (> 3.1)
-    rails_serve_static_assets (0.0.2)
-    rails_stdout_logging (0.0.3)
     railties (4.0.12)
       actionpack (= 4.0.12)
       activesupport (= 4.0.12)
@@ -334,8 +263,6 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    ruby-fogbugz (0.1.1)
-      crack
     rushover (0.3.0)
       json
       rest-client
@@ -343,7 +270,6 @@ GEM
     sawyer (0.5.5)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    simple_oauth (0.3.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
@@ -408,16 +334,8 @@ DEPENDENCIES
   devise
   draper
   email_spec
-  errbit_bitbucket_plugin
-  errbit_fogbugz_plugin
   errbit_github_plugin
-  errbit_gitlab_plugin
-  errbit_jira_plugin
-  errbit_lighthouse_plugin
-  errbit_pivotal_plugin
   errbit_plugin
-  errbit_redmine_plugin
-  errbit_unfuddle_plugin
   execjs
   fabrication
   flowdock


### PR DESCRIPTION
review @stevecrozz

the idea behind the extraction of services into plugins was that we dont need to include all not necessary gems.

We should include one plugin when you install errbit out-of-the-box. I think having the github issue tracker as the default is the best choice.

Also having all those plugins as hard dependencies means that every change we need to merge it back/own all the other plugins, which does not scale at all.
