### PR TITLE
Airbrake 5.0 expects 201 status code for v3 api

### DIFF
--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -18,7 +18,7 @@ class Api::V3::NoticesController < ApplicationController
     return render text: VERSION_TOO_OLD, status: 422 unless report.should_keep?
 
     report.generate_notice!
-    render status: 200, json: {
+    render status: 201, json: {
       id:  report.notice.id,
       url: report.problem.url
     }

--- a/spec/controllers/api/v3/notices_controller_spec.rb
+++ b/spec/controllers/api/v3/notices_controller_spec.rb
@@ -21,9 +21,9 @@ describe Api::V3::NoticesController, type: :controller do
     )
   end
 
-  it 'responds with 200 created on success' do
+  it 'responds with 201 created on success' do
     post :create, legit_body, legit_params
-    expect(response.status).to be(200)
+    expect(response.status).to be(201)
   end
 
   it 'responds with 400 when request attributes are not valid' do


### PR DESCRIPTION
When using the airbrake-ruby gem (used by airbrake 5.0), the client throws an error due to a bad return code from the v3 api controller.

The expected return code is 201 created, but currently the errbit controller returns 200 ok.

See: https://github.com/airbrake/airbrake-ruby/blob/master/lib/airbrake-ruby/response.rb#L22