### PR TITLE
Add omniauth by google

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -23,3 +23,5 @@ GITHUB_API_URL=https://api.github.com
 GITHUB_ACCESS_SCOPE='[repo]'
 GITHUB_SITE_TITLE=GitHub
 DEVISE_MODULES='[database_authenticatable,recoverable,rememberable,trackable,validatable,omniauthable]'
+GOOGLE_AUTHENTICATION=true
+GOOGLE_SITE_TITLE=Google

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'flowdock'
 # ---------------------------------------
 # GitHub OAuth
 gem 'omniauth-github'
+# Google OAuth
+gem 'omniauth-google-oauth2'
 
 gem 'ri_cal'
 gem 'yajl-ruby', platform: 'ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,11 @@ GEM
     omniauth-github (1.1.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
+    omniauth-google-oauth2 (0.4.0)
+      jwt (~> 1.5.0)
+      multi_json (~> 1.3)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.3.1)
     omniauth-oauth2 (1.3.1)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -460,6 +465,7 @@ DEPENDENCIES
   mongoid-rspec (~> 3.0.0)
   mongoid_rails_migrations
   omniauth-github
+  omniauth-google-oauth2
   pjax_rails
   poltergeist
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ few others that could make sense for your needs:
   organization can log in to Errbit through GitHub. Errbit will provision
   accounts for new users.
 
+### Configuring Google authentication:
+* Set GOOGLE_AUTHENTICATION=true
+* Register your instance of Errbit at https://console.developers.google.com/apis/api/plus/overview
+
+If you host Errbit at errbit.example.com, you would fill in:
+
+<dl>
+<dt>URL
+<dd>http://errbit.example.com
+<dt>Callback URL
+<dd>http://errbit.example.com/users/auth/github
+</dl>
+
+* After you have registered your app, set GOOGLE_CLIENT_ID and GOOGLE_SECRET
+  with your app's Client ID and Secret key.
+
+When you start your application, you should see the option to **Sign in with
+Google** on the Login page. You will also be able to link your Google profile
+to your user account on your **Edit profile** page.
+
 ### Configuring LDAP authentication:
 
 * Set USER_HAS_USERNAME=true

--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -231,6 +231,7 @@ a.action  { float: right; font-size: 0.9em;}
 }
 
 #action-bar span.github a:before { font-family: FontAwesome; content: "\f09b"; margin-right: 8px; position: relative; top: 4px; font-size: 26px; }
+#action-bar span.google a:before { font-family: FontAwesome; content: "\f1a0"; margin-right: 8px; position: relative; top: 4px; font-size: 26px; }
 
 #action-bar span a.issue-tracker-button {
   padding-left: 5px;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -51,6 +51,11 @@ class UsersController < ApplicationController
     redirect_to user_path(user)
   end
 
+  def unlink_google
+    user.update(google_uid: nil)
+    redirect_to user_path(user)
+  end
+
 protected
 
   def require_user_edit_priviledges

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User
   field :email
   field :github_login
   field :github_oauth_token
+  field :google_uid
   field :name
   field :admin, type: Boolean, default: false
   field :per_page, type: Fixnum, default: PER_PAGE
@@ -69,6 +70,10 @@ class User
   def github_login=(login)
     login = nil if login.is_a?(String) && login.strip.empty?
     self[:github_login] = login
+  end
+
+  def google_account?
+    google_uid.present?
   end
 
   def ensure_authentication_token

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -5,6 +5,7 @@
   - content_for :action_bar do
     %div.action-bar
       %span.github= link_to "Sign in with #{Errbit::Config.github_site_title}", user_omniauth_authorize_path(:github)
+      %span.google= link_to "Sign in with #{Errbit::Config.google_site_title}", user_omniauth_authorize_path(:google_oauth2)
 
 = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
   .required

--- a/app/views/shared/_link_google_account.html.haml
+++ b/app/views/shared/_link_google_account.html.haml
@@ -1,0 +1,5 @@
+- if Errbit::Config.google_authentication && user == current_user
+  - if user.google_account?
+    %span.google= link_to "Unlink #{Errbit::Config.google_site_title} account", unlink_google_user_path, method: :delete, data: { confirm: 'Are you sure?' }
+  - else
+    %span.google= link_to "Link #{Errbit::Config.google_site_title} account", user_omniauth_authorize_path(:google_oauth2)

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,7 @@
 - content_for :title, "Edit #{user.name}"
 - content_for :action_bar do
   = render 'shared/link_github_account', :user => user
+  = render 'shared/link_google_account'
   = link_to('cancel', user_path(user), :class => 'button')
 
 = form_for user, :html => {:autocomplete => "off"} do |f|

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,6 +7,7 @@
 
 - content_for :action_bar do
   = render 'shared/link_github_account'
+  = render 'shared/link_google_account'
   = link_to 'edit', edit_user_path(user), :class => 'button'
   = link_to 'destroy', user_path(user), :method => :delete,
     :data => { :confirm => t('users.confirm_delete') }, :class => 'delete button'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -252,6 +252,12 @@ Devise.setup do |config|
       github_options
   end
 
+  if Errbit::Config.google_authentication || Rails.env.test?
+    config.omniauth :google_oauth2,
+      Errbit::Config.google_client_id,
+      Errbit::Config.google_secret
+  end
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/load.rb
+++ b/config/load.rb
@@ -39,6 +39,11 @@ Errbit::Config = Configurator.run(
   github_access_scope:       ['GITHUB_ACCESS_SCOPE'],
   github_api_url:            ['GITHUB_API_URL'],
   github_site_title:         ['GITHUB_SITE_TITLE'],
+  # google
+  google_authentication:     ['GOOGLE_AUTHENTICATION'],
+  google_site_title:         ['GOOGLE_SITE_TITLE'],
+  google_client_id:          ['GOOGLE_CLIENT_ID'],
+  google_secret:             ['GOOGLE_SECRET'],
 
   email_delivery_method:     ['EMAIL_DELIVERY_METHOD', lambda do |values|
     values[:email_delivery_method] && values[:email_delivery_method].to_sym

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   resources :users do
     member do
       delete :unlink_github
+      delete :unlink_google
     end
   end
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,16 @@ In order of precedence Errbit uses:
 <dt>GITHUB_SITE_TITLE</dt>
 <dd>The title to use for GitHub. This value is whatever you want displayed in the Errbit UI when referring to GitHub.</dd>
 <dd>defaults to GitHub</dd>
+<dt>GOOGLE_AUTHENTICATION
+<dd>Allow google sign-in via OAuth
+<dd>defaults to true
+<dt>GOOGLE_CLIENT_ID
+<dd>Client id of your google application
+<dt>GOOGLE_SECRET
+<dd>Secret key for your google application
+<dt>GOOGLE_SITE_TITLE</dt>
+<dd>The title to use for Google. This value is whatever you want displayed in the Errbit UI when referring to Google.</dd>
+<dd>defaults to Google</dd>
 <dt>EMAIL_DELIVERY_METHOD
 <dd>:smtp or :sendmail, depending on how you want Errbit to send email
 <dt>SMTP_SERVER

--- a/spec/acceptance/acceptance_helper.rb
+++ b/spec/acceptance/acceptance_helper.rb
@@ -18,6 +18,14 @@ def mock_auth(user = "test_user", token = "abcdef")
       'token' => token
     }
   )
+
+  OmniAuth.config.mock_auth[:google_oauth2] = Hashie::Mash.new(
+    provider: 'google',
+    uid: user,
+    info: {
+      email: 'errbit@errbit.example.com'
+    }
+  )
 end
 
 def log_in(user)

--- a/spec/acceptance/sign_in_with_google_spec.rb
+++ b/spec/acceptance/sign_in_with_google_spec.rb
@@ -1,0 +1,23 @@
+require 'acceptance/acceptance_helper'
+
+feature 'Sign in with Google' do
+  background do
+    allow(Errbit::Config).to receive(:google_authentication).and_return(true)
+    Fabricate(:user, google_uid: 'nashby')
+    visit root_path
+  end
+
+  scenario 'log in via Google with recognized user' do
+    mock_auth('nashby')
+
+    click_link 'Sign in with Google'
+    expect(page).to have_content I18n.t('devise.omniauth_callbacks.success', kind: 'Google')
+  end
+
+  scenario 'reject unrecognized user if authenticating via Google' do
+    mock_auth('unknown_user')
+
+    click_link 'Sign in with Google'
+    expect(page).to have_content 'There are no authorized users with Google login'
+  end
+end


### PR DESCRIPTION
I was implemented authentication by google to errbit.

![demo](https://cloud.githubusercontent.com/assets/8043276/14353304/6f5ada4a-fd13-11e5-8399-5cfc9ef937f9.gif)

The reason for this is that, GitHub is offen unusable.
In the authentication by Google, such a situation is considered unlikely to occur.

Implementation is the following three points.
- Authentication by google
- Test of authentication by google
- Update of the document

Please tell me if there is a correction point:dog: