### PR TITLE
#fix-ui-collapse | when the env info is too long,the UI will collapse :(

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -692,12 +692,14 @@ table.errs td.app .name {
 }
 table.errs td.app .environment {
   font-size: 0.8em;
+  word-break:break-all;
+  text-overflow:ellipsis;
   color: #999;
 }
 table.errs td.message a {
   display: block;
   word-wrap: break-word;
-  width: 440px;
+  width: 400px;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;


### PR DESCRIPTION
>errbit.version = 0.6 && 0.7-dev
### Hi,the team of errbit,when I use errbit to collect errors,I found a issue 💥 about UI as follows.
![collapse](https://user-images.githubusercontent.com/14012511/29276442-3d696b4c-8141-11e7-86f1-b97e2dd343f0.png)
### This is a problem just because of the **css** file and I fixed it.
![errbit_2_](https://user-images.githubusercontent.com/14012511/29276943-cffd964e-8142-11e7-94c0-1b66f15db50c.jpg)

#### Hope you can check this pull request and fix this problem,Thank you all.
>BTW: I am not native english speaker,so sorry for my poor english. :bowtie: 

