### PR TITLE
change slack notification service to be mattermost compatible

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -41,7 +41,7 @@ class NotificationServices::SlackService < NotificationService
             },
             {
               title: "Times Occurred",
-              value: problem.notices_count,
+              value: problem.notices_count.try(:to_s),
               short: true
             },
             {

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -41,7 +41,7 @@ describe NotificationServices::SlackService, type: 'model' do
             },
             {
               title: "Times Occurred",
-              value: problem.notices_count,
+              value: problem.notices_count.try(:to_s),
               short: true
             },
             {


### PR DESCRIPTION
* closes https://github.com/errbit/errbit/issues/1136
* see https://github.com/mattermost/platform/issues/3666#issuecomment-238098539

a really small change, that should enable [Mattermost](https://github.com/mattermost/platform) as Slack alternative.

i used the curl example to check if Slack has a problem with "Times Occured" as a String
```
curl -d '{"username":"Errbit","icon_url":"https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png","attachments":[{"fallback":"[Klaus][development][welcome#index]: RuntimeError http://errbit.example.com/apps/5795cbebdf0f1d0009000000/problems/5795cffadf0f1d0017000007","title":"Hugo","title_link":"http://errbit.example.com/apps/5795cbebdf0f1d0009000000/problems/5795cffadf0f1d0017000007","text":"welcome#index","color":"#D00000","fields":[{"title":"Application","value":"Klaus","short":true},{"title":"Environment","value":"development","short":true},{"title":"Times Occurred","value":"1","short":true},{"title":"First Noticed","value":"2016-07-25 08:38:18","short":true}]}]}' https://[...] -H 'Content-Type: application/json' -v
```

..,{"title":"Times Occurred","value":**"1"**,"short":true}...

Slack Message was delivered without problems.
