### PR TITLE
cache app on notice

### DIFF
--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -65,6 +65,7 @@ class ErrorReport
 
   def make_notice
     @notice = Notice.new(
+      app: app,
       message: message,
       error_class: error_class,
       backtrace: backtrace,

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -12,8 +12,9 @@ class Notice
   field :framework
   field :error_class
   delegate :lines, :to => :backtrace, :prefix => true
-  delegate :app, :problem, :to => :err
+  delegate :problem, :to => :err
 
+  belongs_to :app
   belongs_to :err
   belongs_to :backtrace, :index => true
 

--- a/db/migrate/20150926035420_cache_app_on_notice.rb
+++ b/db/migrate/20150926035420_cache_app_on_notice.rb
@@ -1,0 +1,11 @@
+class CacheAppOnNotice < Mongoid::Migration
+  def self.up
+    Notice.no_timeout.each do |n|
+      n.app_id = n.try(:err).try(:problem).try(:app_id)
+      n.save!
+    end
+  end
+
+  def self.down
+  end
+end

--- a/spec/fabricators/err_fabricator.rb
+++ b/spec/fabricators/err_fabricator.rb
@@ -4,6 +4,7 @@ Fabricator :err do
 end
 
 Fabricator :notice do
+  app
   err
   message             'FooError: Too Much Bar'
   backtrace


### PR DESCRIPTION
Notices always have an app API key when they arrive at Errbit, so it
makes sense to cache the app id onto the notice object. This will allow
for more efficient refingerprinting and reporting down the road.