### PR TITLE
Expand Clickable Area on Buttons

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -92,6 +92,8 @@ a.action  { float: right; font-size: 0.9em;}
   color: #ccc;
   padding: 0 14px;
   line-height: 30px;
+  height: 30px;
+  display: inline-block;
 }
 #header #session-links #sign-out i {
   color: #cc0033;
@@ -143,6 +145,8 @@ a.action  { float: right; font-size: 0.9em;}
   font-size: 14px;
   font-weight: bold;
   line-height: 37px;
+  height: 37px;
+  display: inline-block;
   text-decoration: none;
   text-shadow: 1px 1px 0px #FFF;
   -webkit-text-shadow: 1px 1px 0px #FFF;
@@ -216,7 +220,12 @@ a.action  { float: right; font-size: 0.9em;}
 #action-bar span a {
   color: #666;
   padding: 0 20px;
-  font-size: 14px; font-weight: bold; line-height: 39px; text-decoration: none;
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 39px;
+  height: 39px;
+  display: inline-block;
+  text-decoration: none;
   text-shadow: 1px 1px 0px #FFF; -webkit-text-shadow: 1px 1px 0px #FFF;
   background: transparent 10px 8px no-repeat;
 }


### PR DESCRIPTION
Right now, some of the main navigational buttons are deceptively clickable. I kept finding myself clicking multiple times on the edges of buttons with nothing happening and thinking something wasn't working. It was only because the links have wrapping elements that produce the boundary, which the links don't fully expand across vertically. 

Here's some before/after screens of the css diff: 

| | Main Nav | Action Buttons | Session Nav |
| ----- | ----- | ----- | ----- |
| Before | ![before](https://cl.ly/3L3Z0I3I0P0w/Screen%20Shot%202017-03-07%20at%208.26.14%20PM.png) | ![before](https://cl.ly/0v3R1G2Q0w1Y/Screen%20Shot%202017-03-07%20at%208.27.24%20PM.png) | ![before](https://cl.ly/3G3F3U2R1b44/Screen%20Shot%202017-03-07%20at%208.29.11%20PM.png) |
| After | ![after](https://cl.ly/0L0m0S133r2N/Screen%20Shot%202017-03-07%20at%208.25.22%20PM.png) | ![after](https://cl.ly/3S2D1x1O4402/Screen%20Shot%202017-03-07%20at%208.27.53%20PM.png) | ![after](https://cl.ly/173a003G3x2R/Screen%20Shot%202017-03-07%20at%208.28.55%20PM.png) |