### PR TITLE
Backtrace decorator should not raise an error when no lines present.

### DIFF
--- a/app/decorators/backtrace_decorator.rb
+++ b/app/decorators/backtrace_decorator.rb
@@ -1,6 +1,6 @@
 class BacktraceDecorator < Draper::Decorator
   def lines
-    @lines ||= object.lines.map { |line| BacktraceLineDecorator.new line }
+    @lines ||= Array(object.lines).map { |line| BacktraceLineDecorator.new line }
   end
 
   # Group lines into sections of in-app files and external files


### PR DESCRIPTION
`BacktraceDecorator` raises "undefined method `map' for nil:NilClass" when backtrace contains no lines. After upgrading to latest Airbrake version we receive this error very often. So, I think it's good idea to handle this situation.

![screen shot 2016-02-04 at 15 13 46](https://cloud.githubusercontent.com/assets/855918/12814685/0587ea88-cb52-11e5-88cc-0c142be86288.png)
