### PR TITLE
Allow sending email notification for *every* error

### DIFF
--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -87,8 +87,8 @@ class ErrorReport
 
   # Send email notification if needed
   def email_notification
-    return false unless app.emailable?
-    return false unless should_email?
+    return unless app.emailable?
+    return unless should_email?
     Mailer.err_notification(self).deliver_now
   rescue => e
     HoptoadNotifier.notify(e)
@@ -101,7 +101,7 @@ class ErrorReport
 
   # Launch all notification define on the app associate to this notice
   def services_notification
-    return true unless app.notification_service_configured? && should_notify?
+    return unless app.notification_service_configured? && should_notify?
     app.notification_service.create_notification(problem)
   rescue => e
     HoptoadNotifier.notify(e)

--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -80,10 +80,14 @@ class ErrorReport
     @problem = Problem.cache_notice(@error.problem_id, @notice)
   end
 
+  def should_email?
+    app.email_at_notices.include?(@problem.notices_count)
+  end
+
   # Send email notification if needed
   def email_notification
     return false unless app.emailable?
-    return false unless app.email_at_notices.include?(@problem.notices_count)
+    return false unless should_email?
     Mailer.err_notification(self).deliver_now
   rescue => e
     HoptoadNotifier.notify(e)

--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -87,8 +87,7 @@ class ErrorReport
 
   # Send email notification if needed
   def email_notification
-    return unless app.emailable?
-    return unless should_email?
+    return unless app.emailable? && should_email?
     Mailer.err_notification(self).deliver_now
   rescue => e
     HoptoadNotifier.notify(e)

--- a/app/models/error_report.rb
+++ b/app/models/error_report.rb
@@ -81,7 +81,8 @@ class ErrorReport
   end
 
   def should_email?
-    app.email_at_notices.include?(@problem.notices_count)
+    app.email_at_notices.include?(0) ||
+      app.email_at_notices.include?(@problem.notices_count)
   end
 
   # Send email notification if needed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ In order of precedence Errbit uses:
 <dd>The value that should be set in the 'from' field for outgoing emails
 <dd>defaults to errbit@example.com
 <dt>ERRBIT_EMAIL_AT_NOTICES
-<dd>Errbit notifies watchers via email after the set number of occurances of the same error
+<dd>Errbit notifies watchers via email after the set number of occurances of the same error. [0] means notify on every occurance.
 <dd>defaults to [1,10,100]
 <dt>ERRBIT_PER_APP_EMAIL_AT_NOTICES
 <dd>Let every application have it's own configuration rather than using ERRBIT_EMAIL_AT_NOTICES. If this value is true, you can configure each app using the web UI.

--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -236,6 +236,50 @@ describe ErrorReport do
       expect(email.subject).to include("[#{notice.environment_name}]")
     end
 
+    context 'when email_at_notices config is specified', type: :mailer do
+      before do
+        allow(Errbit::Config).to receive(:email_at_notices).and_return(email_at_notices)
+      end
+
+      context 'as [0]' do
+        let(:email_at_notices) { [0] }
+
+        it "sends email on 1st occurrence" do
+          1.times { described_class.new(xml).generate_notice! }
+          expect(ActionMailer::Base.deliveries.length).to eq(1)
+        end
+
+        it "sends email on 2nd occurrence" do
+          2.times { described_class.new(xml).generate_notice! }
+          expect(ActionMailer::Base.deliveries.length).to eq(2)
+        end
+
+        it "sends email on 3rd occurrence" do
+          3.times { described_class.new(xml).generate_notice! }
+          expect(ActionMailer::Base.deliveries.length).to eq(3)
+        end
+      end
+
+      context "as [1,3]" do
+        let(:email_at_notices) { [1,3] }
+
+        it "sends email on 1st occurrence" do
+          1.times { described_class.new(xml).generate_notice! }
+          expect(ActionMailer::Base.deliveries.length).to eq(1)
+        end
+
+        it "does not send email on 2nd occurrence" do
+          2.times { described_class.new(xml).generate_notice! }
+          expect(ActionMailer::Base.deliveries.length).to eq(1)
+        end
+
+        it "sends email on 3rd occurrence" do
+          3.times { described_class.new(xml).generate_notice! }
+          expect(ActionMailer::Base.deliveries.length).to eq(2)
+        end
+      end
+    end
+
     context "with xml without request section" do
       let(:xml) do
         Rails.root.join('spec', 'fixtures', 'hoptoad_test_notice_without_request_section.xml').read


### PR DESCRIPTION
This makes the behaviour of `ERRBIT_EMAIL_AT_NOTICES` consistent with that of `ERRBIT_NOTIFY_AT_NOTICES`.

We work hard to keep the exception notifications in our apps to zero. The default configuration is to only send emails for the 1st, 10th and 100th occurrence of an error. We've found that this sometimes means we mark the 1st occurrence error as resolved and then it recurs a few more times and we are not notified. We'd prefer to be notified every time, hence this change.