### PR TITLE
Fixing slack integration

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -24,4 +24,8 @@ class NotificationServices::SlackService < NotificationService
   def create_notification(problem)
     HTTParty.post(service_url, :body => post_payload(problem), :headers => { 'Content-Type' => 'application/json' })
   end
+
+  def configured?
+    service_url.present?
+  end
 end


### PR DESCRIPTION
https://github.com/errbit/errbit/commit/28e1148fd14c63b757bbdf7824fc174d236f49d2 changed SlackService notifier to rely only on the service_url, and no longer needing an api_token

This apparently broke the form for any newly created app, because a notifier was only considered `configured?` if the api_token was set, which is now impossible to do for slack

I wasn't really sure how to go about this, because I'm not very familiar with the codebase yet, but I just thought I'd push the fix I've made on my fork so this can be properly discussed