### PR TITLE
Be consistent by always using error(s).

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -78,7 +78,7 @@ class ProblemsController < ApplicationController
 
   def resolve
     problem.resolve!
-    flash[:success] = 'Great news everyone! The err has been resolved.'
+    flash[:success] = 'Great news everyone! The error has been resolved.'
     redirect_to :back
   rescue ActionController::RedirectBackError
     redirect_to app_path(app)

--- a/app/views/mailer/comment_notification.html.haml
+++ b/app/views/mailer/comment_notification.html.haml
@@ -13,7 +13,7 @@
                 %span.bold= @problem.environment
                 environment.
                 %br
-                This err has occurred #{pluralize @problem.notices_count, 'time'}.
+                This error has occurred #{pluralize @problem.notices_count, 'time'}.
               %p
                 = link_to("Click here to view the error and add a comment on Errbit", app_problem_url(@app, @problem), :class => "bold") << "."
 

--- a/app/views/mailer/comment_notification.text.erb
+++ b/app/views/mailer/comment_notification.text.erb
@@ -1,6 +1,6 @@
 <%= @user.name %> has just commented on an error that occurred in <%= @notice.environment_name %>: <%= raw(@notice.message) %>
 
-This err has occurred <%= pluralize @notice.problem.notices_count, 'time' %>. You should really look into it here:
+This error has occurred <%= pluralize @notice.problem.notices_count, 'time' %>. You should really look into it here:
 
   <%= app_problem_url(@app, @notice.problem) %>
 

--- a/app/views/mailer/err_notification.html.haml
+++ b/app/views/mailer/err_notification.html.haml
@@ -6,13 +6,13 @@
           %td.content(valign="top")
             %div
               %p
-                An err has just occurred in
+                An error has just occurred in
                 = link_to(@app.name, app_url(@app), :class => "bold") << ","
                 on the
                 %span.bold= @notice.environment_name
                 environment.
                 %br
-                This err has occurred #{pluralize @notice.problem.notices_count, 'time'}.
+                This error has occurred #{pluralize @notice.problem.notices_count, 'time'}.
               %p
                 = link_to("Click here to view the error on Errbit", app_problem_url(@app, @notice.problem), :class => "bold") << "."
 %tr

--- a/app/views/mailer/err_notification.text.erb
+++ b/app/views/mailer/err_notification.text.erb
@@ -1,6 +1,6 @@
-An err has just occurred in <%= @notice.environment_name %>: <%= raw(@notice.message) %>
+An error has just occurred in <%= @notice.environment_name %>: <%= raw(@notice.message) %>
 
-This err has occurred <%= pluralize @notice.problem.notices_count, 'time' %>. You should really look into it here:
+This error has occurred <%= pluralize @notice.problem.notices_count, 'time' %>. You should really look into it here:
 
   <%= app_problem_url(@app, @notice.problem) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,8 +12,8 @@ en:
         success: "'%{app_name}' was successfully destroyed."
 
   n_errs_have:
-    one:   "%{count} err has"
-    other: "%{count} errs have"
+    one:   "%{count} error has"
+    other: "%{count} errors have"
 
   layouts:
     application:
@@ -102,7 +102,7 @@ en:
       regenerate_api_key: "Regenerate API key"
     show:
       all_deploys: "All Deploys (%{count})"
-      all_errs: all errs
+      all_errs: all errors
       all_users_notified: "All users will be notified when something happens."
       api_key: "API Key:"
       are_you_sure: 'Are you sure?'
@@ -116,12 +116,12 @@ en:
       latest_deploys: Latest Deploys
       message: Message
       no_deploys:  No deploys
-      no_error_yet: "No errs have been caught yet, make sure you setup your app"
+      no_error_yet: "No errors have been caught yet, make sure you setup your app"
       no_watcher: "Sadly, no one is watching this app"
       repository: Repository
       revision: Revision
       show_hide: "(show/hide)"
-      unresolved_errs: unresolved errs
+      unresolved_errs: unresolved errors
       unwatch: unwatch
       user_or_email: User or Email
       watchers: Watchers

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -405,12 +405,12 @@ describe ProblemsController, type: 'controller' do
 
       it "should display a message about 1 err" do
         post :resolve_several, :problems => [@problem2.id.to_s]
-        expect(flash[:success]).to match(/1 err has been resolved/)
+        expect(flash[:success]).to match(/1 error has been resolved/)
       end
 
       it "should display a message about 2 errs" do
         post :resolve_several, :problems => [@problem1.id.to_s, @problem2.id.to_s]
-        expect(flash[:success]).to match(/2 errs have been resolved/)
+        expect(flash[:success]).to match(/2 errors have been resolved/)
         expect(controller.selected_problems).to eq [@problem1, @problem2]
       end
     end

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -92,7 +92,7 @@ describe Mailer do
     end
 
     it "should have the notices count in the body" do
-      expect(@email).to have_body_text("This err has occurred 2 times")
+      expect(@email).to have_body_text("This error has occurred 2 times")
     end
 
     it "should have the comment body" do

--- a/spec/views/apps/show.html.haml_spec.rb
+++ b/spec/views/apps/show.html.haml_spec.rb
@@ -17,14 +17,14 @@ describe "apps/show.html.haml", type: 'view' do
     it "should confirm the 'cancel' link" do
       render
 
-      expect(action_bar).to have_selector('a.button', :text => 'all errs')
+      expect(action_bar).to have_selector('a.button', :text => 'all errors')
     end
   end
 
   context "without errs" do
     it 'see no errs' do
       render
-      expect(rendered).to match(/No errs have been/)
+      expect(rendered).to match(/No errors have been/)
     end
   end
 


### PR DESCRIPTION
"Error(s)" and "Err(s)" where mixed up in the translations.