### PR TITLE
support mentioning users as part of hipchat room notification

### DIFF
--- a/app/models/notification_service.rb
+++ b/app/models/notification_service.rb
@@ -6,6 +6,7 @@ class NotificationService
   default_url_options[:port] = ActionMailer::Base.default_url_options[:port]
 
   field :room_id, type: String
+  field :mentions, type: String
   field :user_id, type: String
   field :service_url, type: String
   field :service, type: String

--- a/app/models/notification_services/hipchat_service.rb
+++ b/app/models/notification_services/hipchat_service.rb
@@ -42,6 +42,8 @@ if defined? HipChat
     end
 
     def create_notification(problem)
+      # @mentions can only be used when format == "text".  See hipchat
+      # api for more info: https://www.hipchat.com/docs/apiv2/method/send_room_notification
       format = self[:mentions].present? ? "text" : "html"
       message = (format == "text") ? message_text(problem) : message_html(problem)
 

--- a/app/models/notification_services/hipchat_service.rb
+++ b/app/models/notification_services/hipchat_service.rb
@@ -42,13 +42,8 @@ if defined? HipChat
     end
 
     def create_notification(problem)
-      url = app_problem_url problem.app, problem
       format = self[:mentions].present? ? "text" : "html"
-      message = if self[:mentions].present?
-                  message_text(problem)
-                else
-                  message_html(problem)
-                end
+      message = (format == "text") ? message_text(problem) : message_html(problem)
 
       options = { api_version: self[:service] }
       options[:server_url] = self[:service_url] if service_url.present?
@@ -60,6 +55,7 @@ if defined? HipChat
     private
 
     def message_html(problem)
+      url = app_problem_url(problem.app, problem)
       <<-MSG.strip_heredoc
         <strong>#{ERB::Util.html_escape problem.app.name}</strong> error in <strong>#{ERB::Util.html_escape problem.environment}</strong> at <strong>#{ERB::Util.html_escape problem.where}</strong> (<a href="#{url}">details</a>)<br>
         &nbsp;&nbsp;#{ERB::Util.html_escape problem.message.to_s.truncate(100)}<br>
@@ -68,6 +64,7 @@ if defined? HipChat
     end
 
     def message_text(problem)
+      url = app_problem_url(problem.app, problem)
       <<-MSG
 #{self[:mentions]} #{problem.app.name} error in #{problem.environment}: #{problem.message.to_s.truncate(100)}
   Error at: #{problem.where} (#{url})


### PR DESCRIPTION
When notifications are sent to hipchat rooms, developers can't receive a push notification unless they are @mentioned.  Getting a push notification when an error happens seems like a fairly useful feature: it definitely is for my team.  I've updated the hipchat notification service to include an @mentioned field that will be prepended to the error message so all users @mentioned can receive the push notification.

One caveat about hipchat though, is that their API only allows @mentions when the message format is 'text'.  The default format (and the one currently used by errbit) is 'html'.  So for this pull request, if @mentions is set the notification service will use the 'text' format, otherwise it will keep the original 'html' format.