### PR TITLE
Remove allow_comments_with_issue_tracker config

### DIFF
--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -175,13 +175,6 @@ class App
     update_attribute(:api_key, SecureRandom.hex)
   end
 
-  ##
-  # Check if comments can be allowed on this application
-  #
-  def comments_allowed?
-    !issue_tracker || issue_tracker.comments_allowed?
-  end
-
   protected
 
     def store_cached_attributes_on_problems

--- a/app/models/issue_tracker.rb
+++ b/app/models/issue_tracker.rb
@@ -41,6 +41,5 @@ class IssueTracker
 
   delegate :configured?, :to => :tracker
   delegate :create_issue, :to => :tracker
-  delegate :comments_allowed?, :to => :tracker
   delegate :url, :to => :tracker
 end

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -73,10 +73,6 @@ class Problem
     Notice.for_errs(errs).ordered
   end
 
-  def comments_allowed?
-    Errbit::Config.allow_comments_with_issue_tracker || app.comments_allowed?
-  end
-
   def resolve!
     self.update_attributes!(:resolved => true, :resolved_at => Time.now)
   end

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -22,32 +22,30 @@
   %br
   = render "issue_tracker_links"
 
-- if problem.comments_allowed? || problem.comments.any?
-  - content_for :comments do
-    %h3 Comments
-    - problem.comments.each do |comment|
-      .window
-        %table.comment
-          %tr
-            %th
-              - if comment.user
-                - if Errbit::Config.use_gravatar
-                  = gravatar_tag comment.user.email, :s => 24
-                %span.comment-info
-                  = time_ago_in_words(comment.created_at, include_seconds: true) << " ago by "
-                  = link_to comment.user.email, comment.user
-              - else
-                %span.comment-info
-                  = time_ago_in_words(comment.created_at, true) << " ago by [Unknown User]"
-              %span.delete= link_to '&#10008;'.html_safe, [app, problem, comment], :method => :delete,
-                :data => { :confirm => t("comments.confirm_delete") }, :class => "destroy-comment"
-          %tr
-            %td= simple_format comment.body
-    - if problem.comments_allowed?
-      = form_for [app, problem, @comment] do |comment_form|
-        %p Add a comment
-        = comment_form.text_area :body
-        = comment_form.submit "Save Comment"
+- content_for :comments do
+  %h3 Comments
+  - problem.comments.each do |comment|
+    .window
+      %table.comment
+        %tr
+          %th
+            - if comment.user
+              - if Errbit::Config.use_gravatar
+                = gravatar_tag comment.user.email, :s => 24
+              %span.comment-info
+                = time_ago_in_words(comment.created_at, include_seconds: true) << " ago by "
+                = link_to comment.user.email, comment.user
+            - else
+              %span.comment-info
+                = time_ago_in_words(comment.created_at, true) << " ago by [Unknown User]"
+            %span.delete= link_to '&#10008;'.html_safe, [app, problem, comment], :method => :delete,
+              :data => { :confirm => t("comments.confirm_delete") }, :class => "destroy-comment"
+        %tr
+          %td= simple_format comment.body
+  = form_for [app, problem, @comment] do |comment_form|
+    %p Add a comment
+    = comment_form.text_area :body
+    = comment_form.submit "Save Comment"
 
 %h4= @notice.try(:message)
 

--- a/config/cloud/cloud66/files/_load_config.rb
+++ b/config/cloud/cloud66/files/_load_config.rb
@@ -11,7 +11,6 @@ unless defined?(Errbit::Config)
     # Errbit::Config.email_at_notices = ENV['ERRBIT_EMAIL_AT_NOTICES']
     Errbit::Config.confirm_resolve_err = ENV['ERRBIT_CONFIRM_RESOLVE_ERR'].to_i == 0
     Errbit::Config.user_has_username = ENV['ERRBIT_USER_HAS_USERNAME'].to_i == 1
-    Errbit::Config.allow_comments_with_issue_tracker = ENV['ERRBIT_ALLOW_COMMENTS_WITH_ISSUE_TRACKER'].to_i == 0
     Errbit::Config.enforce_ssl = ENV['ERRBIT_ENFORCE_SSL']
 
     Errbit::Config.use_gravatar = ENV['ERRBIT_USE_GRAVATAR']

--- a/config/cloud/cloud66/files/config.yml
+++ b/config/cloud/cloud66/files/config.yml
@@ -32,11 +32,6 @@ confirm_resolve_err: true
 # Helpful when you need to plug in a custom authentication strategy, such as LDAP.
 user_has_username: false
 
-# Allow comments while an issue tracker is configured.
-# This is useful if the err is not critical enough to create a ticket,
-# but you want to leave a short comment.
-allow_comments_with_issue_tracker: true
-
 # Display internal errors in production
 # Since this is an internal application, you might like to see what caused Errbit to crash.
 # Pull requests are always welcome!
@@ -44,7 +39,6 @@ allow_comments_with_issue_tracker: true
 display_internal_errors: true
 # The host of your errbit server
 
-allow_comments_with_issue_tracker: true
 # Enable Gravatar.
 use_gravatar: true
 # Default Gravatar image, can be: mm, identicon, monsterid, wavatar, retro.

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -51,11 +51,6 @@ confirm_err_actions: true
 # Helpful when you need to plug in a custom authentication strategy, such as LDAP.
 user_has_username: false
 
-# Allow comments while an issue tracker is configured.
-# This is useful if the err is not critical enough to create a ticket,
-# but you want to leave a short comment.
-allow_comments_with_issue_tracker: true
-
 # Display internal errors in production
 # Since this is an internal application, you might like to see what caused Errbit to crash.
 # Pull requests are always welcome!

--- a/config/initializers/_load_config.rb
+++ b/config/initializers/_load_config.rb
@@ -18,9 +18,7 @@ unless defined?(Errbit::Config)
     # Errbit::Config.email_at_notices = ENV['ERRBIT_EMAIL_AT_NOTICES']
     Errbit::Config.confirm_err_actions = ENV['ERRBIT_CONFIRM_ERR_ACTIONS'].to_i == 0
     Errbit::Config.user_has_username = ENV['ERRBIT_USER_HAS_USERNAME'].to_i == 1
-    Errbit::Config.allow_comments_with_issue_tracker = ENV['ERRBIT_ALLOW_COMMENTS_WITH_ISSUE_TRACKER'].to_i == 0
     Errbit::Config.enforce_ssl = ENV['ERRBIT_ENFORCE_SSL']
-
     Errbit::Config.use_gravatar = ENV['ERRBIT_USE_GRAVATAR']
     Errbit::Config.gravatar_default = ENV['ERRBIT_GRAVATAR_DEFAULT']
 

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -220,26 +220,4 @@ describe App do
       }.to raise_error(Mongoid::Errors::DocumentNotFound)
     end
   end
-
-  describe "#comments_allowed?" do
-    context "without issue_tracker" do
-      it 'return true' do
-        expect(App.new.comments_allowed?).to be_true
-      end
-    end
-
-    context "with issue_tracker" do
-      let(:issue_tracker) do
-        ist = IssueTracker.new
-        ist.stub(:comments_allowed?).and_return('foo')
-        ist
-      end
-      it 'delegate to issue_tracker' do
-        expect(App.new(
-          :issue_tracker => issue_tracker
-        ).comments_allowed?).to eql 'foo'
-      end
-    end
-  end
-
 end

--- a/spec/views/problems/show.html.haml_spec.rb
+++ b/spec/views/problems/show.html.haml_spec.rb
@@ -8,7 +8,6 @@ describe "problems/show.html.haml" do
       def self.label; 'pivotal'; end
       def initialize(app, params); end
       def configured?; true; end
-      def comments_allowed?; false; end
     end
   }
   let(:github_tracker) {
@@ -16,7 +15,6 @@ describe "problems/show.html.haml" do
       def initialize(app, params); end
       def label; 'github'; end
       def configured?; true; end
-      def comments_allowed?; false; end
     end
   }
   let(:trackers) {
@@ -168,18 +166,16 @@ describe "problems/show.html.haml" do
             end
           end
         end
-
       end
     end
   end
 
-  describe "content_for :comments with comments disabled for configured issue tracker" do
+  describe "content_for :comments" do
     before do
-      Errbit::Config.stub(:allow_comments_with_issue_tracker).and_return(false)
       Errbit::Config.stub(:use_gravatar).and_return(true)
     end
 
-    it 'should display comments and new comment form when no issue tracker' do
+    it 'should display comments and new comment form' do
       problem = Fabricate(:problem_with_comments)
       view.stub(:problem).and_return(problem)
       view.stub(:app).and_return(problem.app)
@@ -190,24 +186,14 @@ describe "problems/show.html.haml" do
       expect(view.content_for(:comments)).to include('Add a comment')
     end
 
-    context "with issue tracker" do
-      it 'should not display the comments section' do
-        problem = Fabricate(:problem)
-        with_issue_tracker("pivotal", problem)
-        render
-        expect(view.view_flow.get(:comments)).to be_blank
-      end
+    it 'should display existing comments' do
+      problem = Fabricate(:problem_with_comments)
+      problem.reload
+      with_issue_tracker("pivotal", problem)
+      render
 
-      it 'should display existing comments' do
-        problem = Fabricate(:problem_with_comments)
-        problem.reload
-        with_issue_tracker("pivotal", problem)
-        render
-
-        expect(view.content_for(:comments)).to include('Test comment')
-        expect(view.content_for(:comments)).to have_selector('img[src^="http://www.gravatar.com/avatar"]')
-        expect(view.content_for(:comments)).to_not include('Add a comment')
-      end
+      expect(view.content_for(:comments)).to include('Test comment')
+      expect(view.content_for(:comments)).to have_selector('img[src^="http://www.gravatar.com/avatar"]')
     end
   end
 end


### PR DESCRIPTION
Remove `allow_comments_with_issue_tracker` config.

Allowing comments should not be a issue tracker responsibility.

Having to support an extra `comments_allowed?` API in every plugin is just too much, and again, this should not be up-to the issue tracker.

First I thought to only remove the option from the issue tracker and still leave it globally, but the option name doesnt make sense `allow_comments_with_issue_tracker` , showing comments always is fine, and remove a bit of extra complexity in multi-layers of errbit.

r. @stevecrozz
