### PR TITLE
allow fluid table columns on problem index

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -652,7 +652,7 @@ td.message .line {
 td.latest {
   white-space: nowrap;
 }
-td.count, td.issue_link {
+td.count .td-container, td.issue_link .td-container, td.resolve .td-container {
   text-align: center;
 }
 
@@ -683,30 +683,34 @@ td.count, td.issue_link {
 }
 
 /* Err Tables */
-table.errs td.app .name {
-  display: block;
-  width: 150px;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
-}
 table.errs td.app .environment {
   font-size: 0.8em;
   color: #999;
 }
-table.errs td.message a {
-  display: block;
-  word-wrap: break-word;
-  width: 440px;
+table.errs {
+  width: 100%;
+}
+table.errs td.narrow-as-possible {
+  width: 1px;
   white-space: nowrap;
-  text-overflow: ellipsis;
+}
+table.errs .nowrap {
+  white-space: nowrap;
+}
+/**
+ * td-container is useful for getting overflowing text to hide in a fluid-width
+ * table without having to set static widths on each column
+ */
+table.errs .td-container {
+  width: 0;
+  min-width: 100%;
   overflow: hidden;
+  text-overflow: ellipsis;
 }
 table.errs td.message em {
   color: #727272;
   font-size: 0.9em;
 }
-
 table.errs tr.resolved td > * {
   opacity: 0.5;
   -moz-opacity: 0.5;

--- a/app/views/problems/_table.html.haml
+++ b/app/views/problems/_table.html.haml
@@ -14,36 +14,45 @@
     %tbody
       - problems.each do |problem|
         %tr{:class => problem.resolved? ? 'resolved' : 'unresolved'}
-          %td.select
-            = check_box_tag "problems[]", problem.id, selected_problems.member?(problem.id.to_s)
+          %td.select.narrow-as-possible
+            %div.td-container
+              = check_box_tag "problems[]", problem.id, selected_problems.member?(problem.id.to_s)
           %td.app
-            = link_to problem.app.name, app_path(problem.app), class: 'name', title: problem.app.name
-            - if current_page?(:controller => 'problems')
-              %span.environment= link_to problem.environment, problems_path(:environment => problem.environment)
-            - else
-              %span.environment= link_to problem.environment, app_path(problem.app, :environment => problem.environment)
+            %div.td-container
+              = link_to problem.app.name, app_path(problem.app), class: 'name nowrap', title: problem.app.name
+              - if current_page?(:controller => 'problems')
+                %span.environment{class: 'nowrap', title: problem.environment}
+                  = link_to problem.environment, problems_path(:environment => problem.environment)
+              - else
+                %span.environment{class: 'nowrap', title: problem.environment}
+                  = link_to problem.environment, app_path(problem.app, :environment => problem.environment)
           %td.message
-            = link_to problem.message, app_problem_path(problem.app, problem), title: problem.message
-            %em= problem.where
-            - if problem.comments_count > 0
-              - comment = problem.comments.last
-              %br
-              .inline_comment
-                - if comment.user
-                  %em.commenter= (Errbit::Config.user_has_username ? comment.user.username : comment.user.email).to_s << ":"
-                %em= truncate(comment.body, :length => 100, :separator => ' ')
-          %td.latest #{time_ago_in_words(problem.last_notice_at)} #{I18n.t('problems.table.ago')}
-          %td.count= link_to problem.notices_count, app_problem_path(problem.app, problem)
-          - if any_issue_links
-            %td.issue_link
-              - if problem.app.issue_tracker_configured? && problem.issue_link.present? && problem.issue_link != 'pending'
-                = link_to image_tag("#{problem.issue_type}_goto.png"), problem.issue_link, :target => "_blank"
-          %td.resolve= link_to image_tag("thumbs-up.png"), resolve_app_problem_path(problem.app, problem),
-            :title => "Resolve", :method => :put, :data => { :confirm => problem_confirm('resolve_one') },
-            :class => 'resolve' if problem.unresolved?
+            %div.td-container
+              = link_to problem.message, app_problem_path(problem.app, problem), class: 'nowrap', title: problem.message
+              %em{class: 'nowrap', title: problem.where}= problem.where
+              - if problem.comments_count > 0
+                - comment = problem.comments.last
+                %br
+                .inline_comment{class: 'nowrap'}
+                  - if comment.user
+                    %em.commenter= (Errbit::Config.user_has_username ? comment.user.username : comment.user.email).to_s << ":"
+                  %em= truncate(comment.body, :length => 100, :separator => ' ')
+          %td.latest
+            - value = "#{time_ago_in_words(problem.last_notice_at)} #{I18n.t('problems.table.ago')}"
+            %div.td-container{class: 'nowrap', title: value}= value
+          %td.count.narrow-as-possible
+            %div.td-container= link_to problem.notices_count, app_problem_path(problem.app, problem)
+            - if any_issue_links
+              %td.issue_link.narrow-as-possible
+                - if problem.app.issue_tracker_configured? && problem.issue_link.present? && problem.issue_link != 'pending'
+                  = link_to image_tag("#{problem.issue_type}_goto.png"), problem.issue_link, :target => "_blank"
+          %td.resolve.narrow-as-possible
+            %div.td-container= link_to image_tag("thumbs-up.png"), resolve_app_problem_path(problem.app, problem),
+              :title => "Resolve", :method => :put, :data => { :confirm => problem_confirm('resolve_one') },
+              :class => 'resolve' if problem.unresolved?
       - if problems.none?
         %tr
-          %td{:colspan => (any_issue_links ? 8 : 7)}
+          %td{:colspan => 100}
             %em No errs here
   = paginate problems
   .tab-bar


### PR DESCRIPTION
Ever since we started allowing tables to have varying numbers of columns, we've had problems with our static layout. There are a number of competing goals we have:

1. tables should look fine even when there's lots of non-breaking characters in each of the text fields
2. when text is too long, it should `overflow: ellipsis`
3. when text is too long, it should have a title tag with (more) complete text on hover
4. when text is too long, we should avoid excessively tall table cells, refusing to wrap text wherever possible
5. when columns are added/removed via configuration, the table should remain as wide as its container and not blow outside its bounds
6. ideally, the table should still behave like a classic HTML table and adapt dynamically to the size of its contents

This is surprisingly difficult, but I think we've got something here.