### PR TITLE
Ensure that App#<=> is used for sorting

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -9,7 +9,7 @@ class AppsController < ApplicationController
   expose(:app_scope) { App }
 
   expose(:apps) do
-    app_scope.all.sort.map { |app| AppDecorator.new(app) }
+    app_scope.all.to_a.sort.map { |app| AppDecorator.new(app) }
   end
 
   expose(:app, ancestor: :app_scope, attributes: :app_params)

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -34,7 +34,7 @@ describe AppsController, type: 'controller' do
         sign_in admin
         unwatched_app && watched_app1 && watched_app2
         get :index
-        expect(controller.apps.entries).to eq App.all.sort.entries
+        expect(controller.apps.entries).to eq App.all.to_a.sort.entries
       end
     end
 
@@ -43,7 +43,7 @@ describe AppsController, type: 'controller' do
         sign_in user
         unwatched_app && watched_app1 && watched_app2
         get :index
-        expect(controller.apps.entries).to eq App.all.sort.entries
+        expect(controller.apps.entries).to eq App.all.to_a.sort.entries
       end
     end
   end


### PR DESCRIPTION
Prior to this change, the `#sort` method was being handled by Mongoid and sent
to MongoDB, resulting in the `App#<=>` method being ignored for this purpose.

See additional discussion in #973 