### PR TITLE
remove foreman

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,7 +75,6 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller', platform: 'ruby'
   gem 'meta_request'
-  gem 'foreman', :require => false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,9 +136,6 @@ GEM
     flowdock (0.3.1)
       httparty (~> 0.7)
       multi_json
-    foreman (0.77.0)
-      dotenv (~> 1.0.2)
-      thor (~> 0.19.1)
     haml (4.0.3)
       tilt
     hashie (2.0.5)
@@ -420,7 +417,6 @@ DEPENDENCIES
   errbit_plugin!
   fabrication
   flowdock
-  foreman
   haml
   hipchat
   hoi


### PR DESCRIPTION
[foreman](https://github.com/ddollar/foreman) says it should not be in Gemfile

> Ruby users should take care not to install foreman in their project's Gemfile.