### PR TITLE
Slack rooms

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -4,12 +4,16 @@ class NotificationServices::SlackService < NotificationService
     [:service_url, {
       placeholder: 'Slack Hook URL (https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX)',
       label:       'Hook URL'
+    }],
+    [:room_id, {
+      placeholder: '#general',
+      label:       'Room where slack should notify'
     }]
   ]
 
   def check_params
     if FIELDS.detect { |f| self[f[0]].blank? }
-      errors.add :base, "You must specify your Slack Hook url."
+      errors.add :base, "You must specify your Slack Hook url and channel"
     end
   end
 
@@ -21,6 +25,7 @@ class NotificationServices::SlackService < NotificationService
     {
       username:    "Errbit",
       icon_url:    "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
+      channel:     room_id,
       attachments: [
         {
           fallback:   message_for_slack(problem),

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -25,7 +25,7 @@ class NotificationServices::SlackService < NotificationService
     {
       username:    "Errbit",
       icon_url:    "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
-      channel:     room_id,
+      channel:     "#{room_id}",
       attachments: [
         {
           fallback:   message_for_slack(problem),

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -25,7 +25,7 @@ describe NotificationServices::SlackService, type: 'model' do
     payload = {
       username:    "Errbit",
       icon_url:    "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
-      channel:     "#general",
+      channel:     "#{room_id}",
       attachments: [
         {
           fallback:   service.message_for_slack(problem),

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -3,10 +3,14 @@ describe NotificationServices::SlackService, type: 'model' do
   let(:service_url) do
     "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX"
   end
+  let(:room_id) do
+    "#general"
+  end
 
   let(:service) do
     Fabricate :slack_notification_service, app:         notice.app,
-                                           service_url: service_url
+                                           service_url: service_url,
+                                           room_id: room_id
   end
 
   it "should have icon for slack" do
@@ -21,6 +25,7 @@ describe NotificationServices::SlackService, type: 'model' do
     payload = {
       username:    "Errbit",
       icon_url:    "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
+      channel:     "#general",
       attachments: [
         {
           fallback:   service.message_for_slack(problem),


### PR DESCRIPTION
currently, the slack notifier only allows you to post to the channel the webhook is configured with by default. This PR aligns the notifier with others in that it asks you pick the channel to send notifications to by default
