### PR TITLE
fixes #1040

### DIFF
--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -97,7 +97,7 @@ protected
     # set the app's notification service
     available_notification_classes = [NotificationService] + NotificationService.subclasses
     notification_class = available_notification_classes.detect { |c| c.name == notification_type }
-    if notification_class.present?
+    if !notification_class.nil?
       app.notification_service = notification_class.new(params[:app][:notification_service_attributes])
     end
   end


### PR DESCRIPTION
Checking for `.present?` on the NotificationService class or it's subclasses always returns false.  Using a not `.nil?` check solves the issue.