### PR TITLE
Fix whitespace issues for issue tracker buttons

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -228,6 +228,7 @@ a.action  { float: right; font-size: 0.9em;}
   text-decoration: none;
   text-shadow: 1px 1px 0px #FFF; -webkit-text-shadow: 1px 1px 0px #FFF;
   background: transparent 10px 8px no-repeat;
+  white-space: nowrap;
 }
 #action-bar a:hover { text-decoration: none;}
 #action-bar span:hover {


### PR DESCRIPTION
For some reason the newline after button text caused the button to
show at double it's normal height.

This fix adds css to prevent line-wrapping in button texts.

![Screenshot of Problem](https://user-images.githubusercontent.com/909587/30225048-5dc041ba-94d1-11e7-9e1a-f62b30ee4c85.png)
