### PR TITLE
Refs #1001 truncate long messages on cache

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,6 +1,8 @@
 require 'recurse'
 
 class Notice
+  MESSAGE_LENGTH_LIMIT = 1000
+
   include Mongoid::Document
   include Mongoid::Timestamps
 
@@ -31,6 +33,12 @@ class Notice
   scope :for_errs, lambda { |errs|
     where(:err_id.in => errs.all.map(&:id))
   }
+
+  # Overwrite the default setter to make sure the message length is no longer
+  # than the limit we impose
+  def message=(m)
+    super(m.is_a?(String) ? m[0, MESSAGE_LENGTH_LIMIT] : m)
+  end
 
   def user_agent
     agent_string = env_vars['HTTP_USER_AGENT']

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -55,7 +55,6 @@ class Problem
   validates :last_notice_at, :first_notice_at, presence: true
 
   before_create :cache_app_attributes
-  before_save :truncate_message
 
   scope :resolved, -> { where(resolved: true) }
   scope :unresolved, -> { where(resolved: false) }
@@ -221,10 +220,6 @@ class Problem
 
   def cache_app_attributes
     self.app_name = app.name if app
-  end
-
-  def truncate_message
-    self.message = message[0, 1000] if message
   end
 
   def issue_type

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -19,6 +19,38 @@ describe Notice, type: 'model' do
     end
   end
 
+  describe '#message=' do
+    let(:long_message) do
+      'Presently I heard a slight groan, and I knew it was the groan of   ' \
+      'mortal terror. It was not a groan of pain or of grief --oh, no!    ' \
+      '--it was the low stifled sound that arises from the bottom of the  ' \
+      'soul when overcharged with awe. I knew the sound well. Many a      ' \
+      'night, just at midnight, when all the world slept, it has welled   ' \
+      'up from my own bosom, deepening, with its dreadful echo, the       ' \
+      'terrors that distracted me. I say I knew it well. I knew what the  ' \
+      'old man felt, and pitied him, although I chuckled at heart. I      ' \
+      'knew that he had been lying awake ever since the first slight      ' \
+      'noise, when he had turned in the bed. His fears had been ever      ' \
+      'since growing upon him. He had been trying to fancy them           ' \
+      'causeless, but could not. He had been saying to himself --"It is   ' \
+      'nothing but the wind in the chimney --it is only a mouse crossing  ' \
+      'the floor," or "It is merely a cricket which has made a single     ' \
+      'chirp." Yes, he had been trying to comfort himself with these      ' \
+      'suppositions: but he had found all in vain. All in vain; because   ' \
+      'Death, in approaching him had stalked with his black shadow        ' \
+      'before him, and enveloped the victim. And it was the mournful      ' \
+      'influence of the unperceived shadow that caused him to feel        ' \
+      '--although he neither saw nor heard --to feel the presence of my   ' \
+      'head within the room.                                              '
+    end
+
+    it 'truncates the message' do
+      notice = Fabricate(:notice, message: long_message)
+      expect(long_message.length).to be > 1000
+      expect(notice.message.length).to eq 1000
+    end
+  end
+
   describe "key sanitization" do
     before do
       @hash = { "some.key" => { "$nested.key" => { "$Path" => "/", "some$key" => "key" } } }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -42,7 +42,7 @@ describe User do
       expect(user.reset_password('Password123', 'Password123')).to be_truthy
     end
 
-    it 'should require a password with minimum of 6 characters' do 
+    it 'should require a password with minimum of 6 characters' do
       user = Fabricate.build(:user)
       user.reset_password('12345', '12345')
       expect(user.errors[:password]).to include("is too short (minimum is 6 characters)", "is too short (minimum is 6 characters)")


### PR DESCRIPTION
Long messages need to be truncated so that Errbit will not try to cache
messages that are too long on Problem records because the mongo text
index will complain if the text is too long. Also, it's a good idea to
have these kinds of limits in general.