### PR TITLE
Fix GtalkService Keeaplive-Thread leak

### DIFF
--- a/app/models/notification_services/gtalk_service.rb
+++ b/app/models/notification_services/gtalk_service.rb
@@ -53,6 +53,8 @@ class NotificationServices::GtalkService < NotificationService
     # post the issue to the xmpp room(s)
     send_to_users(client, message) unless user_id.blank?
     send_to_muc(client, message) unless room_id.blank?
+  ensure
+    client.close unless client.nil?
   end
 
   private

--- a/spec/models/notification_service/gtalk_service_spec.rb
+++ b/spec/models/notification_service/gtalk_service_spec.rb
@@ -28,6 +28,7 @@ describe NotificationService::GtalkService do
 
     #assert
     expect(gtalk).to receive(:send).exactly(2).times.with(message)
+    expect(gtalk).to receive(:close)
 
     notification_service.create_notification(problem)
   end
@@ -57,6 +58,7 @@ describe NotificationService::GtalkService do
       expect(Jabber::Message).to receive(:new).with("fourth@domain.org", @error_msg)
       expect(Jabber::MUC::SimpleMUCClient).to_not receive(:new)
       expect(@gtalk).to receive(:send).exactly(4).times
+      expect(@gtalk).to receive(:close)
 
       @notification_service.user_id = "first@domain.org,second@domain.org, third@domain.org ,   fourth@domain.org  "
       @notification_service.room_id = ""
@@ -69,6 +71,7 @@ describe NotificationService::GtalkService do
       expect(Jabber::Message).to receive(:new).with("fourth@domain.org", @error_msg)
       expect(Jabber::MUC::SimpleMUCClient).to_not receive(:new)
       expect(@gtalk).to receive(:send).exactly(4).times
+      expect(@gtalk).to receive(:close)
 
       @notification_service.user_id = "first@domain.org;second@domain.org; third@domain.org ;   fourth@domain.org  "
       @notification_service.room_id = ""
@@ -81,6 +84,7 @@ describe NotificationService::GtalkService do
       expect(Jabber::Message).to receive(:new).with("fourth@domain.org", @error_msg)
       expect(Jabber::MUC::SimpleMUCClient).to_not receive(:new)
       expect(@gtalk).to receive(:send).exactly(4).times
+      expect(@gtalk).to receive(:close)
 
       @notification_service.user_id = "first@domain.org second@domain.org  third@domain.org     fourth@domain.org  "
       @notification_service.room_id = ""
@@ -117,6 +121,7 @@ describe NotificationService::GtalkService do
 
     #assert
     expect(gtalk).to receive(:send).with(message)
+    expect(gtalk).to receive(:close)
 
     notification_service.create_notification(problem)
   end


### PR DESCRIPTION
The GoogleTalk/Jabber Notification Service was leaking keepalive threads, because xmpp4r creates an internal keealive thread on connect that is only cleaned up when closing the client.

This lead to workers quickly running out of threads and throwing exceptions like `ThreadError: can't alloc thread`. The fix ensures that the xmpp4r client is always closed after notifications have been sent.

Example Exception-Backtrace:
```
ThreadError: can't alloc thread:
xmpp4r-0.5.5/lib/xmpp4r/connection.rb:83→ new
xmpp4r-0.5.5/lib/xmpp4r/connection.rb:83→ connect
xmpp4r-0.5.5/lib/xmpp4r/client.rb:71→ connect
app/models/notification_services/gtalk_service.rb:45→ create_notification
mongoid-4.0.0/lib/mongoid/relations/proxy.rb:150→ method_missing
app/models/notice.rb:196→ services_notification
```