### PR TITLE
Add sparklines to graph recent occurrences of a problem

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -740,6 +740,26 @@ table.tally th.value {
   text-transform: none;
 }
 
+/* Sparklines */
+.spark {
+  position: relative;
+  border: 1px solid #ddd;
+  float: left;
+  padding: 1px;
+  margin: 0;
+  height: 30px;
+}
+
+.spark > i {
+  display: inline-block;
+  position: relative;
+  width: 10px;
+  background: black;
+  margin: 0;
+  padding: 0;
+  vertical-align: bottom;
+}
+
 /* Resolve Errs */
 #action-bar .resolve:before {
   font-family: FontAwesome;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,6 +54,32 @@ module ApplicationHelper
     collection.to_a[head_size..-1].to_a
   end
 
+  def sparkline(times, start_time, num_buckets = 10)
+    times = times.select {|time| time >= start_time }
+    buckets = bucketize(times, start_time, Time.now.to_i, num_buckets)
+    bars = buckets.map do |val|
+      percent = (val * 100.0).round(2).to_s + "%";
+      "<i style='height:#{percent}'></i>"
+    end.join()
+    "<div class='spark'>#{bars}</div>".html_safe
+  end
+
+  def bucketize(values, min, max, num_buckets)
+    get_min = lambda { |a,b| a > b ? b : a }
+    range = max - min
+    buckets = Array.new(num_buckets, 0)
+    values.each do |val|
+      normalized = (val - min) / range.to_f
+
+      # Use get_min() here because there will inevitably be one value == max
+      # which means normalized = 1 and bucket[1 * num_buckets] doesn't exist
+      bucket_index = get_min.call((normalized * num_buckets).floor, num_buckets-1)
+      buckets[bucket_index] += 1
+    end
+    max = buckets.max.to_f
+    return buckets.map {|count| count / max}
+  end
+
   def issue_tracker_types
     ErrbitPlugin::Registry.issue_trackers.map do |_, object|
       IssueTrackerTypeDecorator.new(object)

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -207,8 +207,15 @@ class Problem
 
     # recache each new problem
     new_problems.each(&:recache)
-
     new_problems
+  end
+
+  # Returns an array of unix epoc timestamps for the created_at field of
+  # all notices sincethe since parameter
+  def timestamps_since(since)
+    notices.where(:created_at.gte => since).
+    pluck(:created_at).
+    map {|created_at| created_at.to_time.to_i }
   end
 
   def self.ordered_by(sort, order)

--- a/app/views/notices/_summary.html.haml
+++ b/app/views/notices/_summary.html.haml
@@ -20,6 +20,13 @@
       %th= t('.similar')
       %td= problem.notices_count - 1
     %tr
+      - two_weeks = problem.timestamps_since(Time.now.to_i - 86400 * 14)
+      %th Graph (2w @ 12h)
+      %td= sparkline(two_weeks, Time.now.to_i - 86400*14, 28)
+    %tr
+      %th Graph (1d @ 1h)
+      %td= sparkline(two_weeks, Time.now.to_i - 86400, 24)
+    %tr
       %th= t('.browser')
       %td= user_agent_graph(problem)
     %tr

--- a/app/views/notices/_summary.html.haml
+++ b/app/views/notices/_summary.html.haml
@@ -21,10 +21,10 @@
       %td= problem.notices_count - 1
     %tr
       - two_weeks = problem.timestamps_since(Time.now.to_i - 86400 * 14)
-      %th Graph (2w @ 12h)
+      %th= t('.graph-2-weeks')
       %td= sparkline(two_weeks, Time.now.to_i - 86400*14, 28)
     %tr
-      %th Graph (1d @ 1h)
+      %th= t('.graph (24 hours)')
       %td= sparkline(two_weeks, Time.now.to_i - 86400, 24)
     %tr
       %th= t('.browser')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,8 @@ en:
       similar: Similar
       browser: Browser
       tenant: Origin
+      graph-2-weeks: Graph (2 weeks)
+      graph-24-hours: Graph (24 hours)
       app_server: App Server
       app_version: App Version
       framework: Framework


### PR DESCRIPTION
Now we include a sparkline of the timestamps from recent notices.
Two graphs give at-a-glance access to near and far history.

![image](https://cloud.githubusercontent.com/assets/26855/6877477/8b197632-d48e-11e4-84fd-4fa7ebbf1ace.png)
