### PR TITLE
add ability to override mongo authentication mechanism

### DIFF
--- a/config/load.rb
+++ b/config/load.rb
@@ -28,6 +28,11 @@ Errbit::Config = Configurator.run(
   secret_key_base:           ['SECRET_KEY_BASE'],
   mongo_url:                 %w(MONGOLAB_URI MONGOHQ_URL MONGODB_URL MONGO_URL),
 
+  # Change the default authentication mechanism. Valid options are: :scram,
+  # :mongodb_cr, :mongodb_x509, and :plain. (default on 3.0 is :scram, default
+  # on 2.4 and 2.6 is :plain)
+  mongo_auth_mechanism:      ['MONGO_AUTH_MECH'],
+
   # github
   github_url:                ['GITHUB_URL', lambda do |values|
     values[:github_url].gsub(%r{/*\z}, '')

--- a/config/mongo.rb
+++ b/config/mongo.rb
@@ -13,7 +13,10 @@ Mongoid.configure do |config|
   config.load_configuration(
     clients: {
       default: {
-        uri: uri
+        uri: uri,
+        options: {
+          auth_mech: Errbit::Config.mongo_auth_mechanism
+        }
       }
     },
     options: {


### PR DESCRIPTION
New versions of mongo offer additional authentication mechanisms. This pull request allows the errbit installation to use an auth_mech option from the ENV if available.