### PR TITLE
fixed button 'show/hide resolved' on errors#index page

### DIFF
--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -91,7 +91,7 @@
 - if app.problems.any?
   %h3.clear=t('.errors')
   %section
-    = render 'problems/search', :all_errs => @all_errs, :app_id => app.id
+    = render 'problems/search', :all_errs => all_errs, :app_id => app.id
   %br
   %section
     .problem_table{:id => 'problem_table'}

--- a/app/views/problems/index.html.haml
+++ b/app/views/problems/index.html.haml
@@ -1,15 +1,15 @@
-- content_for :title, @all_errs ? 'All Errors' : 'Unresolved Errors'
+- content_for :title, all_errs ? 'All Errors' : 'Unresolved Errors'
 - content_for :head do
   = auto_discovery_link_tag :atom, problems_path(User.token_authentication_key => current_user.authentication_token, :format => "atom"), :title => "Errbit notices at #{request.host}"
 
 - content_for :action_bar do
-  - if @all_errs
+  - if all_errs
     = link_to 'hide resolved', problems_path, :class => 'button'
   - else
     = link_to 'show resolved', problems_path(:all_errs => true), :class => 'button'
 
 %section
-  = render 'problems/search', :all_errs => @all_errs, :app_id => nil
+  = render 'problems/search', :all_errs => all_errs, :app_id => nil
 %br
 %section
   #problem_table.problem_table

--- a/spec/views/problems/index.html.haml_spec.rb
+++ b/spec/views/problems/index.html.haml_spec.rb
@@ -4,6 +4,7 @@ describe "problems/index.html.haml", type: 'view' do
 
   before do
     allow(view).to receive(:selected_problems).and_return([])
+    allow(view).to receive(:all_errs).and_return(false)
     allow(view).to receive(:problems).and_return(
       Kaminari.paginate_array([problem_1, problem_2]).page(1).per(10)
     )
@@ -18,5 +19,23 @@ describe "problems/index.html.haml", type: 'view' do
       render
       expect(rendered).to have_selector('div#problem_table.problem_table')
     end
+  end
+
+  describe "show/hide resolved button behavior" do
+
+    it "displays unresolved errors title and button" do
+      allow(view).to receive(:all_errs).and_return(false)
+      render
+      expect(view.content_for(:title)).to match 'Unresolved Errors'
+      expect(view.content_for(:action_bar)).to have_link 'show resolved'
+    end
+
+    it "displays all errors title and button" do
+      allow(view).to receive(:all_errs).and_return(true)
+      render
+      expect(view.content_for :title).to match 'All Errors'
+      expect(view.content_for :action_bar).to have_link 'hide resolved'
+    end
+
   end
 end


### PR DESCRIPTION
Fixed bug:
1. Go to errors page /problems
2. Title = Unresolved Errors, button = show resolved
3. Click show resolved button (link actually)
4. Title has the same name instead of 'All Errors' and button is the same as before. So now we can't hide resolved errors

Problem was in using instance variable inside view.