### PR TITLE
Remove puma and Procfile.dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,8 +69,6 @@ group :development do
   gem 'binding_of_caller'
   gem 'meta_request'
   gem 'foreman', :require => false
-  # Use puma for development
-  gem 'puma', :require => false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,8 +229,6 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.2)
       pry (>= 0.9.10)
-    puma (2.6.0)
-      rack (>= 1.1, < 2.0)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
     rack (1.5.2)
@@ -382,7 +380,6 @@ DEPENDENCIES
   pjax_rails
   poltergeist
   pry-rails
-  puma
   quiet_assets
   rack-ssl
   rack-ssl-enforcer

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,0 @@
-web: bundle exec puma


### PR DESCRIPTION
It would be better to use same app server between dev and prod.

Is there any reason to use puma on dev?