### PR TITLE
Add backtrace to Slack's notification

### DIFF
--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -92,7 +92,7 @@ class NotificationServices::SlackService < NotificationService
 
     def backtrace_line(line)
       path = line.decorated_path.gsub(%r{</?strong>}, '')
-      "#{path}#{line.number} → #{line.method}\n"
+      "#{path}#{line.file_name}:#{line.number} → #{line.method}\n"
     end
 
     def backtrace_lines(problem)

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -42,33 +42,7 @@ class NotificationServices::SlackService < NotificationService
           text:       problem.where,
           color:      "#D00000",
           mrkdwn_in:  ["fields"],
-          fields:     [
-            {
-              title: "Application",
-              value: problem.app.name,
-              short: true
-            },
-            {
-              title: "Environment",
-              value: problem.environment,
-              short: true
-            },
-            {
-              title: "Times Occurred",
-              value: problem.notices_count.try(:to_s),
-              short: true
-            },
-            {
-              title: "First Noticed",
-              value: problem.first_notice_at.try(:to_s, :db),
-              short: true
-            },
-            {
-              title: "Backtrace",
-              value: backtrace_lines(problem),
-              short: false
-            }
-          ]
+          fields:     post_payload_fields(problem)
         }
       ]
     }.compact.to_json # compact to remove empty channel in case it wasn't selected by user
@@ -89,6 +63,18 @@ class NotificationServices::SlackService < NotificationService
   end
 
 private
+
+  def post_payload_fields(problem)
+    [
+      { title: "Application", value: problem.app.name, short: true },
+      { title: "Environment", value: problem.environment, short: true },
+      { title: "Times Occurred", value: problem.notices_count.try(:to_s),
+        short: true },
+      { title: "First Noticed", value: problem.first_notice_at.try(:to_s, :db),
+        short: true },
+      { title: "Backtrace", value: backtrace_lines(problem), short: false }
+    ]
+  end
 
   def backtrace_line(line)
     path = line.decorated_path.gsub(%r{</?strong>}, '')

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -66,7 +66,7 @@ class NotificationServices::SlackService < NotificationService
             {
               title: "Backtrace",
               value: backtrace_lines(problem),
-              short:false
+              short: false
             }
           ]
         }
@@ -88,21 +88,21 @@ class NotificationServices::SlackService < NotificationService
     service_url.present?
   end
 
-  private
+private
 
-    def backtrace_line(line)
-      path = line.decorated_path.gsub(%r{</?strong>}, '')
-      "#{path}#{line.file_name}:#{line.number} → #{line.method}\n"
-    end
+  def backtrace_line(line)
+    path = line.decorated_path.gsub(%r{</?strong>}, '')
+    "#{path}#{line.file_name}:#{line.number} → #{line.method}\n"
+  end
 
-    def backtrace_lines(problem)
-      notice = NoticeDecorator.new problem.notices.last
-      return unless notice
-      backtrace = notice.backtrace
-      return unless backtrace
+  def backtrace_lines(problem)
+    notice = NoticeDecorator.new problem.notices.last
+    return unless notice
+    backtrace = notice.backtrace
+    return unless backtrace
 
-      output = ''
-      backtrace.lines[0..4].each { |line| output << backtrace_line(line) }
-      "```#{output}```"
-    end
+    output = ''
+    backtrace.lines[0..4].each { |line| output << backtrace_line(line) }
+    "```#{output}```"
+  end
 end

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -12,6 +12,15 @@ describe NotificationServices::SlackService, type: 'model' do
   let(:room_id) do
     "#general"
   end
+  let(:backtrace_lines) do
+    backtrace = BacktraceDecorator.new problem.notices.last.backtrace
+    backtrace_lines = ''
+    backtrace.lines[0..4].each do |line|
+      path = line.decorated_path.gsub(%r{</?strong>}, '')
+      backtrace_lines << "#{path}#{line.number} → #{line.method}\n"
+    end
+    "```#{backtrace_lines}```"
+  end
 
   # faraday stubbing
   let(:payload_hash) do
@@ -26,6 +35,7 @@ describe NotificationServices::SlackService, type: 'model' do
           title_link: problem.url,
           text:       problem.where,
           color:      "#D00000",
+          mrkdwn_in:  ["fields"],
           fields:     [
             {
               title: "Application",
@@ -46,6 +56,11 @@ describe NotificationServices::SlackService, type: 'model' do
               title: "First Noticed",
               value: problem.first_notice_at.try(:to_s, :db),
               short: true
+            },
+            {
+              title: "Backtrace",
+              value: backtrace_lines,
+              short: false
             }
           ]
         }

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -1,5 +1,15 @@
 describe NotificationServices::SlackService, type: 'model' do
-  let(:notice) { Fabricate :notice }
+  let(:backtrace) do
+    Fabricate :backtrace, lines: [
+      { number: 22, file: "/path/to/file/1.rb", method: 'first_method' },
+      { number: 44, file: "/path/to/file/2.rb", method: 'second_method' },
+      { number: 11, file: "/path/to/file/3.rb", method: 'third_method' },
+      { number: 103, file: "/path/to/file/4.rb", method: 'fourth_method' },
+      { number: 923, file: "/path/to/file/5.rb", method: 'fifth_method' },
+      { number: 8, file: "/path/to/file/6.rb", method: 'sixth_method' }
+    ]
+  end
+  let(:notice) { Fabricate :notice, backtrace: backtrace }
   let(:problem) { notice.problem }
   let(:service_url) do
     "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX"
@@ -13,13 +23,12 @@ describe NotificationServices::SlackService, type: 'model' do
     "#general"
   end
   let(:backtrace_lines) do
-    backtrace = BacktraceDecorator.new problem.notices.last.backtrace
-    backtrace_lines = ''
-    backtrace.lines[0..4].each do |line|
-      path = line.decorated_path.gsub(%r{</?strong>}, '')
-      backtrace_lines << "#{path}#{line.number} → #{line.method}\n"
-    end
-    "```#{backtrace_lines}```"
+    lines = "/path/to/file/1.rb:22 → first_method\n" \
+            "/path/to/file/2.rb:44 → second_method\n" \
+            "/path/to/file/3.rb:11 → third_method\n" \
+            "/path/to/file/4.rb:103 → fourth_method\n" \
+            "/path/to/file/5.rb:923 → fifth_method\n"
+    "```#{lines}```"
   end
 
   # faraday stubbing


### PR DESCRIPTION
It's helpful to see a little more information about the error in Slack,
so now the first five lines of the backtrace show up at the bottom of
the notification.

https://content.screencast.com/users/dsandstrom/folders/Jing/media/ef18cfa1-91f8-4b2d-bd9c-28b0228ae6c4/00000293.png

Fixes #1104