### PR TITLE
Fixed line break typo causing Heroku to crash

### DIFF
--- a/app/controllers/site_config_controller.rb
+++ b/app/controllers/site_config_controller.rb
@@ -12,16 +12,18 @@ class SiteConfigController < ApplicationController
     redirect_to action: :index
   end
 
-  private def filtered_update_params
-    params
-      .require(:site_config)
-      .require(:notice_fingerprinter_attributes)
-      .permit(
-        :error_class,
-        :message,
-        :backtrace_lines,
-        :component,
-        :action,
-        :environment_name)
-  end
+  private
+
+    def filtered_update_params
+      params
+        .require(:site_config)
+        .require(:notice_fingerprinter_attributes)
+        .permit(
+          :error_class,
+          :message,
+          :backtrace_lines,
+          :component,
+          :action,
+          :environment_name)
+    end
 end


### PR DESCRIPTION
Had this error on Heroku after today's update:
```
/app/app/controllers/site_config_controller.rb:15:in `private': nil is not a symbol (TypeError)
```

Any idea why I'm the only one with this issue ? Adding a line break after `private` fixed the issue.