### PR TITLE
errbit:setup creates tmp/pids

### DIFF
--- a/config/deploy.example.rb
+++ b/config/deploy.example.rb
@@ -41,7 +41,7 @@ namespace :errbit do
   task :setup do
     on roles(:app) do
       execute "mkdir -p #{shared_path}/config"
-      execute "mkdir -p #{shared_path}/pids"
+      execute "mkdir -p #{shared_path}/tmp/pids"
       execute "touch #{shared_path}/.env"
 
       {


### PR DESCRIPTION
Unicorn uses shared/tmp/pids instead of shared/pids