### PR TITLE
Fix UrlGenerationError exception thrown when Google auth is disabled

### DIFF
--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,11 +1,13 @@
 - content_for :title, 'Sign in'
 - auth_key = Devise.authentication_keys.first
 
-- if Errbit::Config.github_authentication
+- if Errbit::Config.github_authentication || Errbit::Config.google_authentication
   - content_for :action_bar do
     %div.action-bar
-      %span.github= link_to "Sign in with #{Errbit::Config.github_site_title}", user_omniauth_authorize_path(:github)
-      %span.google= link_to "Sign in with #{Errbit::Config.google_site_title}", user_omniauth_authorize_path(:google_oauth2)
+      - if Errbit::Config.github_authentication
+        %span.github= link_to "Sign in with #{Errbit::Config.github_site_title}", user_omniauth_authorize_path(:github)
+      - if Errbit::Config.google_authentication
+        %span.google= link_to "Sign in with #{Errbit::Config.google_site_title}", user_omniauth_authorize_path(:google_oauth2)
 
 = form_for(resource, :as => resource_name, :url => session_path(resource_name)) do |f|
   .required


### PR DESCRIPTION
If you disable Google authentication, the `/users/sign_in` page throws an exception of type: `ActionController::UrlGenerationError`