### PR TITLE
Don't link and copy old config files

### DIFF
--- a/config/deploy.example.rb
+++ b/config/deploy.example.rb
@@ -20,8 +20,6 @@ set :ssh_options, forward_agent: true
 
 set :linked_files, fetch(:linked_files, []) + %w(
   .env
-  config/config.yml
-  config/mongoid.yml
   config/newrelic.yml
 )
 
@@ -42,8 +40,6 @@ namespace :errbit do
     on roles(:app) do
       execute "mkdir -p #{shared_path}/config"
       {
-        'config/config.example.yml' => 'config/config.yml',
-        'config/mongoid.example.yml' => 'config/mongoid.yml',
         'config/newrelic.example.yml' => 'config/newrelic.yml'
       }.each do |src, target|
         execute "if [ ! -f #{shared_path}/#{target} ]; then cp #{current_path}/#{src} #{shared_path}/#{target}; fi"


### PR DESCRIPTION
[This change](427ab3b0a0f9a03c60bb019dc1be28793a284bc4) is really great and is a huge simplification of the deployment/configuration process.

Although, the `config/deploy.example.rb` still mention the copy and linking of `config.yml` and `mongoid.yml`

I've removed them in my `config/deploy.rb` and it works.