### PR TITLE
Add UI for per-app fingerprinting

### DIFF
--- a/app/views/apps/_fields.html.haml
+++ b/app/views/apps/_fields.html.haml
@@ -37,6 +37,35 @@
       = f.text_field :email_at_notices, :value => app_decorate.email_at_notices
       .field-helpertext times an error occurs (comma separated).
 
+%fieldset
+  %legend= t('.notice_fingerprinter')
+  %p= t('.notice_fingerprinter_text')
+
+  = f.fields_for :notice_fingerprinter do |g|
+    .checkbox
+      = g.check_box :error_class
+      = g.label :error_class, t('.error_class')
+
+    .checkbox
+      = g.check_box :message
+      = g.label :message, t('.message')
+
+    %div
+      = g.label :backtrace_lines, t('.backtrace_lines')
+      = g.text_field :backtrace_lines
+
+    .checkbox
+      = g.check_box :component
+      = g.label :component, t('.component')
+
+    .checkbox
+      = g.check_box :action
+      = g.label :action, t('.action')
+
+    .checkbox
+      = g.check_box :environment_name
+      = g.label :environment_name, t('.environment_name')
+
 %div.checkbox
   = f.check_box :notify_all_users
   = f.label :notify_all_users, t('.notify_all_users')


### PR DESCRIPTION
Work in progress. Still needs: 

 * Get rid of the site-wide notification fingerprinting UI or add a note in that screen that is going to override any per-app fingerprinting that is set up.
 * Add the source field to `notice_fingerprinter.attributes`