### PR TITLE
Use asset pipeline logo in notifications

### DIFF
--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -10,7 +10,7 @@
         %tbody
           %tr
             %td.header
-              = link_to image_tag(URI.join(root_url,"assets/images/logo.png").to_s, :alt => "Errbit"), root_url
+              = link_to image_tag(URI.join(root_url, ActionController::Base.helpers.asset_path("images/logo.png")).to_s, :alt => "Errbit"), root_url
 
           = yield
 


### PR DESCRIPTION
This fixes issue #886 by using the correct fingerprinted logo asset.