### PR TITLE
Fix portuguese word in en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -250,7 +250,7 @@ en:
       occurred: Occurred
       similar: Similar
       browser: Browser
-      tenant: Origem
+      tenant: Origin
       app_server: App Server
       app_version: App Version
       framework: Framework


### PR DESCRIPTION
Used to be called "Tenant" in older versions, now it's portuguese, I propose "Origin"?

![](http://files.sven.bmonkeys.net/images/Errbit__ActionControllerUnknownFormat_2017-09-03_15-32-07.png)