### PR TITLE
First setup the config files and later check

### DIFF
--- a/docs/deployment/capistrano.md
+++ b/docs/deployment/capistrano.md
@@ -18,12 +18,12 @@ $EDITOR config/deploy.rb
 cp config/deploy/production.example.rb config/deploy/production.rb
 $EDITOR config/deploy/production.rb
 
-# Check to make sure configs exist
-bundle exec cap production deploy:check
-
 # Create the configs yourself, or run errbit:setup to upload the
 # defaults
 bundle exec cap production errbit:setup
+
+# Check to make sure configs exist
+bundle exec cap production deploy:check
 
 # Deploy
 bundle exec cap production deploy


### PR DESCRIPTION
Please correct me if I'm wrong but first the config files should be uploaded to the destination server and later check the configs.

If I run first `bundle exec cap production deploy:check` I'll get this error:
```
ERROR linked file /var/www/apps/errbit/shared/config/puma.rb does not exist on 
(Backtrace restricted to imported tasks)
```
Running first `bundle exec cap production errbit:setup` will pass