### PR TITLE
Fix tmp directory permissions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,9 @@ RUN apk add --no-cache --virtual build-dependencies \
   && apk del build-dependencies
 
 COPY . /app
-RUN chown -R errbit:errbit /app
 
 RUN RAILS_ENV=production bundle exec rake assets:precompile
+RUN chown -R errbit:errbit /app
 
 USER errbit
 


### PR DESCRIPTION
Ordering of commands is important in the Dockerfile because when asset:precompile is run, it's done as root, which then creates the /app/tmp file with root permissions. 

Subsequently, after the docker image is started, when connecting to the website for the first time you get a Permission denied error from Devise like this:

![image](https://cloud.githubusercontent.com/assets/521795/22249200/d98d2164-e239-11e6-90ea-9639fca8efbd.png)

This relates to the recent changes from #1160