### PR TITLE
incompatible ruby version error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,14 @@ RAILS_VERSION = '~> 4.2.0'
 
 send :ruby, ENV['GEMFILE_RUBY_VERSION'] if ENV['GEMFILE_RUBY_VERSION']
 
+detected_ruby_version = Gem::Version.new(RUBY_VERSION.dup)
+required_ruby_version = Gem::Version.new('2.1.0') # minimum supported version
+
+if detected_ruby_version < required_ruby_version
+  fail RuntimeError, "RUBY_VERSION must be at least #{required_ruby_version}" \
+                     ", detected RUBY_VERSION #{RUBY_VERSION}"
+end
+
 gem 'actionmailer', RAILS_VERSION
 gem 'actionpack', RAILS_VERSION
 gem 'railties', RAILS_VERSION


### PR DESCRIPTION
Some users are reporting errors due to incompatible ruby versions. This
commit aims to provide users with a helpful error message so they can
more easily spot the issue.