### PR TITLE
add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM ubuntu:utopic
+FROM ubuntu
 RUN apt-get update
 ADD . /errbit
 WORKDIR /errbit
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
-  ca-certificates gcc git make node ruby-dev ruby2.1 && \
+  ca-certificates gcc git make node ruby-dev ruby && \
   cd /errbit && gem install bundler && bundle install && \
   DEBIAN_FRONTEND=noninteractive apt-get -y purge gcc git make ruby-dev && \
   DEBIAN_FRONTEND=noninteractive apt-get -y autoremove
+
+RUN env > /myenv
 
 CMD ["bundle", "exec", "foreman", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:utopic
+RUN apt-get update
+ADD . /errbit
+WORKDIR /errbit
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install \
+  ca-certificates gcc git make node ruby-dev ruby2.1 && \
+  cd /errbit && gem install bundler && bundle install && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y purge gcc git make ruby-dev && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y autoremove
+
+CMD ["bundle", "exec", "foreman", "start"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,10 +1,11 @@
 # Deployment Notes
 There are any number of ways to deploy Errbit, but official support is limited
-to heroku and capistrano.
+to heroku, capistrano and docker.
 
 See specific notes on deployment via:
 - [heroku](deployment/heroku.md)
 - [capistrano](deployment/capistrano.md)
+- [docker](deployment/docker.md)
 
 You can use a process manager to deploy Errbit, but Errbit doesn't maintain
 support for any specific process manager. But if you use systemd, @nofxx has

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,0 +1,35 @@
+# Deploy with Docker
+Errbit provides official [docker](https://www.docker.com/) images to
+make docker deployment easy.  You can pass all of [Errbit's
+configuration](docs/configuration.md) to the Docker container using
+`docker run -e`.
+
+For instance, if you already have a mongo, pass along the mongo URL
+using `docker run -e "MONGO_URL=mongodb://my-mongo-url". This example
+will run an Errbit process in the background, giving it the name
+'my-errbit':
+```bash
+docker run -d \
+  -e "MONGO_URL=mongodb://my-mongo-url" \
+  --name my-errbit \
+  -p 5000:5000 \
+  stevecrozz/errbit
+```
+
+If you want to run mongo in a container as well, you can use `--link` to
+link your Errbit and mongo containers:
+
+```bash
+docker run -d \
+  --name my-mongo \
+  mongo
+
+docker run -d \
+  --link my-mongo:my-mongo
+  -e "MONGO_URL=mongodb://my-mongo/mydbname" \
+  --name my-errbit \
+  -p 5000:5000 \
+  stevecrozz/errbit
+```
+
+Errbit should now be accessible on your Docker host over port 5000.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1,6 +1,6 @@
 # Deploy with Docker
-Errbit provides official [docker](https://www.docker.com/) images to
-make docker deployment easy.  You can pass all of [Errbit's
+Errbit provides official [Docker](https://www.docker.com/) images to
+make Docker deployment easy.  You can pass all of [Errbit's
 configuration](docs/configuration.md) to the Docker container using
 `docker run -e`.
 
@@ -25,11 +25,22 @@ docker run -d \
   mongo
 
 docker run -d \
-  --link my-mongo:my-mongo
+  --link my-mongo:my-mongo \
   -e "MONGO_URL=mongodb://my-mongo/mydbname" \
   --name my-errbit \
   -p 5000:5000 \
   stevecrozz/errbit
+```
+
+Now run `rake errbit:bootstrap` to bootstrap the Errbit db within an ephemeral
+Docker container:
+```bash
+docker run \
+  --rm \
+  --link my-mongo:my-mongo \
+  -e "MONGO_URL=mongodb://my-mongo/mydbname" \
+  stevecrozz/errbit \
+  rake errbit:bootstrap
 ```
 
 Errbit should now be accessible on your Docker host over port 5000.


### PR DESCRIPTION
Now that we have env-only config, docker support is pretty straightforward. Is this something we should have in errbit? I also created a Docker errbit organization so we can use that instead of 'stevecrozz' if we decide to go ahead with this.

One thing left to consider is the the db create / rake errbit:bootstrap stuff.