### PR TITLE
Return false in the overridden onerror function.

### DIFF
--- a/public/javascripts/notifier.js
+++ b/public/javascripts/notifier.js
@@ -491,7 +491,7 @@ printStackTrace.implementation.prototype = {
 };// Airbrake JavaScript Notifier
 (function() {
     "use strict";
-    
+
     var NOTICE_XML = '<?xml version="1.0" encoding="UTF-8"?>' +
         '<notice version="2.0">' +
             '<api-key>{key}</api-key>' +
@@ -529,7 +529,7 @@ printStackTrace.implementation.prototype = {
         Global,
         Util,
         _publicAPI,
-        
+
         NOTICE_JSON = {
             "notifier": {
                 "name": "airbrake_js",
@@ -541,13 +541,13 @@ printStackTrace.implementation.prototype = {
 				"type": "{exception_class}",
                 "message": "{exception_message}",
                 "backtrace": []
-				
+
             }
 			],
             "context": {
 				"language": "JavaScript",
 				"environment": "{environment}",
-				
+
                 "version": "1.1.1",
 				"url": "{request_url}",
                 "rootDirectory": "{project_root}",
@@ -566,25 +566,25 @@ printStackTrace.implementation.prototype = {
     Util = {
         /*
          * Merge a number of objects into one.
-         * 
-         * Usage example: 
+         *
+         * Usage example:
          *  var obj1 = {
          *          a: 'a'
          *      },
          *      obj2 = {
-         *          b: 'b'     
+         *          b: 'b'
          *      },
          *      obj3 = {
-         *          c: 'c'     
+         *          c: 'c'
          *      },
-         *      mergedObj = Util.merge(obj1, obj2, obj3);  
+         *      mergedObj = Util.merge(obj1, obj2, obj3);
          *
          * mergedObj is: {
          *     a: 'a',
          *     b: 'b',
          *     c: 'c'
          * }
-         * 
+         *
          */
         merge: (function() {
             function processProperty (key, dest, src) {
@@ -608,7 +608,7 @@ printStackTrace.implementation.prototype = {
                 return result;
             };
         })(),
-        
+
         /*
          * Replace &, <, >, ', " characters with correspondent HTML entities.
          */
@@ -616,20 +616,20 @@ printStackTrace.implementation.prototype = {
             return text.replace(/&/g, '&#38;').replace(/</g, '&#60;').replace(/>/g, '&#62;')
                     .replace(/'/g, '&#39;').replace(/"/g, '&#34;');
         },
-        
+
         /*
-         * Remove leading and trailing space characters. 
+         * Remove leading and trailing space characters.
          */
         trim: function (text) {
             return text.toString().replace(/^\s+/, '').replace(/\s+$/, '');
         },
-        
+
         /*
          * Fill 'text' pattern with 'data' values.
-         * 
+         *
          * e.g. Utils.substitute('<{tag}></{tag}>', {tag: 'div'}, true) will return '<div></div>'
-         * 
-         * emptyForUndefinedData - a flag, if true, all matched {<name>} without data.<name> value specified will be 
+         *
+         * emptyForUndefinedData - a flag, if true, all matched {<name>} without data.<name> value specified will be
          * replaced with empty string.
          */
         substitute: function (text, data, emptyForUndefinedData) {
@@ -637,35 +637,35 @@ printStackTrace.implementation.prototype = {
                 return (key in data) ? data[key] : (emptyForUndefinedData ? '' : match);
             });
         },
-        
+
         /*
-         * Perform pattern rendering for an array of data objects. 
-         * Returns a concatenation of rendered strings of all objects in array. 
+         * Perform pattern rendering for an array of data objects.
+         * Returns a concatenation of rendered strings of all objects in array.
          */
         substituteArr: function (text, dataArr, emptyForUndefinedData) {
-            var _i = 0, _l = 0, 
+            var _i = 0, _l = 0,
                 returnStr = '';
-            
+
             for (_i = 0, _l = dataArr.length; _i < _l; _i += 1) {
                 returnStr += this.substitute(text, dataArr[_i], emptyForUndefinedData);
             }
-            
+
             return returnStr;
         },
-        
+
         /*
          * Add hook for jQuery.fn.on function, to manualy call window.Airbrake.captureException() method
          * for every exception occurred.
-         * 
+         *
          * Let function 'f' be binded as an event handler:
-         * 
+         *
          * $(window).on 'click', f
-         * 
-         * If an exception is occurred inside f's body, it will be catched here 
+         *
+         * If an exception is occurred inside f's body, it will be catched here
          * and forwarded to captureException method.
-         * 
+         *
          * processjQueryEventHandlerWrapping is called every time window.Airbrake.setTrackJQ method is used,
-         * if it switches previously setted value. 
+         * if it switches previously setted value.
          */
         processjQueryEventHandlerWrapping: function () {
             if (Config.options.trackJQ === true) {
@@ -693,8 +693,8 @@ printStackTrace.implementation.prototype = {
                             }
                         };
                     })(args[fnArgIdx]);
-                    
-                    // Call original jQuery.fn.on, with the same list of arguments, but 
+
+                    // Call original jQuery.fn.on, with the same list of arguments, but
                     // a function replaced with a proxy.
                     return Config.jQuery_fn_on_original.apply(this, args);
                 };
@@ -709,30 +709,30 @@ printStackTrace.implementation.prototype = {
             return (typeof jQuery === 'function') && ('fn' in jQuery) && ('jquery' in jQuery.fn)
                     && (jQuery.fn.jquery.indexOf('1.7') === 0)
         },
-        
+
         /*
          * Make first letter in a string capital. e.g. 'guessFunctionName' -> 'GuessFunctionName'
          * Is used to generate getter and setter method names.
          */
         capitalizeFirstLetter: function (str) {
-            return str.charAt(0).toUpperCase() + str.slice(1);  
+            return str.charAt(0).toUpperCase() + str.slice(1);
         },
-        
+
         /*
          * Generate public API from an array of specifically formated objects, e.g.
-         * 
+         *
          * - this will generate 'setEnvironment' and 'getEnvironment' API methods for configObj.xmlData.environment variable:
          * {
          *     variable: 'environment',
          *     namespace: 'xmlData'
          * }
-         * 
-         * - this will define 'method' function as 'captureException' API method 
+         *
+         * - this will define 'method' function as 'captureException' API method
          * {
          *     methodName: 'captureException',
          *     method: (function (...) {...});
          * }
-         * 
+         *
          */
         generatePublicAPI: (function () {
             function _generateSetter (variable, namespace, configObj) {
@@ -740,40 +740,40 @@ printStackTrace.implementation.prototype = {
                     configObj[namespace][variable] = value;
                 };
             }
-            
+
             function _generateGetter (variable, namespace, configObj) {
                 return function (value) {
                     return configObj[namespace][variable];
                 };
             }
-            
+
             /*
              * publicAPI: array of specifically formated objects
-             * configObj: inner configuration object 
+             * configObj: inner configuration object
              */
             return function (publicAPI, configObj) {
                 var _i = 0, _m = null, _capitalized = '',
                     returnObj = {};
-                
+
                 for (_i = 0; _i < publicAPI.length; _i += 1) {
                     _m = publicAPI[_i];
-                    
+
                     switch (true) {
                         case (typeof _m.variable !== 'undefined') && (typeof _m.methodName === 'undefined'):
                             _capitalized = Util.capitalizeFirstLetter(_m.variable)
                             returnObj['set' + _capitalized] = _generateSetter(_m.variable, _m.namespace, configObj);
                             returnObj['get' + _capitalized] = _generateGetter(_m.variable, _m.namespace, configObj);
-                            
+
                             break;
                         case (typeof _m.methodName !== 'undefined') && (typeof _m.method !== 'undefined'):
                             returnObj[_m.methodName] = _m.method
-                            
+
                             break;
-                        
-                        default:                       
+
+                        default:
                     }
                 }
-                
+
                 return returnObj;
             };
         } ())
@@ -798,7 +798,7 @@ printStackTrace.implementation.prototype = {
             outputFormat: 'XML' // Can be 'XML' or 'JSON'
         }
     };
-    
+
     /*
      * The public API definition object. If no 'methodName' and 'method' values specified,
      * getter and setter for 'variable' will be defined.
@@ -842,15 +842,15 @@ printStackTrace.implementation.prototype = {
                 if (!Util.isjQueryPresent()) {
                     throw Error('Please do not call \'Airbrake.setTrackJQ\' if jQuery does\'t present');
                 }
-    
+
                 value = !!value;
-    
+
                 if (Config.options.trackJQ === value) {
                     return;
                 }
-    
+
                 Config.options.trackJQ = value;
-    
+
                 Util.processjQueryEventHandlerWrapping();
             })
         }, {
@@ -880,7 +880,7 @@ printStackTrace.implementation.prototype = {
         this.options = Util.merge({}, Config.options);
         this.xmlData = Util.merge(this.DEF_XML_DATA, Config.xmlData);
     }
-    
+
     Notifier.prototype = {
         constructor: Notifier,
         VERSION: '0.2.0',
@@ -898,10 +898,10 @@ printStackTrace.implementation.prototype = {
              */
             function _sendGETRequest (url, data) {
                 var request = document.createElement('iframe');
-                
+
                 request.style.display = 'none';
                 request.src = url + '?data=' + data;
-                
+
                 // When request has been sent, delete iframe
                 request.onload = function () {
                     // To avoid infinite progress indicator
@@ -909,13 +909,13 @@ printStackTrace.implementation.prototype = {
                         document.body.removeChild(request);
                     }, 0);
                 };
-    
+
                 document.body.appendChild(request);
             }
-            
+
             /*
-             * Cross-domain AJAX POST request. 
-             * 
+             * Cross-domain AJAX POST request.
+             *
              * It requires a server setup as described in Cross-Origin Resource Sharing spec:
              * http://www.w3.org/TR/cors/
              */
@@ -925,19 +925,19 @@ printStackTrace.implementation.prototype = {
                 request.setRequestHeader('Content-Type', 'application/json');
                 request.send(data);
             }
-            
+
             return function (error) {
                 var outputData = '', jsonData,
 					url =  '';
 				    //
-                
+
                    /*
                     * Should be changed to url = '//' + ...
-                    * to use the protocol of current page (http or https). Only sends 'secure' if page is secure.  
+                    * to use the protocol of current page (http or https). Only sends 'secure' if page is secure.
 					* XML uses V2 API. http://collect.airbrake.io/notifier_api/v2/notices
 			       */
-               
-			
+
+
                 switch (this.options['outputFormat']) {
                     case 'XML':
                      jsonData = this.generateDataJSON(error);
@@ -948,15 +948,15 @@ printStackTrace.implementation.prototype = {
                      }
 					   break;
 
-                    case 'JSON': 
+                    case 'JSON':
  					/*
-					*   JSON uses API V3. Needs project in URL. 
+					*   JSON uses API V3. Needs project in URL.
 					*   http://collect.airbrake.io/api/v3/projects/[PROJECT_ID]/notices?key=[API_KEY]
 					* url = window.location.protocol + '://' + this.options.host + '/api/v3/projects' + this.options.projectId + '/notices?key=' + this.options.key;
 					*/
                         jsonData = this.generateDataJSON(error);
                         if (this.shouldSendData(jsonData)){
-                          outputData = JSON.stringify(this.generateJSON(jsonData));  
+                          outputData = JSON.stringify(this.generateJSON(jsonData));
                           url = ('https:' == document.location.protocol ? 'https://' : 'http://') + this.options.host + '/api/v3/projects/' + this.options.projectId + '/notices?key=' + this.xmlData.key;
                           _sendPOSTRequest(url, outputData);
                         }
@@ -967,22 +967,22 @@ printStackTrace.implementation.prototype = {
 
             };
         } ()),
-        
+
         /*
-         * Generate inner JSON representation of exception data that can be rendered as XML or JSON. 
+         * Generate inner JSON representation of exception data that can be rendered as XML or JSON.
          */
         generateDataJSON: (function () {
             /*
              * Generate variables array for inputObj object.
-             * 
+             *
              * e.g.
-             * 
+             *
              * _generateVariables({a: 'a'}) -> [{key: 'a', value: 'a'}]
-             * 
+             *
              */
             function _generateVariables (inputObj) {
                 var key = '', returnArr = [];
-                
+
                 for (key in inputObj) {
                     if (inputObj.hasOwnProperty(key)) {
                         returnArr.push({
@@ -991,43 +991,43 @@ printStackTrace.implementation.prototype = {
                         });
                     }
                 }
-                
+
                 return returnArr;
             }
-            
+
             /*
-             * Generate Request part of notification.  
+             * Generate Request part of notification.
              */
             function _composeRequestObj (methods, errorObj) {
                 var _i = 0,
                     returnObj = {},
                     type = '';
-                
+
                 for (_i = 0; _i < methods.length; _i += 1) {
                     type = methods[_i];
                     if (typeof errorObj[type] !== 'undefined') {
                         returnObj[type] = _generateVariables(errorObj[type]);
                     }
                 }
-                
-                return returnObj;             
+
+                return returnObj;
             }
-            
+
             return function (errorWithoutDefaults) {
                     /*
                      * A constructor line:
-                     * 
+                     *
                      * this.xmlData = Util.merge(this.DEF_XML_DATA, Config.xmlData);
                      */
-                var outputData = this.xmlData, 
+                var outputData = this.xmlData,
                     error = Util.merge(this.options.errorDefaults, errorWithoutDefaults),
-                    
+
                     component = error.component || '',
                     request_url = (error.url || '' + location.href),
-                    
+
                     methods = ['cgi-data', 'params', 'session'],
                     _outputData = null;
-                
+
                 _outputData = {
                     request_url: request_url,
                     request_action: (error.action || ''),
@@ -1041,20 +1041,20 @@ printStackTrace.implementation.prototype = {
                             return {}
                         }
                     } ()),
-                    
+
                     project_root: this.ROOT,
                     exception_class: (error.type || errorWithoutDefaults.type ||
                                         (errorWithoutDefaults.constructor.name != "Object" ? errorWithoutDefaults.constructor.name : 'Error')),
                     exception_message: (error.message || errorWithoutDefaults.message || 'Unknown error.'),
                     backtrace_lines: this.generateBacktrace(errorWithoutDefaults)
                 }
-                
+
                 outputData = Util.merge(outputData, _outputData);
-                
+
                 return outputData;
             };
         } ()),
-        
+
         /*
          * Generate XML notification from inner JSON representation.
          * NOTICE_XML is used as pattern.
@@ -1063,7 +1063,7 @@ printStackTrace.implementation.prototype = {
             function _generateRequestVariableGroups (requestObj) {
                 var _group = '',
                     returnStr = '';
-                
+
                 for (_group in requestObj) {
                     if (requestObj.hasOwnProperty(_group)) {
                         returnStr += Util.substitute(REQUEST_VARIABLE_GROUP_XML, {
@@ -1072,18 +1072,18 @@ printStackTrace.implementation.prototype = {
                         }, true);
                     }
                 }
-                
+
                 return returnStr;
             }
-            
+
             return function (JSONdataObj) {
                 JSONdataObj.request = _generateRequestVariableGroups(JSONdataObj.request);
                 JSONdataObj.backtrace_lines = Util.substituteArr(BACKTRACE_LINE_XML, JSONdataObj.backtrace_lines, true);
-                
+
                 return Util.substitute(NOTICE_XML, JSONdataObj, true);
             };
         } ()),
-        
+
         /*
          * Generate JSON notification from inner JSON representation.
          * NOTICE_JSON is used as pattern.
@@ -1092,14 +1092,14 @@ printStackTrace.implementation.prototype = {
             // Pattern string is JSON.stringify(NOTICE_JSON)
             // The rendered string is parsed back as JSON.
             var outputJSON = JSON.parse(Util.substitute(JSON.stringify(NOTICE_JSON), JSONdataObj, true));
-            
-            // REMOVED - Request from JSON. 
+
+            // REMOVED - Request from JSON.
 			outputJSON.request = Util.merge(outputJSON.request, JSONdataObj.request);
             outputJSON.error.backtrace = JSONdataObj.backtrace_lines;
-            
+
             return outputJSON;
         },
-        
+
         generateBacktrace: function (error) {
             var backtrace = [],
                 file,
@@ -1127,7 +1127,7 @@ printStackTrace.implementation.prototype = {
 
                     if (i === 0 && matches[2].match(document.location.href)) {
                         // backtrace.push('<line method="" file="internal: " number=""/>');
-                       
+
                         backtrace.push({
 						// Updated to fit in with V3 new terms for Backtrace data.
                             'function': '',
@@ -1138,7 +1138,7 @@ printStackTrace.implementation.prototype = {
 
                     // backtrace.push('<line method="' + Util.escape(matches[1]) + '" file="' + Util.escape(file) +
                     //        '" number="' + matches[3] + '" />');
-                    
+
                     backtrace.push({
                         'function': Util.escape(matches[1]),
                         file: Util.escape(file),
@@ -1212,7 +1212,7 @@ printStackTrace.implementation.prototype = {
         if (oldOnerror) {
           return oldOnerror(message, file, line, code, error);
         }
-        return true;
+        return false;
     };
 })();
 })(window, document);


### PR DESCRIPTION
onerror should return false in order to allow the default browser behavior for javascript exceptions. Reference document here: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers.onerror