### PR TITLE
Fix bitbucket link to bitbucket source.

### DIFF
--- a/app/decorators/backtrace_line_decorator.rb
+++ b/app/decorators/backtrace_line_decorator.rb
@@ -78,7 +78,7 @@ class BacktraceLineDecorator < Draper::Decorator
 
   def link_to_bitbucket(app, text = nil)
     return unless app.bitbucket_repo?
-    href = "%s#cl-%s" % [app.bitbucket_url_to_file(decorated_path + file_name), number]
+    href = "%s#%s-%s" % [app.bitbucket_url_to_file(decorated_path + file_name), file_name , number]
     h.link_to(text || file_name, href, :target => '_blank')
   end
 


### PR DESCRIPTION
Bitbucket has a new url schema for linking to files that is slightly more verbose and allows for selection of ranges. 

This simple restores previous behavior. 

See https://bitbucket.org/site/master/issues/10622/url-link-to-multiple-lines-with-cl-xx-yy