### PR TITLE
Improve the notices query in comment notification

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -31,7 +31,7 @@ class Mailer < ActionMailer::Base
     @comment  = comment
     @user     = comment.user
     @problem  = ProblemDecorator.new comment.err
-    @notice   = @problem.notices.first
+    @notice   = NoticeDecorator.new comment.err.notices.first
     @app      = @problem.app
 
     recipients = @comment.notification_recipients


### PR DESCRIPTION
Decorator's association like `ProblemDecorator.new(comment.err).notices.first` doesn't optimise the query, instead it pulls all the `notices` from database. When a `problem` has many `notices`, this becomes a critical performance issue. 

Perhaps no additional test is required.