### PR TITLE
Fix a bug during deploy [assets:precompile]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ group :heroku, :production do
   gem 'unicorn', require: false, platform: 'ruby'
 end
 
+gem 'therubyracer', :platform => :ruby  # C Ruby (MRI) or Rubinius, but NOT Windows
 gem 'sass-rails'
 gem 'coffee-rails'
 gem 'uglifier'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,7 @@ GEM
     launchy (2.4.3-java)
       addressable (~> 2.3)
       spoon (~> 0.0.1)
+    libv8 (3.16.14.7)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     meta_request (0.2.8)
@@ -280,6 +281,7 @@ GEM
     rake (10.4.2)
     rdoc (4.1.2)
       json (~> 1.4)
+    ref (1.0.5)
     request_store (1.1.0)
     responders (1.1.2)
       railties (>= 3.2, < 4.2)
@@ -351,6 +353,9 @@ GEM
       tins (~> 0.8)
     test-unit (3.0.8)
       power_assert
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.4)
     thread_safe (0.3.4-java)
@@ -443,6 +448,7 @@ DEPENDENCIES
   rushover
   sass-rails
   test-unit
+  therubyracer
   timecop
   uglifier
   underscore-rails


### PR DESCRIPTION
Hi. During deployment Errbit I get the following error:
```
INFO [0a491011] Running ~/.rbenv/bin/rbenv exec bundle exec rake assets:precompile as deploy@server.dev
DEBUG [0a491011] Command: cd /home/deploy/errbit/releases/20150529161719 && ( RBENV_ROOT=~/.rbenv RBENV_VERSION=2.2.2 RAILS_ENV=production ~/.rbenv/bin/rbenv exec bundle exec rake assets:precompile )
DEBUG [0a491011]        rake aborted!
DEBUG [0a491011]        ExecJS::RuntimeUnavailable: Could not find a JavaScript runtime. See https://github.com/sstephenson/execjs for a list of available runtimes.
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/execjs-2.0.2/lib/execjs/runtimes.rb:51:in `autodetect'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/execjs-2.0.2/lib/execjs.rb:5:in `<module:ExecJS>'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/execjs-2.0.2/lib/execjs.rb:4:in `<top (required)>'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `block in require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:232:in `load_dependency'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/coffee-script-2.3.0/lib/coffee_script.rb:1:in `<top (required)>'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `block in require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:232:in `load_dependency'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/coffee-script-2.3.0/lib/coffee-script.rb:1:in `<top (required)>'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `block in require'
DEBUG [0a491011]
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:232:in `load_dependency'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247:in `require'
DEBUG [0a491011]        /home/deploy/errbit/shared/bundle/ruby/2.2.0/gems/coffee-rails-4.1.0/lib/coffee-rails.rb:1:in `<top (required)>'
DEBUG [0a491011]        /home/deploy/errbit/releases/20150529161719/config/application.rb:10:in `<top (required)>'
DEBUG [0a491011]        /home/deploy/errbit/releases/20150529161719/Rakefile:4:in `require'
DEBUG [0a491011]        /home/deploy/errbit/releases/20150529161719/Rakefile:4:in `<top (required)>'
DEBUG [0a491011]        (See full trace by running task with --trace)
```

To fix this, need to add gem `therubyracer` into Gemfile.