### PR TITLE
fix Bitbucket file URL

### DIFF
--- a/app/decorators/backtrace_line_decorator.rb
+++ b/app/decorators/backtrace_line_decorator.rb
@@ -76,7 +76,7 @@ class BacktraceLineDecorator < Draper::Decorator
 
   def link_to_bitbucket(app, text = nil)
     return unless app.bitbucket_repo?
-    href = "%s#cl-%s" % [app.bitbucket_url_to_file(decorated_path + file_name), number]
+    href = "%s#%s-%s" % [app.bitbucket_url_to_file(decorated_path + file_name), file_name, number]
     h.link_to(text || file_name, href, :target => '_blank')
   end
 

--- a/app/helpers/backtrace_line_helper.rb
+++ b/app/helpers/backtrace_line_helper.rb
@@ -33,7 +33,7 @@ module BacktraceLineHelper
 
   def link_to_bitbucket(line, app, text = nil)
     return unless app.bitbucket_repo?
-    href = "%s#cl-%s" % [app.bitbucket_url_to_file(line.decorated_path + line.file_name), line.number]
+    href = "%s#%s-%s" % [app.bitbucket_url_to_file(line.decorated_path + line.file_name), line.file_name, line.number]
     link_to(text || line.file_name, href, :target => '_blank')
   end
 


### PR DESCRIPTION
Hi,

Bitbucket URLs have changed, here is a fix.
I've tried to upgrade `spec/helpers/backtrace_line_helper.rb` but:
* it seems to be ignored
* when I rename it to `spec/helpers/backtrace_line_helper_spec.rb` the current spec fails with
```
Failure/Error: Fabricate.build(:backtrace_line, :file => "[PROJECT_ROOT]/path/to/asset.js")
     Fabrication::UnknownFabricatorError:
       No Fabricator defined for 'backtrace_line'
```

If you want me to fill this spec, please fix current spec and I'll be happy to upgrade it.
