### PR TITLE
Fix webhook service notification payload

### DIFF
--- a/app/models/notification_services/webhook_service.rb
+++ b/app/models/notification_services/webhook_service.rb
@@ -15,7 +15,7 @@ class NotificationServices::WebhookService < NotificationService
 
   def message_for_webhook(problem)
     {
-      problem: { url: problem.url }.merge(problem.as_json).to_json
+      problem: { url: problem.url }.merge(problem.as_json)
     }
   end
 

--- a/spec/models/notification_service/webhook_service_spec.rb
+++ b/spec/models/notification_service/webhook_service_spec.rb
@@ -9,4 +9,16 @@ describe NotificationServices::WebhookService, type: 'model' do
 
     notification_service.create_notification(problem)
   end
+
+  context "#message_for_webhook" do
+    it "should return an hash with all the keys nested inside 'problem' key" do
+      notice = Fabricate :notice
+      notification_service = Fabricate :webhook_notification_service, app: notice.app
+      problem = notice.problem
+
+      payload = notification_service.message_for_webhook(problem)
+
+      expect(payload[:problem]).to be_a(Hash)
+    end
+  end
 end


### PR DESCRIPTION
NotificationServices::WebhookService#message_for_webhook
previously returned an Hash with a single key "problem"
with a string as value:

{
    "problem": "Stringified json here"
}

actually loosing almost all the "problem" properties.

Now the "problem" key bring on a child Hash as expected.