### PR TITLE
Slack channels

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -1,4 +1,5 @@
 class NotificationServices::SlackService < NotificationService
+  CHANNEL_NAME_REGEXP = /^#[a-z\d_-]+$/
   LABEL = "slack"
   FIELDS += [
     [:service_url, {
@@ -15,8 +16,12 @@ class NotificationServices::SlackService < NotificationService
   # Make room_id optional in case users want to use the default channel
   # setup on Slack when creating the webhook
   def check_params
-    if FIELDS.detect { |f| f[0] != :room_id && self[f[0]].blank? }
-      errors.add :base, "You must specify your Slack Hook url"
+    if service_url.blank?
+      errors.add :service_url, "You must specify your Slack Hook url"
+    end
+
+    if room_id.present? && !CHANNEL_NAME_REGEXP.match(room_id)
+      errors.add :room_id, "Slack channel name must be lowercase, with no space, special character, or periods."
     end
   end
 

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -4,12 +4,19 @@ class NotificationServices::SlackService < NotificationService
     [:service_url, {
       placeholder: 'Slack Hook URL (https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX)',
       label:       'Hook URL'
+    }],
+    [:room_id, {
+      placeholder: '#general',
+      label:       'Notification channel',
+      hint:        'If empty Errbit will use the default channel for the webook'
     }]
   ]
 
+  # Make room_id optional in case users want to use the default channel
+  # setup on Slack when creating the webhook
   def check_params
-    if FIELDS.detect { |f| self[f[0]].blank? }
-      errors.add :base, "You must specify your Slack Hook url."
+    if FIELDS.detect { |f| f[0] != :room_id && self[f[0]].blank? }
+      errors.add :base, "You must specify your Slack Hook url"
     end
   end
 
@@ -21,6 +28,7 @@ class NotificationServices::SlackService < NotificationService
     {
       username:    "Errbit",
       icon_url:    "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
+      channel:     room_id,
       attachments: [
         {
           fallback:   message_for_slack(problem),
@@ -52,7 +60,7 @@ class NotificationServices::SlackService < NotificationService
           ]
         }
       ]
-    }.to_json
+    }.contact.to_json # compact to remove empty channel in case it wasn't selected by user
   end
 
   def create_notification(problem)

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -60,7 +60,7 @@ class NotificationServices::SlackService < NotificationService
           ]
         }
       ]
-    }.contact.to_json # compact to remove empty channel in case it wasn't selected by user
+    }.compact.to_json # compact to remove empty channel in case it wasn't selected by user
   end
 
   def create_notification(problem)

--- a/app/views/apps/_service_notification_fields.html.haml
+++ b/app/views/apps/_service_notification_fields.html.haml
@@ -16,7 +16,8 @@
         %div.notification_params{:class => (w.object.is_a?(notification_service) ? 'chosen ' : '') << notification_service.label}
           - notification_service::FIELDS.each do |field, field_info|
             = w.label field, field_info[:label] || field.to_s.titleize
-            %em= field_info[:hint]
+            - if field_info[:hint].present?
+              %em= field_info[:hint]
             - field_type = field == :password ? :password_field : :text_field
             - value = field == :notify_at_notices ? w.object.notify_at_notices.join(", ") : w.object.send(field)
             = w.send field_type, field, :placeholder => field_info[:placeholder], :value => value

--- a/app/views/apps/_service_notification_fields.html.haml
+++ b/app/views/apps/_service_notification_fields.html.haml
@@ -16,6 +16,7 @@
         %div.notification_params{:class => (w.object.is_a?(notification_service) ? 'chosen ' : '') << notification_service.label}
           - notification_service::FIELDS.each do |field, field_info|
             = w.label field, field_info[:label] || field.to_s.titleize
+            %em= field_info[:hint]
             - field_type = field == :password ? :password_field : :text_field
             - value = field == :notify_at_notices ? w.object.notify_at_notices.join(", ") : w.object.send(field)
             = w.send field_type, field, :placeholder => field_info[:placeholder], :value => value

--- a/spec/fabricators/notification_service_fabricator.rb
+++ b/spec/fabricators/notification_service_fabricator.rb
@@ -14,6 +14,7 @@ end
 
 Fabricator :slack_notification_service, from: :notification_service, class_name: "NotificationServices::SlackService" do
   service_url { sequence :word }
+  room_id { sequence(:room_id)  { |i| "#room-#{i}" } }
 end
 
 Fabricator :hipchat_notification_service, from: :notification_service, class_name: "NotificationServices::HipchatService" do

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -9,6 +9,9 @@ describe NotificationServices::SlackService, type: 'model' do
                                            service_url: service_url,
                                            room_id:     room_id
   end
+  let(:room_id) do
+    "#general"
+  end
 
   # faraday stubbing
   let(:payload_hash) do
@@ -54,11 +57,35 @@ describe NotificationServices::SlackService, type: 'model' do
     expect(Rails.root.join("docs/notifications/slack/errbit.png")).to exist
   end
 
-  context 'with room_id' do
-    let(:room_id) do
-      "#general"
+  context 'Validations' do
+    it 'validates presence of service_url' do
+      service.service_url = ""
+      service.valid?
+
+      expect(service.errors[:service_url]).
+        to include("You must specify your Slack Hook url")
+
+      service.service_url = service_url
+      service.valid?
+
+      expect(service.errors[:service_url]).to be_blank
     end
 
+    it 'validates format of room_id' do
+      service.room_id = "INVALID NAME"
+      service.valid?
+
+      expect(service.errors[:room_id]).
+        to include("Slack channel name must be lowercase, with no space, special character, or periods.")
+
+      service.room_id = "#valid-room-name"
+      service.valid?
+
+      expect(service.errors[:room_id]).to be_blank
+    end
+  end
+
+  context 'with room_id' do
     it "should send a notification to Slack with hook url and channel" do
       payload = payload_hash.to_json
 


### PR DESCRIPTION
This is a follow up PR to #1095.

This adds the ability to users to select a channel in which the Slack notifications will be send when setting up Slack notifications.
The channel field is not compulsory and, if empty, the default channel setup on slack when creating the webhook.

##### TODO
- [x] Write specs to ensure the right payload is sent with a channel both selected or not
- [x] Validate `room_id` field to ensure it matches a slack channels name format