### PR TITLE
More compact slack notifications

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -19,41 +19,35 @@ class NotificationServices::SlackService < NotificationService
 
   def post_payload(problem)
     {
+      username: "Errbit",
+      icon_emoji: ":collision:",
       attachments: [
         {
-          fallback: message_for_slack(problem),
-          pretext:  "<#{problem.url}|Errbit - #{problem.app.name}: #{problem.error_class}>",
-          color:    "#D00000",
-          fields:   [
+          fallback:   message_for_slack(problem),
+          title:      problem.message.to_s.truncate(100),
+          title_link: problem.url,
+          text:       problem.where,
+          color:      "#D00000",
+          fields: [
+            {
+              title: "Application",
+              value: problem.app.name,
+              short: true
+            },
             {
               title: "Environment",
               value: problem.environment,
-              short: false
-            },
-            {
-              title: "Location",
-              value: problem.where,
-              short: false
-            },
-            {
-              title: "Message",
-              value: problem.message.to_s,
-              short: false
-            },
-            {
-              title: "First Noticed",
-              value: problem.first_notice_at,
-              short: false
-            },
-            {
-              title: "Last Noticed",
-              value: problem.last_notice_at,
-              short: false
+              short: true
             },
             {
               title: "Times Occurred",
               value: problem.notices_count,
-              short: false
+              short: true
+            },
+            {
+              title: "First Noticed",
+              value: problem.first_notice_at.try(:to_s, :db),
+              short: true
             }
           ]
         }

--- a/spec/fabricators/notice_fabricator.rb
+++ b/spec/fabricators/notice_fabricator.rb
@@ -2,7 +2,7 @@ Fabricator :notice do
   app
   err
   error_class 'FooError'
-  message 'Too Much Bar'
+  message 'FooError: Too Much Bar'
   backtrace
   server_environment  { { 'environment-name' => 'production' } }
   request             { { 'component' => 'foo', 'action' => 'bar' } }

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -2,46 +2,42 @@ describe NotificationServices::SlackService, type: 'model' do
   it "it should send a notification to Slack with hook url" do
     # setup
     notice = Fabricate :notice
-    notification_service = Fabricate :slack_notification_service, app: notice.app, service_url: "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX"
+    notification_service = Fabricate :slack_notification_service,
+      app: notice.app,
+      service_url: "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX"
     problem = notice.problem
 
     # faraday stubbing
     payload = {
+      username: "Errbit",
+      icon_emoji: ":collision:",
       attachments: [
         {
-          fallback: notification_service.message_for_slack(problem),
-          pretext:  "<#{problem.url}|Errbit - #{problem.app.name}: #{problem.error_class}>",
-          color:    "#D00000",
-          fields:   [
+          fallback:   notification_service.message_for_slack(problem),
+          title:      problem.message.to_s.truncate(100),
+          title_link: problem.url,
+          text:       problem.where,
+          color:      "#D00000",
+          fields: [
+            {
+              title: "Application",
+              value: problem.app.name,
+              short: true
+            },
             {
               title: "Environment",
               value: problem.environment,
-              short: false
-            },
-            {
-              title: "Location",
-              value: problem.where,
-              short: false
-            },
-            {
-              title: "Message",
-              value: problem.message.to_s,
-              short: false
-            },
-            {
-              title: "First Noticed",
-              value: problem.first_notice_at,
-              short: false
-            },
-            {
-              title: "Last Noticed",
-              value: problem.last_notice_at,
-              short: false
+              short: true
             },
             {
               title: "Times Occurred",
               value: problem.notices_count,
-              short: false
+              short: true
+            },
+            {
+              title: "First Noticed",
+              value: problem.first_notice_at.try(:to_s, :db),
+              short: true
             }
           ]
         }


### PR DESCRIPTION
Before:

<img width="338" alt="slack1" src="https://cloud.githubusercontent.com/assets/8155/13216474/a3aaf6a4-d964-11e5-8910-042521cc9ea9.png">

After:

<img width="947" alt="slack2" src="https://cloud.githubusercontent.com/assets/8155/13216481/a7c01eb8-d964-11e5-8915-d35338ba5370.png">

This also includes #1023.

I removed "Last noticed at", as this should be around the same time when the notification comes.
At least in ruby `error_class` (FooError) is always prefixed in the `message` (FooError: Too much bar). Also problems#index shows only the message.