### PR TITLE
Allowing Errbit to run on OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "gem: --no-document" >> /etc/gemrc \
 
 RUN mkdir -p /app \
   && chown -R errbit:errbit /app \
-  && chmod 700 /app/
+  && chmod 705 /app/
 WORKDIR /app
 
 RUN gem update --system \


### PR DESCRIPTION
#1232 

As OpenShift assigns an arbritrary user to the container at start up the user requires a read and execute permission to run/read the code, so the permission has been modified accordingly.

700 -> 705
