### PR TITLE
fix searching when search field is empty

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -124,7 +124,11 @@ class ProblemsController < ApplicationController
   end
 
   def search
-    ps = Problem.search(params[:search]).for_apps(app_scope).in_env(params[:environment]).all_else_unresolved(params[:all_errs]).ordered_by(params_sort, params_order)
+    if params[:search].blank?
+      ps = Problem.for_apps(app_scope).in_env(params[:environment]).all_else_unresolved(params[:all_errs]).ordered_by(params_sort, params_order)
+    else
+      ps = Problem.search(params[:search]).for_apps(app_scope).in_env(params[:environment]).all_else_unresolved(params[:all_errs]).ordered_by(params_sort, params_order)
+    end
     self.problems = ps.page(params[:page]).per(current_user.per_page)
     respond_to do |format|
       format.html { render :index }

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -114,6 +114,13 @@ describe ProblemsController, type: 'controller' do
       expect(controller.problems).to include(@problem1)
       expect(controller.problems).to_not include(@problem2)
     end
+
+    it "works when given string is empty" do
+      get :search, search: ""
+      expect(controller.problems).to include(@problem1)
+      expect(controller.problems).to include(@problem2)
+    end
+
   end
 
   describe "GET /apps/:app_id/problems/:id" do


### PR DESCRIPTION
closes #1054 by skipping the search part of the scope when no search criteria is specified and added a test example to ensure searching without criteria returned a result set instead of blowing up.