### PR TITLE
smtp config: support additional ssl related keys

### DIFF
--- a/config/initializers/action_mailer.rb
+++ b/config/initializers/action_mailer.rb
@@ -2,12 +2,14 @@
 if Errbit::Config.email_delivery_method == :smtp
   ActionMailer::Base.delivery_method = :smtp
   ActionMailer::Base.smtp_settings = {
-    address:        Errbit::Config.smtp_address,
-    port:           Errbit::Config.smtp_port,
-    authentication: Errbit::Config.smtp_authentication,
-    user_name:      Errbit::Config.smtp_user_name,
-    password:       Errbit::Config.smtp_password,
-    domain:         Errbit::Config.smtp_domain
+    address:              Errbit::Config.smtp_address,
+    port:                 Errbit::Config.smtp_port,
+    authentication:       Errbit::Config.smtp_authentication,
+    user_name:            Errbit::Config.smtp_user_name,
+    password:             Errbit::Config.smtp_password,
+    domain:               Errbit::Config.smtp_domain,
+    enable_starttls_auto: Errbit::Config.smtp_enable_starttls_auto,
+    openssl_verify_mode:  Errbit::Config.smtp_openssl_verify_mode
   }
 end
 

--- a/config/load.rb
+++ b/config/load.rb
@@ -53,6 +53,8 @@ Errbit::Config = Configurator.run(
   smtp_address:              ['SMTP_SERVER'],
   smtp_port:                 ['SMTP_PORT'],
   smtp_authentication:       ['SMTP_AUTHENTICATION'],
+  smtp_enable_starttls_auto: ['SMTP_ENABLE_STARTTLS_AUTO'],
+  smtp_openssl_verify_mode:  ['SMTP_OPENSSL_VERIFY_MODE'],
   smtp_user_name:            %w(SMTP_USERNAME SENDGRID_USERNAME),
   smtp_password:             %w(SMTP_PASSWORD SENDGRID_PASSWORD),
   smtp_domain:               ['SMTP_DOMAIN', 'SENDGRID_DOMAIN', lambda do |values|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,10 @@ In order of precedence Errbit uses:
 <dd>Password for SMTP auth, you could also set SENDGRID_PASSWORD
 <dt>SMTP_DOMAIN
 <dd>HELO domain to set for outgoing SMTP messages, you can also use SENDGRID_DOMAIN
+<dt>SMTP_ENABLE_STARTTLS_AUTO
+<dd>Detects if STARTTLS is enabled in your SMTP server and starts to use it
+<dt>SMTP_OPENSSL_VERIFY_MODE
+<dd>When using TLS, you can set how OpenSSL checks the certificate. This is really useful if you need to validate a self-signed and/or a wildcard certificate. You can use the name of an OpenSSL verify constant ('none', 'peer', 'client_once', 'fail_if_no_peer_cert').
 <dt>SENDMAIL_LOCATION
 <dd>Path to sendmail
 <dt>SENDMAIL_ARGUMENTS

--- a/spec/initializers/action_mailer_spec.rb
+++ b/spec/initializers/action_mailer_spec.rb
@@ -32,15 +32,19 @@ describe 'initializers/action_mailer' do
       allow(Errbit::Config).to receive(:smtp_user_name).and_return('my-username')
       allow(Errbit::Config).to receive(:smtp_password).and_return('my-password')
       allow(Errbit::Config).to receive(:smtp_domain).and_return('someotherdomain.com')
+      allow(Errbit::Config).to receive(:smtp_enable_starttls_auto).and_return(true)
+      allow(Errbit::Config).to receive(:smtp_openssl_verify_mode).and_return('peer')
       load_initializer
 
       expect(ActionMailer::Base.smtp_settings).to eq(
-        address:        'smtp.somedomain.com',
-        port:           998,
-        authentication: :login,
-        user_name:      'my-username',
-        password:       'my-password',
-        domain:         'someotherdomain.com'
+        address:              'smtp.somedomain.com',
+        port:                 998,
+        authentication:       :login,
+        user_name:            'my-username',
+        password:             'my-password',
+        domain:               'someotherdomain.com',
+        enable_starttls_auto: true,
+        openssl_verify_mode:  'peer'
       )
     end
   end


### PR DESCRIPTION
- smtp_enable_starttls_auto, smtp_openssl_verify_mode

I did not see a way to have a default value for these settings.  I would like to ensure that "enable_starttls_auto" as the expected default value of `true`.

See: http://api.rubyonrails.org/classes/ActionMailer/Base.html#class-ActionMailer::Base-label-Configuration+options