### PR TITLE
Fix notice fingerprinter when backtrace is nil

### DIFF
--- a/app/models/notice_fingerprinter.rb
+++ b/app/models/notice_fingerprinter.rb
@@ -21,10 +21,13 @@ class NoticeFingerprinter
     material << notice.action if action
     material << notice.environment_name if environment_name
 
-    if backtrace_lines < 0
-      material << backtrace.lines
-    else
-      material << backtrace.lines.slice(0, backtrace_lines)
+    # Sometimes backtrace is nil
+    if backtrace
+      if backtrace_lines < 0
+        material << backtrace.lines
+      else
+        material << backtrace.lines.slice(0, backtrace_lines)
+      end
     end
 
     Digest::MD5.hexdigest(material.map(&:to_s).join)

--- a/spec/models/notice_fingerprinter_spec.rb
+++ b/spec/models/notice_fingerprinter_spec.rb
@@ -60,5 +60,14 @@ describe NoticeFingerprinter, type: 'model' do
         expect(f1).to_not eq(f2)
       end
     end
+
+    context "two notices with no backtrace" do
+      it "has the same fingerprint" do
+        f1 = fingerprinter.generate('123', notice, nil)
+        f2 = fingerprinter.generate('123', notice, nil)
+
+        expect(f1).to eq(f2)
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes it's nil
Due to storage limit (especially on Heroku)