### PR TITLE
Default to using MongoDB with compression

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ errbit:
     - RACK_ENV=production
     - MONGO_URL=mongodb://mongo:27017/errbit
 mongo:
-  image: mongo:3.0
+  image: mongo:3.2
   ports:
     - "27017"
-  command: -smallfiles
-


### PR DESCRIPTION
MongoDB 3.2 defaults to WiredTiger as storage engine. As with WiredTiger MongDB finally supports compression the resulting database in many cases has a far smaller file size.
If the mongo:3.2 container is started with an existing volume created by the old 3.0 version the old storage engine is automatically used, therefor this change should be downward compatible.