### PR TITLE
Update README link to Github app registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Authentication
 --------------
 ### Configuring GitHub authentication:
 * Set GITHUB_AUTHENTICATION=true
-* Register your instance of Errbit at https://github.com/settings/applications
+* Register your instance of Errbit at https://github.com/settings/applications/new
 
 If you host Errbit at errbit.example.com, you would fill in:
 


### PR DESCRIPTION
When I followed the current link to Github I couldn't find the button to register a new app.
So I think a more specific link would avoid needing to Google it.