### PR TITLE
Allow to specify Ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 RAILS_VERSION = '~> 4.1.8'
 
+ruby ENV['RUBY_VERSION'] if ENV['RUBY_VERSION']
+
 gem 'actionmailer', RAILS_VERSION
 gem 'actionpack', RAILS_VERSION
 gem 'railties', RAILS_VERSION


### PR DESCRIPTION
It seems errbit officially supports [Ruby 2.1 or higher](https://github.com/errbit/errbit#requirements).
Otherwise Heroku uses Ruby 2.0.0 when `Gemfile` has no `ruby` section.

So I specify `ruby` section for Heroku.