### PR TITLE
fix does not work with airbrake 5.4 refs #1102

### DIFF
--- a/app/views/apps/_configuration_instructions.html.haml
+++ b/app/views/apps/_configuration_instructions.html.haml
@@ -12,6 +12,6 @@
 
       Airbrake.configure do |config|
         config.host = '#{request.base_url}'
-        config.project_id = true
+        config.project_id = -1
         config.project_key = '#{app.api_key}'
       end


### PR DESCRIPTION
refs #1102 
fix docs for airbrake 5.4

https://github.com/airbrake/airbrake-ruby/blob/989187744e7ea65f3383aacbac0e0f27500ce62a/lib/airbrake-ruby/config.rb#L133

In 5.4, an exception occurs at the point of the case `to_i` project_id is true.
project_id was work in -1, but it is first aid.
