### PR TITLE
add instructions to configure environment in errbit initializer

### DIFF
--- a/app/views/apps/_configuration_instructions.html.haml
+++ b/app/views/apps/_configuration_instructions.html.haml
@@ -14,4 +14,8 @@
         config.host = '#{request.base_url}'
         config.project_id = -1
         config.project_key = '#{app.api_key}'
+
+        # Uncomment for Rails apps
+        # config.environment = Rails.env
+        # config.ignore_environments = %w(development test)
       end


### PR DESCRIPTION
closes #1106 
airbrake 5.4 gem does not set environment if not configured in initializer.
as suggested in #1106 this change adds additional comments to the configuration instructions
