### PR TITLE
783 allow custom issue tracker templates

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -61,10 +61,9 @@ class ProblemsController < ApplicationController
   end
 
   def create_issue
-    body = render_to_string "issue_trackers/issue", layout: false, formats: [:md]
-    title = "[#{ problem.environment }][#{ problem.where }] #{problem.message.to_s.truncate(100)}"
+    issue = Issue.new(problem: problem, user: current_user)
+    issue.body = render_to_string(*issue.render_body_args)
 
-    issue = Issue.new(problem: problem, user: current_user, title: title, body: body)
     unless issue.save
       flash[:error] = issue.errors.full_messages.join(', ')
     end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -1,33 +1,41 @@
 class Issue
   include ActiveModel::Model
-  attr_accessor :problem, :user, :title, :body
+  attr_accessor :problem, :user, :body
 
   def issue_tracker
-    problem.app.issue_tracker
+    @issue_tracker ||= problem.app.issue_tracker
+  end
+
+  def tracker
+    @tracker ||= issue_tracker && issue_tracker.tracker
+  end
+
+  def render_body_args
+    if tracker.respond_to?(:render_body_args)
+      tracker.render_body_args
+    else
+      [ 'issue_trackers/issue', formats: [:md] ]
+    end
+  end
+
+  def title
+    if tracker.respond_to?(:title)
+      tracker.title
+    else
+      "[#{ problem.environment }][#{ problem.where }] #{problem.message.to_s.truncate(100)}"
+    end
   end
 
   def save
-    unless body
-      errors.add :base, "The issue has no body"
-      return false
-    end
+    errors.add :base, "The issue has no body" unless body
+    errors.add :base, "This app has no issue tracker" unless issue_tracker
+    return false if errors.present?
 
-    unless title
-      errors.add :base, "The issue has no title"
-      return false
-    end
+    tracker.errors.each { |k, err| errors.add k, err }
+    return false if errors.present?
 
-    if issue_tracker
-      issue_tracker.tracker.errors.each do |k, err|
-        errors.add k, err
-      end
-      return false if errors.present?
-
-      url = issue_tracker.create_issue(title, body, user: user.as_document)
-      problem.update_attributes(issue_link: url, issue_type: issue_tracker.tracker.class.label)
-    else
-      errors.add :base, "This app has no issue tracker setup."
-    end
+    url = issue_tracker.create_issue(title, body, user: user.as_document)
+    problem.update_attributes(issue_link: url, issue_type: tracker.class.label)
 
     errors.empty?
   rescue => ex

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -290,7 +290,6 @@ describe ProblemsController, type: 'controller' do
         expect(problem.issue_type).to eq("mock")
       end
 
-
       context "when rendering views" do
         render_views
 
@@ -299,6 +298,14 @@ describe ProblemsController, type: 'controller' do
           line = issue_tracker.tracker.output.shift
           expect(line[1]).to include(app_problem_url problem.app, problem)
         end
+
+        it "should render whatever the issue tracker says" do
+          allow_any_instance_of(Issue).to receive(:render_body_args).and_return(
+            [{ :inline => 'one <%= problem.id %> two' }])
+          post :create_issue, app_id: problem.app.id, id: problem.id, format: 'html'
+          line = issue_tracker.tracker.output.shift
+          expect(line[1]).to eq("one #{problem.id} two")
+        end
       end
     end
 
@@ -306,7 +313,7 @@ describe ProblemsController, type: 'controller' do
       it "should redirect to problem page" do
         post :create_issue, app_id: problem.app.id, id: problem.id
         expect(response).to redirect_to( app_problem_path(problem.app, problem) )
-        expect(flash[:error]).to eql "This app has no issue tracker setup."
+        expect(flash[:error]).to eql "This app has no issue tracker"
       end
     end
   end


### PR DESCRIPTION
For #783: Allow issue trackers to implement their own titles and bodies while preserving sane defaults