### PR TITLE
Remind heroku button users to bootstrap

### DIFF
--- a/docs/deployment/heroku.md
+++ b/docs/deployment/heroku.md
@@ -7,6 +7,9 @@ you can use this deploy button to get a basic deployment running on Heroku.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/errbit/errbit/tree/master)
 
+After deploying the application, you still need to run `heroku run rake errbit:bootstrap` 
+to create indexes and get your admin user set up.
+
 ## The Hard Way
 
 We designed Errbit to work well with Heroku. These instructions should result


### PR DESCRIPTION
I ran through the Heroku installer and didn't have an admin user. I had to bootstrap to set it up.

This is lower in the page, but it wasn't clear where the manual instructions ended.  We could say "finish configuration (link)" instead of this if you think that's better.