### PR TITLE
libv8 updated to 3.16.14.15 to be able to compile it on OS X

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
     launchy (2.4.3-java)
       addressable (~> 2.3)
       spoon (~> 0.0.1)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.15)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)


### PR DESCRIPTION
The old libv wasn't compiling.
It was getting this error:
```
Installing libv8 3.16.14.13 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/ext/libv8
/Users/andrei/.rvm/rubies/ruby-2.3.1/bin/ruby -r ./siteconf20160727-65116-eqmldx.rb extconf.rb
creating Makefile
Compiling v8 for x64
Using python 2.7.10
Using compiler: /usr/bin/c++ (clang version 7.3.0)
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/libtool: file: /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/atomicops_internals_x86_gcc.o has no symbols
In file included from ../src/accessors.cc:28:
In file included from ../src/v8.h:60:
In file included from ../src/objects-inl.h:38:
In file included from ../src/elements.h:32:
../src/objects.h:5252:44: error: shifting a negative signed value is undefined [-Werror,-Wshift-negative-value]
  static const int kElementsKindMask = (-1 << kElementsKindShift) &
                                        ~~ ^
../src/objects.h:7386:36: error: shifting a negative signed value is undefined [-Werror,-Wshift-negative-value]
      (~kMaxCachedArrayIndexLength << kArrayIndexHashLengthShift) |
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
2 errors generated.
make[1]: *** [/Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/v8_base/src/accessors.o] Error 1
make: *** [x64.release] Error 2
/Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/ext/libv8/location.rb:36:in `block in verify_installation!': libv8 did not install properly, expected binary v8 archive '/Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/tools/gyp/libv8_base.a'to exist, but it was not found (Libv8::Location::Vendor::ArchiveNotFound)
	from /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/ext/libv8/location.rb:35:in `each'
	from /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/ext/libv8/location.rb:35:in `verify_installation!'
	from /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/ext/libv8/location.rb:26:in `install!'
	from extconf.rb:7:in `<main>'
GYP_GENERATORS=make \
	build/gyp/gyp --generator-output="out" build/all.gyp \
	              -Ibuild/standalone.gypi --depth=. \
	              -Dv8_target_arch=x64 \
	              -S.x64  -Dv8_enable_backtrace=1 -Dv8_can_use_vfp2_instructions=true -Darm_fpu=vfpv2 -Dv8_can_use_vfp3_instructions=true -Darm_fpu=vfpv3 -Dwerror=''
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/allocation.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/atomicops_internals_x86_gcc.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/bignum-dtoa.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/cached-powers.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/conversions.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/diy-fp.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/dtoa.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/fast-dtoa.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/fixed-dtoa.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/once.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/preparse-data.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/preparser.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/preparser-api.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/scanner.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/strtod.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/token.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/unicode.o
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser_lib/src/utils.o
  LIBTOOL-STATIC /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/libpreparser_lib.a
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/preparser/preparser/preparser-process.o
  LINK(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/preparser
  CXX(target) /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13/vendor/v8/out/x64.release/obj.target/v8_base/src/accessors.o

extconf failed, exit code 1

Gem files will remain installed in /Users/andrei/.rvm/gems/ruby-2.3.1/gems/libv8-3.16.14.13 for inspection.
Results logged to /Users/andrei/.rvm/gems/ruby-2.3.1/extensions/x86_64-darwin-15/2.3.0/libv8-3.16.14.13/gem_make.out
```