### PR TITLE
github_org_id can't match (String vs. Integer)

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -8,8 +8,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # See if they are a member of the organization that we have access for
       # If they are, automatically create an account
       client = Octokit::Client.new(access_token: github_token)
-      org_ids = client.organizations.map { |org| org.id.to_s }
-      if org_ids.include?(github_org_id.to_s)
+      org_ids = client.organizations.map { |org| org.id }
+      if org_ids.include?(github_org_id)
         github_user = User.create(name: env["omniauth.auth"].extra.raw_info.name, email: env["omniauth.auth"].extra.raw_info.email)
       end
     end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -9,7 +9,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       # If they are, automatically create an account
       client = Octokit::Client.new(access_token: github_token)
       org_ids = client.organizations.map { |org| org.id.to_s }
-      if org_ids.include?(github_org_id)
+      if org_ids.include?(github_org_id.to_s)
         github_user = User.create(name: env["omniauth.auth"].extra.raw_info.name, email: env["omniauth.auth"].extra.raw_info.email)
       end
     end


### PR DESCRIPTION
The user's organization ids are converted to String, but the configuration value `Errbit::Config.github_org_id` is always an Integer. They can't possibly match.

Unifying value types make this work.