### PR TITLE
Update Ruby from 2.2 to 2.2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.1
-  - 2.2
+  - 2.2.6
   - 2.3.1
   - ruby-head
   - jruby-head


### PR DESCRIPTION
"2.2" means "2.2.0" on Travis CI.
ref: https://travis-ci.org/errbit/errbit/jobs/181392638

And it is too older to break build.