### PR TITLE
Remove test-unit to avoid 'invalid option' message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,6 @@ group :test do
   gem 'launchy'
   gem 'email_spec'
   gem 'timecop'
-  gem 'test-unit', require: 'test/unit'
   gem 'coveralls', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,6 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    power_assert (0.2.3)
     powerpack (0.1.1)
     premailer (1.8.4)
       css_parser (>= 1.3.6)
@@ -379,8 +378,6 @@ GEM
       net-ssh (>= 2.8.0)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    test-unit (3.1.2)
-      power_assert
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -478,7 +475,6 @@ DEPENDENCIES
   rubocop
   rushover
   sass-rails
-  test-unit
   therubyracer
   timecop
   uglifier


### PR DESCRIPTION
The Test::Unit runner will attempt to parse options that are meant for RSpec. See https://github.com/rspec/rspec-rails/issues/1343 for details.

This makes `bundle exec rake` work.