### PR TITLE
Security update: Rails 4.1.11 release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-RAILS_VERSION = '~> 4.1.8'
+RAILS_VERSION = '~> 4.1.11'
 
 send :ruby, ENV['GEMFILE_RUBY_VERSION'] if ENV['GEMFILE_RUBY_VERSION']
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,8 +318,8 @@ GEM
     rushover (0.3.0)
       json
       rest-client
-    sass (3.4.9)
-    sass-rails (5.0.1)
+    sass (3.4.14)
+    sass-rails (5.0.3)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,31 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.1.8)
-      actionpack (= 4.1.8)
-      actionview (= 4.1.8)
+    actionmailer (4.1.11)
+      actionpack (= 4.1.11)
+      actionview (= 4.1.11)
       mail (~> 2.5, >= 2.5.4)
     actionmailer_inline_css (1.5.3)
       actionmailer (>= 3.0.0)
       nokogiri (>= 1.4.4)
       premailer (>= 1.7.1)
-    actionpack (4.1.8)
-      actionview (= 4.1.8)
-      activesupport (= 4.1.8)
+    actionpack (4.1.11)
+      actionview (= 4.1.11)
+      activesupport (= 4.1.11)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.8)
-      activesupport (= 4.1.8)
+    actionview (4.1.11)
+      activesupport (= 4.1.11)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-    activemodel (4.1.8)
-      activesupport (= 4.1.8)
+    activemodel (4.1.11)
+      activesupport (= 4.1.11)
       builder (~> 3.1)
-    activerecord (4.1.8)
-      activemodel (= 4.1.8)
-      activesupport (= 4.1.8)
+    activerecord (4.1.11)
+      activemodel (= 4.1.11)
+      activesupport (= 4.1.11)
       arel (~> 5.0.0)
-    activesupport (4.1.8)
+    activesupport (4.1.11)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -129,7 +129,6 @@ GEM
     haml (4.0.3)
       tilt
     hashie (2.0.5)
-    hike (1.2.3)
     hipchat (1.5.1)
       httparty
       mimemagic
@@ -148,8 +147,8 @@ GEM
     jquery-rails (2.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
-    json (1.8.2)
-    json (1.8.2-java)
+    json (1.8.3)
+    json (1.8.3-java)
     jwt (0.1.8)
       multi_json (>= 1.5)
     kaminari (0.14.1)
@@ -172,7 +171,7 @@ GEM
     mime-types (1.25.1)
     mimemagic (0.3.0)
     mini_portile (0.6.2)
-    minitest (5.5.1)
+    minitest (5.7.0)
     mongoid (4.0.2)
       activemodel (~> 4.0)
       moped (~> 2.0.0)
@@ -191,7 +190,7 @@ GEM
       bson (~> 2.2)
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
-    multi_json (1.10.1)
+    multi_json (1.11.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -247,7 +246,7 @@ GEM
       pry (>= 0.9.10)
     quiet_assets (1.0.2)
       railties (>= 3.1, < 5.0)
-    rack (1.5.2)
+    rack (1.5.4)
     rack-contrib (1.1.0)
       rack (>= 0.9.1)
     rack-ssl (1.4.0)
@@ -255,15 +254,15 @@ GEM
     rack-ssl-enforcer (0.2.6)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.1.8)
-      actionmailer (= 4.1.8)
-      actionpack (= 4.1.8)
-      actionview (= 4.1.8)
-      activemodel (= 4.1.8)
-      activerecord (= 4.1.8)
-      activesupport (= 4.1.8)
+    rails (4.1.11)
+      actionmailer (= 4.1.11)
+      actionpack (= 4.1.11)
+      actionview (= 4.1.11)
+      activemodel (= 4.1.11)
+      activerecord (= 4.1.11)
+      activesupport (= 4.1.11)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.1.8)
+      railties (= 4.1.11)
       sprockets-rails (~> 2.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
@@ -272,9 +271,9 @@ GEM
       rails (> 3.1)
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.3)
-    railties (4.1.8)
-      actionpack (= 4.1.8)
-      activesupport (= 4.1.8)
+    railties (4.1.11)
+      actionpack (= 4.1.11)
+      activesupport (= 4.1.11)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     raindrops (0.13.0)
@@ -336,12 +335,9 @@ GEM
     slop (3.4.6)
     spoon (0.0.4)
       ffi
-    sprockets (2.12.3)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
+    sprockets (3.2.0)
       rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.2.2)
+    sprockets-rails (2.3.1)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
@@ -357,8 +353,8 @@ GEM
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
-    thread_safe (0.3.4)
-    thread_safe (0.3.4-java)
+    thread_safe (0.3.5)
+    thread_safe (0.3.5-java)
     tilt (1.4.1)
     timecop (0.6.3)
     tins (0.12.0)
@@ -390,9 +386,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionmailer (~> 4.1.8)
+  actionmailer (~> 4.1.11)
   actionmailer_inline_css
-  actionpack (~> 4.1.8)
+  actionpack (~> 4.1.11)
   airbrake
   better_errors
   binding_of_caller
@@ -439,7 +435,7 @@ DEPENDENCIES
   rack-ssl-enforcer
   rails_12factor
   rails_autolink
-  railties (~> 4.1.8)
+  railties (~> 4.1.11)
   ri_cal
   rspec
   rspec-activemodel-mocks
@@ -456,3 +452,6 @@ DEPENDENCIES
   useragent
   xmpp4r
   yajl-ruby
+
+BUNDLED WITH
+   1.10.3


### PR DESCRIPTION
Release notes: http://weblog.rubyonrails.org/2015/6/16/Rails-3-2-22-4-1-11-and-4-2-2-have-been-released-and-more/

Security alerts at https://gemnasium.com/errbit/errbit/alerts