### PR TITLE
Fix table layout on the problems page (#1051)

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -683,6 +683,9 @@ td.count, td.issue_link {
 }
 
 /* Err Tables */
+table.errs th, table.errs td {
+  word-break: break-all;
+}
 table.errs td.app .name {
   display: block;
   width: 150px;
@@ -696,11 +699,6 @@ table.errs td.app .environment {
 }
 table.errs td.message a {
   display: block;
-  word-wrap: break-word;
-  width: 440px;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
 }
 table.errs td.message em {
   color: #727272;


### PR DESCRIPTION
## Summary

See #1051

By not specifying the cell width of `WHERE & WHAT`, auto layout the table.
because if the cell size is fixed, table overflows the width of container when the number of columns changes. (e.g. issue column)

## Before

![errbit_current](https://cloud.githubusercontent.com/assets/1935816/26479699/4517476c-4210-11e7-83bd-791b526bb612.png)

## After

![errbit_fix_layout](https://cloud.githubusercontent.com/assets/1935816/26479702/480c27e4-4210-11e7-87db-9b616da86323.png)

