### PR TITLE
RSpec: run in random order

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--order random

--- a/spec/models/notification_service/notification_service_spec.rb
+++ b/spec/models/notification_service/notification_service_spec.rb
@@ -9,7 +9,7 @@ describe NotificationServices, type: 'model' do
   end
 
   it "it should use the protocol value specified in the config in #problem_url" do
-    Errbit::Config.protocol = 'https'
+    allow(Errbit::Config).to receive(:protocol).and_return('https')
     expect(notification_service.problem_url(problem)).to start_with 'https://'
   end
 end


### PR DESCRIPTION
This is usually a good way to ferret out state leaking from one test to another, making the tests frustrating to work with. Fortunately it seems like everything is in pretty good order. 

I've been running this in a console locally for a while:
```
 while (true) { bundle exec rspec --order random || say "failed once" }
```
Looks good so far. 

If this passes on Travis I'll push an update to use a random test ordering each time, and not a fixed seed like now.