### PR TITLE
Add airbrake json api url routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
   end
 
   match '/api/v3/projects/:project_id/create-notice' => 'api/v3/notices#create', via: [:post]
+  match '/api/v3/projects/:project_id/notices' => 'api/v3/notices#create', via: [:post]
 
   root :to => 'apps#index'
 end


### PR DESCRIPTION
https://github.com/errbit/errbit/commit/6a233224beeb6f7882f488cbfc41a2858f8f00bb#diff-21497849d8f00507c9c8dcaf6288b136L63

This commit changes errbit json api endoint, but Airbrake's json api is yet `notices` not `create-notice`.

so, it is necessary to accept old(?) api endpoint of Airbrake.