### PR TITLE
add phantomjs gem to fix failing acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,6 +88,7 @@ group :test do
   gem 'fabrication'
   gem 'capybara'
   gem 'poltergeist'
+  gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'launchy'
   gem 'email_spec'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,7 @@ GEM
     orm_adapter (0.5.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
+    phantomjs (2.1.1.0)
     pjax_rails (0.4.0)
       jquery-rails
       railties (>= 3.2, < 5.0)
@@ -466,6 +467,7 @@ DEPENDENCIES
   mongoid_rails_migrations
   omniauth-github
   omniauth-google-oauth2
+  phantomjs
   pjax_rails
   poltergeist
   pry-byebug


### PR DESCRIPTION
When i run rspec spec the acceptance tests are failing with the following error message:

_Cliver::Dependency::NotFound:
  Could not find an executable ["phantomjs"] on your path._

I had to add phantomjs to the Gemfile [as described here](https://github.com/colszowka/phantomjs-gem#usage-with-poltergeistcapybara)