### PR TITLE
Use Ruby 2.2.3 by default for Heroku deployment

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/errbit/errbit",
   "env": {
     "ERRBIT_ENFORCE_SSL": "true",
-    "GEMFILE_RUBY_VERSION": "2.2.0",
+    "GEMFILE_RUBY_VERSION": "2.2.3",
     "SECRET_KEY_BASE": {
       "generator": "secret"
     }


### PR DESCRIPTION
Ruby 2.2.3 is the latest release of Ruby.