### PR TITLE
Get hostname from the hostname key

### DIFF
--- a/lib/airbrake_api/v3/notice_parser.rb
+++ b/lib/airbrake_api/v3/notice_parser.rb
@@ -84,7 +84,7 @@ module AirbrakeApi
       end
 
       def hostname
-        URI.parse(url).hostname
+        context['hostname'] || URI.parse(url).hostname
       rescue URI::InvalidURIError
         ''
       end

--- a/spec/lib/airbrake_api/v3/notice_parser_spec.rb
+++ b/spec/lib/airbrake_api/v3/notice_parser_spec.rb
@@ -91,6 +91,14 @@ describe AirbrakeApi::V3::NoticeParser do
     expect(parser.attributes[:notifier]).to eq(notifier_params)
   end
 
+  it 'takes the hostname from the context' do
+    parser = described_class.new(
+        'errors'      => ['MyError'],
+        'context'     => { 'hostname' => 'app01.infra.example.com', 'url' => 'http://example.com/some-page' },
+        'environment' => {})
+    expect(parser.attributes[:server_environment]['hostname']).to eq('app01.infra.example.com')
+  end
+
   def build_params_for(fixture, options = {})
     json = Rails.root.join('spec', 'fixtures', fixture).read
     data = JSON.parse(json)


### PR DESCRIPTION
According to the [API V3 docs](http://airbrake.io/docs/#create-notice-v3) context has a separate key for _hostname_.

When I have 2 app servers: `app01.infra.example.com` and `app02.infra.example.com`  those handle similar requests, I want to realize which one produces the error.

In this case parsing the URL doesn't make sense.
