### PR TITLE
Add support for new user payload

### DIFF
--- a/lib/airbrake_api/v3/notice_parser.rb
+++ b/lib/airbrake_api/v3/notice_parser.rb
@@ -69,8 +69,10 @@ module AirbrakeApi
       end
 
       def user_attributes
-        hash = context.slice('userId', 'userUsername', 'userName', 'userEmail')
-        Hash[hash.map { |key, value| [key.sub(/^user/, ''), value] }]
+        context['user'] || begin
+          hash = context.slice('userId', 'userUsername', 'userName', 'userEmail')
+          Hash[hash.map { |key, value| [key[4..-1].downcase, value] }]
+        end
       end
 
       def url

--- a/spec/fixtures/api_v3_request_with_deprecated_user_keys.json
+++ b/spec/fixtures/api_v3_request_with_deprecated_user_keys.json
@@ -22,12 +22,10 @@
     "sourceMapEnabled":true,
     "userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.99 Safari/537.36",
     "url":"http://localhost:3000/kontakt",
-    "user": {
-      "id":1,"userUsername":"john",
-      "name":"John Doe",
-      "username": "john",
-      "email":"john.doe@example.org"
-    },
+    "userId":1,"userUsername":"john",
+    "userName":"John Doe",
+    "userUsername": "john",
+    "userEmail":"john.doe@example.org",
     "version":"1.0",
     "component":"ContactsController",
     "action":"show"


### PR DESCRIPTION
The airbrake gem v5 has changed the keys for the user payload as described in #1026.