### PR TITLE
Refs #785 add md and txt issue tracker templates

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -61,7 +61,7 @@ class ProblemsController < ApplicationController
   end
 
   def create_issue
-    body = render_to_string "issue_trackers/issue", layout: false, formats: [:txt]
+    body = render_to_string "issue_trackers/issue", layout: false, formats: [:md]
     title = "[#{ problem.environment }][#{ problem.where }] #{problem.message.to_s.truncate(100)}"
 
     issue = Issue.new(problem: problem, user: current_user, title: title, body: body)

--- a/app/helpers/hash_helper.rb
+++ b/app/helpers/hash_helper.rb
@@ -1,6 +1,8 @@
 module HashHelper
 
   def pretty_hash(hash, nesting = 0)
+    return '{}' if hash.empty?
+
     tab_size = 2
     nesting += 1
 

--- a/app/views/issue_trackers/issue.md.erb
+++ b/app/views/issue_trackers/issue.md.erb
@@ -1,0 +1,41 @@
+[See this exception on Errbit](<%= app_problem_url problem.app, problem %>)
+<% if notice = problem.notices.first %>
+# <%= notice.message %> #
+## Summary ##
+<% if notice.request['url'].present? %>
+### URL ###
+[<%= notice.request['url'] %>](<%= notice.request['url'] %>)"
+<% end %>
+### Where ###
+<%= notice.where %>
+
+### Occured ###
+<%= notice.created_at.to_s(:micro) %>
+
+### Similar ###
+<%= (notice.problem.notices_count - 1).to_s %>
+
+## Params ##
+~~~
+<%= pretty_hash(notice.params) %>
+~~~
+
+## Session ##
+~~~
+<%= pretty_hash(notice.session) %>
+~~~
+
+## Backtrace ##
+~~~
+<% notice.backtrace_lines.each do |line| %><%= line.number %>:  <%= line.file_relative %> -> **<%= line.method %>**
+<% end %>
+~~~
+
+<% if notice.env_vars.present? %>
+## Environment ##
+| Key        | Value      |
+|------------|------------|
+<% notice.env_vars.each do |key, val| %>| <%= key %> | <%= val %> |
+<% end %>
+<% end %>
+<% end %>

--- a/app/views/issue_trackers/issue.txt.erb
+++ b/app/views/issue_trackers/issue.txt.erb
@@ -1,45 +1,21 @@
-[See this exception on Errbit](<%= app_problem_url problem.app, problem %> "See this exception on Errbit")
+Errbit link: <%= app_problem_url problem.app, problem %>
 <% if notice = problem.notices.first %>
-# <%= notice.message %> #
-## Summary ##
+<% notice.message %>
+
+Summary
+-------
 <% if notice.request['url'].present? %>
-### URL ###
-[<%= notice.request['url'] %>](<%= notice.request['url'] %>)"
+URL:     <%= notice.request['url'] %>
 <% end %>
-### Where ###
-<%= notice.where %>
+Where:   <%= notice.where %>
+Occured: <%= notice.created_at.to_s(:micro) %>
+Similar: <%= (notice.problem.notices_count - 1).to_s %>
+Params:  <%= pretty_hash notice.params %>
+Session: <%= pretty_hash notice.session %>
+Env:     <%= pretty_hash notice.env_vars %>
 
-### Occured ###
-<%= notice.created_at.to_s(:micro) %>
-
-### Similar ###
-<%= (notice.problem.notices_count - 1).to_s %>
-
-## Params ##
-```
-<%= pretty_hash(notice.params) %>
-```
-
-## Session ##
-```
-<%= pretty_hash(notice.session) %>
-```
-
-## Backtrace ##
-```
-<% notice.backtrace_lines.each do |line| %><%= line.number %>:  <%= line.file_relative %> -> **<%= line.method %>**
+Backtrace
+---------
+<% notice.backtrace_lines.each do |line| %><%= sprintf('%5d: %s **%s', line.number, line.file_relative, line.method) %>
 <% end %>
-```
-
-## Environment ##
-
-<table>
-<% for key, val in notice.env_vars %>
-  <tr>
-    <td><%= key %>:</td>
-    <td><%= val %></td>
-  </tr>
 <% end %>
-</table>
-<% end %>
-

--- a/spec/views/issue_trackers/issue.md.erb_spec.rb
+++ b/spec/views/issue_trackers/issue.md.erb_spec.rb
@@ -1,0 +1,16 @@
+describe "issue_trackers/issue.md.erb", type: 'view' do
+  let(:problem) {
+    problem = Fabricate(:problem)
+    Fabricate(:notice, :err => Fabricate(:err, :problem => problem))
+    problem
+  }
+
+  before do
+    allow(view).to receive(:problem).and_return(problem)
+  end
+
+  it "has the problem url" do
+    render
+    expect(rendered).to match(app_problem_url problem.app, problem)
+  end
+end

--- a/spec/views/issue_trackers/issue.txt.erb_spec.rb
+++ b/spec/views/issue_trackers/issue.txt.erb_spec.rb
@@ -1,0 +1,16 @@
+describe "issue_trackers/issue.txt.erb", type: 'view' do
+  let(:problem) {
+    problem = Fabricate(:problem)
+    Fabricate(:notice, :err => Fabricate(:err, :problem => problem))
+    problem
+  }
+
+  before do
+    allow(view).to receive(:problem).and_return(problem)
+  end
+
+  it "has the problem url" do
+    render
+    expect(rendered).to match(app_problem_url problem.app, problem)
+  end
+end


### PR DESCRIPTION
This PR adds an unused txt format issue tracker body and a markdown format issue tracker body to prepare for issue trackers that can specify which template to use.