### PR TITLE
Fix double escaping of problem title in list view

### DIFF
--- a/app/helpers/problems_helper.rb
+++ b/app/helpers/problems_helper.rb
@@ -6,7 +6,7 @@ module ProblemsHelper
   def truncated_problem_message(problem)
     unless (msg = problem.message).blank?
       # Truncate & insert invisible chars so that firefox can emulate 'word-wrap: break-word' CSS rule
-      truncate(msg, :length => 300).scan(/.{1,5}/).map { |s| h(s) }.join("&#8203;").html_safe
+      truncate(msg, :length => 300, :escape => false).scan(/.{1,5}/).map { |s| h(s) }.join("&#8203;").html_safe
     end
   end
 

--- a/spec/helpers/problems_helper_spec.rb
+++ b/spec/helpers/problems_helper_spec.rb
@@ -8,6 +8,13 @@ describe ProblemsHelper do
       expect(truncated).to be_html_safe
       expect(truncated).to_not include('<', '>')
     end
+
+    it 'does not double escape html' do
+      problem = double('problem', :message => '#<NoMethodError: ...>')
+      truncated = helper.truncated_problem_message(problem)
+      expect(truncated).to be_html_safe
+      expect(truncated).to_not include('&amp;')
+    end
   end
 
   describe "#gravatar_tag" do


### PR DESCRIPTION
Without this change, the truncated text, which is already html escaped gets escaped again in the map block.