### PR TITLE
Document the necessity to avoid the Dockerfile deployment detection

### DIFF
--- a/docs/deployment/dokku.md
+++ b/docs/deployment/dokku.md
@@ -10,6 +10,8 @@ dokku apps:create errbit
 dokku plugin:install https://github.com/dokku/dokku-mongo.git mongo
 dokku mongo:create errbit errbit
 dokku mongo:link errbit errbit
+# Override the automatic Dockerfile deployment detection
+dokku config:set errbit BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-ruby.git
 dokku config:set errbit HEROKU=1
 dokku config:set errbit GEMFILE_RUBY_VERSION=2.3.3
 dokku config:set errbit SECRET_KEY_BASE="$(bundle exec rake secret)"


### PR DESCRIPTION
Hi,

First, I've to thank your for this great project.

My issue is that installing Errbit on dokku fails because it uses the `Dockerfile` as the deployment method instead of the ordinary Buildpack way.

As an example of the deployment output, I've added the error messages:
```
...

curl: (7) Failed to connect to 172.17.0.3 port 8080: Connection refused
 !     Check attempt 5/5 failed.
=====> errbit web container output:
       bundler: failed to load command: puma (/usr/local/bundle/bin/puma)
       Bundler::VersionConflict: Bundler could not find compatible versions for gem "ffi":
         In snapshot (Gemfile.lock):
           ffi (= 1.9.8) java
         In Gemfile:
           launchy was resolved to 2.4.3, which depends on
             spoon (~> 0.0.1) java was resolved to 0.0.4, which depends on
               ffi java
           launchy was resolved to 2.4.3, which depends on
             spoon (~> 0.0.1) java was resolved to 0.0.4, which depends on
               ffi
       Running `bundle update` will rebuild your snapshot from scratch, using only
       the gems in your Gemfile, which may resolve the conflict.
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/resolver.rb:207:in `rescue in start'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/resolver.rb:201:in `start'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/resolver.rb:181:in `resolve'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/definition.rb:251:in `resolve'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/definition.rb:175:in `specs'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/definition.rb:234:in `specs_for'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/definition.rb:223:in `requested_specs'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/runtime.rb:118:in `block in definition_method'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/runtime.rb:19:in `setup'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler.rb:100:in `setup'
         /usr/local/bundle/gems/bundler-1.14.1/lib/bundler/setup.rb:20:in `<top (required)>'
         /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
         /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'

...

=====> end errbit web container output
```

My workaround was to force the use of the Buildpack method, as could be seem in the docs (http://dokku.viewdocs.io/dokku/deployment/methods/buildpacks/). It's as simple as:
```
dokku config:set errbit BUILDPACK_URL=https://github.com/heroku/heroku-buildpack-ruby.git
```

I think that this could be valuable enough to update the docs about dokku.