### PR TITLE
Adds the rails_12factor gem for Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ group :test do
 end
 
 group :heroku, :production do
+  gem 'rails_12factor', require: !!ENV["HEROKU"]
   gem 'unicorn', :require => false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,8 +264,13 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.8)
       sprockets-rails (~> 2.0)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
     rails_autolink (1.1.6)
       rails (> 3.1)
+    rails_serve_static_assets (0.0.3)
+    rails_stdout_logging (0.0.3)
     railties (4.1.8)
       actionpack (= 4.1.8)
       activesupport (= 4.1.8)
@@ -421,6 +426,7 @@ DEPENDENCIES
   quiet_assets
   rack-ssl
   rack-ssl-enforcer
+  rails_12factor
   rails_autolink
   railties (~> 4.1.8)
   ri_cal


### PR DESCRIPTION
This PR adds the rails_12factor gem to the Gemfile, but it is only required if the `HEROKU` environment variable is set. This should have no ill effect on other deployment targets. This should solve issue #806…