### PR TITLE
Fix #1225 - Use X-Airbrake-Token header when present

### DIFF
--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -12,8 +12,9 @@ class Api::V3::NoticesController < ApplicationController
     response.headers['Access-Control-Allow-Headers'] = 'origin, content-type, accept'
     return render(status: 200, text: '') if request.method == 'OPTIONS'
 
-    report = AirbrakeApi::V3::NoticeParser.new(
-      params.merge(JSON.parse(request.raw_post) || {})).report
+    merged_params = params.merge(JSON.parse(request.raw_post) || {})
+    merged_params = merged_params.merge('key' => request.headers['X-Airbrake-Token']) if request.headers['X-Airbrake-Token']
+    report = AirbrakeApi::V3::NoticeParser.new(merged_params).report
 
     return render text: UNKNOWN_API_KEY, status: 422 unless report.valid?
     return render text: VERSION_TOO_OLD, status: 422 unless report.should_keep?

--- a/spec/controllers/api/v3/notices_controller_spec.rb
+++ b/spec/controllers/api/v3/notices_controller_spec.rb
@@ -32,6 +32,12 @@ describe Api::V3::NoticesController, type: :controller do
     expect(response.status).to be(201)
   end
 
+  it 'responds with 201 created on success with token in headers' do
+    request.headers['X-Airbrake-Token'] = project_id
+    post :create, legit_body, project_id: 123
+    expect(response.status).to be(201)
+  end
+
   it 'responds with 400 when request attributes are not valid' do
     allow_any_instance_of(AirbrakeApi::V3::NoticeParser).
       to receive(:report).and_raise(AirbrakeApi::ParamsError)


### PR DESCRIPTION
Fixes compatibility issues with javabrake, the new Airbrake java client. 

This client uses the X-Airbrake-Token header instead of sending the apiKey in the ?key=foobar query parameter.