### PR TITLE
Fixed notice parsing error when request['url'] is 'file:///...'

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -74,7 +74,7 @@ class Notice
 
   def host
     uri = url && URI.parse(url)
-    uri.blank? ? "N/A" : uri.host
+    uri && uri.host || "N/A"
   rescue URI::InvalidURIError
     "N/A"
   end

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -89,6 +89,11 @@ describe Notice, type: 'model' do
     end
 
     it "returns 'N/A' when url is not valid" do
+      notice = Fabricate.build(:notice, :request => {'url' => "file:///path/to/some/resource/12"})
+      expect(notice.host).to eq 'N/A'
+    end
+
+    it "returns 'N/A' when url is not valid" do
       notice = Fabricate.build(:notice, :request => {'url' => "some string"})
       expect(notice.host).to eq 'N/A'
     end


### PR DESCRIPTION
This PR fixes a problem when error reports with file URIs are submitted.

E.g. in cases where reports are submitted from our Cordova apps and

    request['url'] = "file:///path/to/some/resource"

then

    URI.parse(request['url']).host == nil

However, `Notice#host` is expected to always return a string (a hostname or "N/A"). When "file:///..." URIs are used `Notice#host` is returning nil and breaking Errbit code (e.g. in app/models/problem.rb#85). This PR fixes that.

Note, I've simplified the fix to the following code:

    uri && uri.host || "N/A"

but it could also be written as 

    (uri.blank? or uri.host.blank?) ? "N/A" : uri.host

in keeping with the original form. Up to you.

New test added and all tests passing.