### PR TITLE
Feature outdated problem clearer

### DIFF
--- a/app/interactors/outdated_problem_clearer.rb
+++ b/app/interactors/outdated_problem_clearer.rb
@@ -1,0 +1,31 @@
+require 'problem_destroy'
+
+class OutdatedProblemClearer
+  ##
+  # Clear all problem not present for more than one week.
+  #
+  def execute
+    nb_problem_outdated.tap do |nb|
+      if nb > 0
+        criteria.each do |problem|
+          ProblemDestroy.new(problem).execute
+        end
+        repair_database
+      end
+    end
+  end
+
+private
+
+  def nb_problem_outdated
+    @count ||= criteria.count
+  end
+
+  def criteria
+    @criteria ||= Problem.where(:last_notice_at.lt => Errbit::Config.notice_deprecation_days.to_f.days.ago)
+  end
+
+  def repair_database
+    Mongoid.default_client.command repairDatabase: 1
+  end
+end

--- a/app/interactors/outdated_problem_clearer.rb
+++ b/app/interactors/outdated_problem_clearer.rb
@@ -22,7 +22,7 @@ private
   end
 
   def criteria
-    @criteria ||= Problem.where(:last_notice_at.lt => Errbit::Config.notice_deprecation_days.to_f.days.ago)
+    @criteria ||= Problem.where(:last_notice_at.lt => Errbit::Config.errbit_problem_destroy_after_days.to_f.days.ago)
   end
 
   def repair_database

--- a/config/load.rb
+++ b/config/load.rb
@@ -23,6 +23,7 @@ Errbit::Config = Configurator.run(
   per_app_notify_at_notices: ['ERRBIT_PER_APP_NOTIFY_AT_NOTICES'],
   log_location:              ['ERRBIT_LOG_LOCATION'],
   log_level:                 ['ERRBIT_LOG_LEVEL'],
+  notice_deprecation_days:   ['ERRBIT_PROBLEM_DESTROY_AFTER_DAYS'],
 
   serve_static_assets:       ['SERVE_STATIC_ASSETS'],
   secret_key_base:           ['SECRET_KEY_BASE'],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,9 @@ In order of precedence Errbit uses:
 <dt>ERRBIT_PER_APP_NOTIFY_AT_NOTICES
 <dd>Let every application have it's own configuration rather than using ERRBIT_NOTIFY_AT_NOTICES. If this value is set to true, you can configure each app using the web UI.
 <dd>defaults to false
+<dt>ERRBIT_PROBLEM_DESTROY_AFTER_DAYS
+<dd>Number of days to keep errors in the database when running rake errbit:clear_outdated
+<dd>defaults to nil (off)
 <dt>SERVE_STATIC_ASSETS
 <dd>Allow Rails to serve static assets. For most production environments, this should be false because your web server should be configured to serve static assets for you. But some environments like Heroku require this to be true.
 <dd>defaults to true

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -11,7 +11,7 @@ namespace :errbit do
   end
 
   desc "Delete old errors from the database. (Useful for limited heroku databases)"
-  task :clear_outdated => :environment do
+  task clear_outdated: :environment do
     require 'outdated_problem_clearer'
     if Errbit.config.errbit_problem_destroy_after_days.present?
       puts "=== Cleared #{OutdatedProblemClearer.new.execute} outdated errors from the database."

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -10,6 +10,16 @@ namespace :errbit do
     puts "=== Cleared #{ResolvedProblemClearer.new.execute} resolved errors from the database."
   end
 
+  desc "Delete old errors from the database. (Useful for limited heroku databases)"
+  task :clear_outdated => :environment do
+    require 'outdated_problem_clearer'
+    if Errbit.config.errbit_problem_destroy_after_days.present?
+      puts "=== Cleared #{OutdatedProblemClearer.new.execute} outdated errors from the database."
+    else
+      puts "=== ERRBIT_PROBLEM_DESTROY_AFTER_DAYS not set. Old problems will not be destroyed."
+    end
+  end
+
   desc "Regenerate fingerprints"
   task notice_refingerprint: :environment do
     NoticeRefingerprinter.run

--- a/spec/interactors/outdated_problem_clearer_spec.rb
+++ b/spec/interactors/outdated_problem_clearer_spec.rb
@@ -1,0 +1,56 @@
+describe OutdatedProblemClearer do
+  before do
+    allow(Errbit::Config).to receive(:errbit_problem_destroy_after_days).and_return(7)
+  end
+
+  let(:outdated_problem_clearer) do
+    OutdatedProblemClearer.new
+  end
+  describe "#execute" do
+    let!(:problems) do
+      [
+        Fabricate(:problem),
+        Fabricate(:problem),
+        Fabricate(:problem)
+      ]
+    end
+    context 'without old problems' do
+      it 'do nothing' do
+        expect do
+          expect(outdated_problem_clearer.execute).to eq 0
+        end.to_not change {
+          Problem.count
+        }
+      end
+      it 'not repair database' do
+        allow(Mongoid.default_client).to receive(:command).and_call_original
+        expect(Mongoid.default_client).to_not receive(:command).with(repairDatabase: 1)
+        outdated_problem_clearer.execute
+      end
+    end
+
+    context "with old problems" do
+      before do
+        allow(Mongoid.default_client).to receive(:command).and_call_original
+        allow(Mongoid.default_client).to receive(:command).with(repairDatabase: 1)
+        problems.first.update(last_notice_at: Time.zone.at(946_684_800.0))
+        problems.second.update(last_notice_at: Time.zone.at(946_684_800.0))
+      end
+
+      it 'deletes old problems' do
+        expect do
+          expect(outdated_problem_clearer.execute).to eq 2
+        end.to change {
+          Problem.count
+        }.by(-2)
+        expect(Problem.where(_id: problems.first.id).first).to be_nil
+        expect(Problem.where(_id: problems.second.id).first).to be_nil
+      end
+
+      it 'repair database' do
+        expect(Mongoid.default_client).to receive(:command).with(repairDatabase: 1)
+        outdated_problem_clearer.execute
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rebase of #660

Now that the deployment tracking is gone I could really use a way to clear old `Problems` without clicking...