### PR TITLE
use dotenv-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'draper'
 gem 'errbit_plugin', github: 'errbit/errbit_plugin'
 gem 'errbit_github_plugin', github: 'errbit/errbit_github_plugin'
 
-gem 'dotenv-deployment'
+gem 'dotenv-rails'
 
 # Notification services
 # ---------------------------------------

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,9 +116,9 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
-    dotenv (1.0.2)
-    dotenv-deployment (0.2.0)
-      dotenv (~> 1.0)
+    dotenv (2.0.0)
+    dotenv-rails (2.0.0)
+      dotenv (= 2.0.0)
     draper (1.4.0)
       actionpack (>= 3.0)
       activemodel (>= 3.0)
@@ -410,7 +410,7 @@ DEPENDENCIES
   database_cleaner
   decent_exposure
   devise
-  dotenv-deployment
+  dotenv-rails
   draper
   email_spec
   errbit_github_plugin!


### PR DESCRIPTION
[dotenv-deployment](https://github.com/bkeepers/dotenv-deployment) is deprecated.

> This gem is deprecated and no longer maintained. Use dotenv-rails, or manually configure dotenv to meet your own needs.

Tested on my installation.