### PR TITLE
Set special password for using in Teatro

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,3 @@
+stage:
+  after_database:
+    - "bundle exec rails runner 'u=User.first; u.password=u.password_confirmation=\"TeatroTeatro\"; u.save!; puts \"Change admin password to: TeatroTeatro\"'"


### PR DESCRIPTION
This config changes admin's password to `TeatroTeatro` so Teatro can be used again :)