### PR TITLE
fix missing english translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,7 +150,7 @@ en:
     new:
       title: New User
       cancel: cancel
-      add_user: Adicionar usuário
+      add_user: Add User
     show:
       name: Name
       email: Email


### PR DESCRIPTION
Translates submit button on /users/new page to english
See #1168 