### PR TITLE
Asynchronous problem sending notifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,13 @@ gem 'httparty'
 # Flowdock
 gem 'flowdock'
 
+# Asynchronous JOB
+# ---------------------------------------
+gem 'sidekiq', '~> 3.2.6'
+gem 'sinatra', require: false
+gem 'slim'
+gem 'sidekiq-failures'
+
 # Authentication
 # ---------------------------------------
 # GitHub OAuth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    celluloid (0.15.2)
+      timers (~> 1.1.0)
     cliver (0.3.2)
     coderay (1.0.9)
     coffee-rails (4.1.0)
@@ -262,6 +264,8 @@ GEM
     rack (1.5.2)
     rack-contrib (1.1.0)
       rack (>= 0.9.1)
+    rack-protection (1.5.3)
+      rack
     rack-ssl (1.4.0)
       rack
     rack-ssl-enforcer (0.2.6)
@@ -293,6 +297,9 @@ GEM
     rake (10.4.2)
     rdoc (4.1.2)
       json (~> 1.4)
+    redis (3.2.0)
+    redis-namespace (1.5.1)
+      redis (~> 3.0, >= 3.0.4)
     request_store (1.1.0)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
@@ -340,10 +347,25 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
+    sidekiq (3.2.6)
+      celluloid (= 0.15.2)
+      connection_pool (>= 2.0.0)
+      json
+      redis (>= 3.0.6)
+      redis-namespace (>= 1.3.1)
+    sidekiq-failures (0.4.3)
+      sidekiq (>= 2.16.0)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slim (3.0.1)
+      temple (~> 0.7.3)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.4.6)
     spoon (0.0.4)
       ffi
@@ -360,6 +382,7 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    temple (0.7.5)
     term-ansicolor (1.2.2)
       tins (~> 0.8)
     test-unit (3.0.8)
@@ -369,6 +392,7 @@ GEM
     thread_safe (0.3.4-java)
     tilt (1.4.1)
     timecop (0.6.3)
+    timers (1.1.0)
     tins (0.12.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -456,6 +480,10 @@ DEPENDENCIES
   rspec-rails (~> 3.0)
   rushover
   sass-rails
+  sidekiq (~> 3.2.6)
+  sidekiq-failures
+  sinatra
+  slim
   test-unit
   timecop
   uglifier

--- a/app/workers/problem_worker.rb
+++ b/app/workers/problem_worker.rb
@@ -1,0 +1,12 @@
+class ProblemWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: 'problems'
+
+  def perform(problem_id)
+    # Find problem
+    problem = Problem.find problem_id
+
+    # Send problem via notification service
+    problem.app.notification_service.create_notification(problem)
+  end
+end

--- a/config/load.rb
+++ b/config/load.rb
@@ -36,6 +36,11 @@ Errbit::Config = Configurator.run({
 
   email_delivery_method:     ['EMAIL_DELIVERY_METHOD'],
 
+  # Sidekiq authorization
+  notify_async:              ['NOTIFY_ASYNC'],
+  sidekiq_username:          ['SIDEKIQ_USERNAME'],
+  sidekiq_password:          ['SIDEKIQ_PASSWORD'],
+
   # smtp settings
   smtp_address:              ['SMTP_SERVER'],
   smtp_port:                 ['SMTP_PORT'],

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,15 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
 
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
+
+  # Sidekiq authorization
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    username == Errbit::Config.sidekiq_username && password == Errbit::Config.sidekiq_password
+  end if Rails.env.production?
+
+  mount Sidekiq::Web, at: "/sidekiq"
 
   # Hoptoad Notifier Routes
   match '/notifier_api/v2/notices' => 'notices#create', via: [:get, :post]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,10 @@ require 'xmpp4r/muc'
 require 'mongoid-rspec'
 require 'fabrication'
 require 'errbit_plugin/mock_issue_tracker'
+require 'sidekiq/testing'
+
+# Starts faking sidekiq jobs
+Sidekiq::Testing.fake!
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
@@ -40,6 +44,7 @@ RSpec.configure do |config|
   config.before(:each) do
     DatabaseCleaner[:mongoid].strategy = :truncation
     DatabaseCleaner.clean
+    Sidekiq::Worker.clear_all
   end
 
   config.include Haml, type: :helper

--- a/spec/workers/problem_worker_spec.rb
+++ b/spec/workers/problem_worker_spec.rb
@@ -1,0 +1,19 @@
+describe ProblemWorker, type: 'model' do
+  let(:app) { Fabricate(:app, :email_at_notices => [1], :notification_service => Fabricate(:campfire_notification_service))}
+  let(:err) { Fabricate(:err, :problem => Fabricate(:problem, :app => app, :notices_count => 100)) }
+  let(:backtrace) { Fabricate(:backtrace) }
+
+  it 'should call create notification on problem notification service' do
+    # Because the worker is looking for problem again by find method
+    # it's required to stub notification service method
+    campy = double('CampfireService')
+    allow(Campy::Room).to receive(:new).and_return(campy)
+    allow(campy).to receive(:speak).and_return(true)
+
+    # assert
+    expect(campy).to receive(:speak)
+
+    # Send a problem
+    ProblemWorker.new.perform(err.problem.id)
+  end
+end


### PR DESCRIPTION
We face one simple problem, our monitored application are depend to other services (for example SSO services, database clusters or other services). We have quite big amount of users, so if the depending service is accidentally down our errbit server is overloaded with requests (it seems in most case puma forks are waiting to notification service IO, http requests), actually we need to know about unavailability 3rd party services (so thats why we can't blacklist Timeout or Net errors in Rails applications) and we also require accepting other errors from applications. Using sidekiq with delay queue can be a quite nice solution to speed-up api responses.