### PR TITLE
Restore migration to extract issue trackers

### DIFF
--- a/db/migrate/201510290041_extract_issue_tracker.rb
+++ b/db/migrate/201510290041_extract_issue_tracker.rb
@@ -1,0 +1,46 @@
+class ExtractIssueTracker < Mongoid::Migration
+
+  TRACKER_MAPPING = {
+    'ErrbitTracPlugin::IssueTracker' => 'trac',
+    'IssueTrackers::BitbucketIssuesTracker' => 'bitbucket',
+    'IssueTrackers::FogbugzTracker' => 'fogbugz',
+    'IssueTrackers::GithubIssuesTracker' => 'github',
+    'IssueTrackers::GitlabTracker' => 'gitlab',
+    'IssueTrackers::JiraTracker' => 'jira',
+    'IssueTrackers::LighthouseTracker' => 'lighthouse',
+    'IssueTrackers::PivotalLabsTracker' => 'pivotal',
+    'IssueTrackers::RedmineTracker' => 'redmine',
+    'IssueTrackers::UnfuddleTracker' => 'unfuddle'
+  }
+
+  def self.up
+    App.all.each do |app|
+      next unless app.attributes['issue_tracker'].present?
+      next unless app.attributes['issue_tracker']['_type'].present?
+
+      options = app['issue_tracker'].dup
+      options.delete('_type')
+      options.delete('_id')
+
+      _type = app.attributes['issue_tracker']['_type']
+      updated_at = options.delete('updated_at')
+      created_at = options.delete('created_at')
+
+      if TRACKER_MAPPING.include?(_type)
+        tracker = {
+          'type_tracker' => TRACKER_MAPPING[_type],
+          'options' => options,
+          'updated_at' => updated_at,
+          'created_at' => created_at
+        }
+
+        App.where({ _id: app.id }).update({
+          "$set" => { :issue_tracker => tracker }
+        })
+      end
+    end
+  end
+
+  def self.down
+  end
+end

--- a/db/migrate/201510290041_extract_issue_tracker.rb
+++ b/db/migrate/201510290041_extract_issue_tracker.rb
@@ -22,13 +22,13 @@ class ExtractIssueTracker < Mongoid::Migration
       options.delete('_type')
       options.delete('_id')
 
-      _type = app.attributes['issue_tracker']['_type']
+      type = app.attributes['issue_tracker']['_type']
       updated_at = options.delete('updated_at')
       created_at = options.delete('created_at')
 
-      if TRACKER_MAPPING.include?(_type)
+      if TRACKER_MAPPING.include?(type)
         tracker = {
-          'type_tracker' => TRACKER_MAPPING[_type],
+          'type_tracker' => TRACKER_MAPPING[type],
           'options' => options,
           'updated_at' => updated_at,
           'created_at' => created_at


### PR DESCRIPTION
Addresses #926.

Between 0.4.0 and 0.5.0 all old migrations were removed because they were assumed to have been run in any production environment. However, it appears that the data migration for the IssueTrackers collection was [changed](https://github.com/errbit/errbit/commit/8dbfda4566fbf24b73f6173967fb0d0de032d296) during the process of building 0.4.0. Which meant anyone before then would not have the new structure in place. The proposed solution of migrating to 0.4.0 and then migrating forwards does not work if the MongoDB database underlying errbit was already moved to MongoDB 3.0 (which MongoLabs did for all their databases), because 0.4.0 doesn't have the updated Mongoid 5 drivers needed to connect.

This restores the commit so that it errbit installations before 0.4.0 can be upgraded directly to 0.5.0 using the new Mongoid drivers. Following @jerefrer's suggestion from https://gitter.im/errbit/errbit I patched the migration to work with the new Mongoid drivers and tested in our production setting.