### PR TITLE
Support HipChat v2 API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,8 +130,9 @@ GEM
       tilt
     hashie (2.0.5)
     hike (1.2.3)
-    hipchat (0.12.0)
+    hipchat (1.5.1)
       httparty
+      mimemagic
     hoi (0.0.6)
       httparty (> 0.6.0)
       json (> 1.4.0)
@@ -139,7 +140,7 @@ GEM
       activesupport
       builder
     htmlentities (4.3.3)
-    httparty (0.13.3)
+    httparty (0.13.5)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     httpauth (0.2.0)
@@ -168,6 +169,7 @@ GEM
       railties
     method_source (0.8.2)
     mime-types (1.25.1)
+    mimemagic (0.3.0)
     mini_portile (0.6.2)
     minitest (5.5.1)
     mongoid (4.0.2)

--- a/app/models/notification_services/hipchat_service.rb
+++ b/app/models/notification_services/hipchat_service.rb
@@ -2,18 +2,34 @@ if defined? HipChat
   class NotificationServices::HipchatService < NotificationService
     Label = 'hipchat'
     Fields += [
+      [:service, {
+        :placeholder => "'v1' (admin API token) or 'v2' (account API token)",
+        :label       => "HipChat API version"
+      }],
+      [:service_url, {
+        :placeholder => "Optional, leave empty for HipChat.com",
+        :label       => "Custom HipChat Server URL"
+      }],
       [:api_token, {
-        :placeholder => "API Token"
+        :placeholder => "API token",
+        :label       => "API token"
       }],
       [:room_id, {
         :placeholder => "Room name",
         :label       => "Room name"
       }],
     ]
+    Mandatory_fields = [:service, :api_token, :room_id]
+    API_versions = ['v1', 'v2']
 
     def check_params
-      if Fields.any? { |f, _| self[f].blank? }
-        errors.add :base, 'You must specify your Hipchat API token and Room ID'
+      Fields.each do |field, hash|
+        if Mandatory_fields.include?(field) && self[field].blank?
+          errors.add field, "You must specify #{hash[:label]}"
+        end
+      end
+      unless API_versions.include?(self[:service])
+        errors.add :service, "API version must be #{API_versions.join(' or ')}"
       end
     end
 
@@ -29,7 +45,10 @@ if defined? HipChat
         &nbsp;&nbsp;Times occurred: #{problem.notices_count}
       MSG
 
-      client = HipChat::Client.new(api_token)
+      options = { :api_version => self[:service] }
+      options[:server_url] = self[:service_url] if service_url.present?
+
+      client = HipChat::Client.new(api_token, options)
       client[room_id].send('Errbit', message, :color => 'red', :notify => true)
     end
   end

--- a/db/migrate/20150527202629_add_v1_to_hipchat_notification_services.rb
+++ b/db/migrate/20150527202629_add_v1_to_hipchat_notification_services.rb
@@ -1,0 +1,13 @@
+class AddV1ToHipchatNotificationServices < Mongoid::Migration
+  def self.up
+    App.all.each do |app|
+      ns = app.notification_service
+      if ns.is_a?(NotificationServices::HipchatService) && ns.service.blank?
+        app.notification_service.update_attribute(:service, 'v1')
+      end
+    end
+  end
+
+  def self.down
+  end
+end

--- a/spec/fabricators/notification_service_fabricator.rb
+++ b/spec/fabricators/notification_service_fabricator.rb
@@ -16,6 +16,10 @@ Fabricator :slack_notification_service, :from => :notification_service, :class_n
   service_url { sequence :word }
 end
 
-%w(campfire flowdock hipchat hoiio hubot pushover webhook).each do |t|
+Fabricator :hipchat_notification_service, :from => :notification_service, :class_name => "NotificationService::HipchatService" do
+  service { 'v2' }
+end
+
+%w(campfire flowdock hoiio hubot pushover webhook).each do |t|
   Fabricator "#{t}_notification_service".to_sym, :from => :notification_service, :class_name => "NotificationService::#{t.camelcase}Service"
 end

--- a/spec/models/notification_service/hipchat_service_spec.rb
+++ b/spec/models/notification_service/hipchat_service_spec.rb
@@ -7,6 +7,34 @@ describe NotificationServices::HipchatService, type: 'model' do
     allow_any_instance_of(HipChat::Client).to receive(:[]).and_return(room)
   end
 
+  describe '#check_params' do
+    context 'empty field check' do
+      %w(service api_token room_id).each do |field|
+        it "'doesn\'t allow #{field} to be empty'" do
+          service[field.to_sym] = ''
+          service.check_params
+          expect(service.errors).to include(field.to_sym)
+        end
+      end
+    end
+
+    context 'API version field check' do
+      %w(v1 v2).each do |version|
+        it "allows #{version}" do
+          service[:service] = version
+          service.check_params
+          expect(service.errors).to_not include(:service)
+        end
+      end
+
+      it 'doesn\t allow an unknown version' do
+        service[:service] = 'vFOO'
+        service.check_params
+        expect(service.errors).to include(:service)
+      end
+    end
+  end
+
   it 'sends message' do
     expect(room).to receive(:send)
     service.create_notification(problem)


### PR DESCRIPTION
HipChat has a [new API](https://www.hipchat.com/docs/apiv2) for a while now, and the new API allows users to use their own API token instead of requiring an administrator to generate one for them. V2 is also the only available API version for people running their own HipChat server.

This PR updates the HipChat gem, uses a migration to set already configured HipChat notifications to v1, and allows users to switch to v2 at their own pace.