### PR TITLE
Allow Authorization header for authentication

### DIFF
--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -29,7 +29,7 @@ class Api::V3::NoticesController < ApplicationController
     render text: 'Invalid request', status: 400
   end
 
-  private
+private
 
   def authorization_token
     request.headers['Authorization'].to_s[/Bearer (.+)/, 1]

--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -14,7 +14,7 @@ class Api::V3::NoticesController < ApplicationController
 
     merged_params = params.merge(JSON.parse(request.raw_post) || {})
     merged_params = merged_params.merge('key' => request.headers['X-Airbrake-Token']) if request.headers['X-Airbrake-Token']
-    merged_params = merged_params.merge('key' => authorization_token) if request.headers['Authorization']
+    merged_params = merged_params.merge('key' => authorization_token) if authorization_token
     report = AirbrakeApi::V3::NoticeParser.new(merged_params).report
 
     return render text: UNKNOWN_API_KEY, status: 422 unless report.valid?
@@ -32,7 +32,6 @@ class Api::V3::NoticesController < ApplicationController
   private
 
   def authorization_token
-    matches = request.headers['Authorization'].match /Bearer (.+)/
-    matches[1]
+    request.headers['Authorization'].to_s[/Bearer (.+)/, 1]
   end
 end

--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -14,6 +14,7 @@ class Api::V3::NoticesController < ApplicationController
 
     merged_params = params.merge(JSON.parse(request.raw_post) || {})
     merged_params = merged_params.merge('key' => request.headers['X-Airbrake-Token']) if request.headers['X-Airbrake-Token']
+    merged_params = merged_params.merge('key' => authorization_token) if request.headers['Authorization']
     report = AirbrakeApi::V3::NoticeParser.new(merged_params).report
 
     return render text: UNKNOWN_API_KEY, status: 422 unless report.valid?
@@ -26,5 +27,12 @@ class Api::V3::NoticesController < ApplicationController
     }
   rescue AirbrakeApi::ParamsError
     render text: 'Invalid request', status: 400
+  end
+
+  private
+
+  def authorization_token
+    matches = request.headers['Authorization'].match /Bearer (.+)/
+    matches[1]
   end
 end

--- a/spec/controllers/api/v3/notices_controller_spec.rb
+++ b/spec/controllers/api/v3/notices_controller_spec.rb
@@ -32,10 +32,22 @@ describe Api::V3::NoticesController, type: :controller do
     expect(response.status).to be(201)
   end
 
-  it 'responds with 201 created on success with token in headers' do
+  it 'responds with 201 created on success with token in Airbrake Token header' do
     request.headers['X-Airbrake-Token'] = project_id
     post :create, legit_body, project_id: 123
     expect(response.status).to be(201)
+  end
+
+  it 'responds with 201 created on success with token in Authorization header' do
+    request.headers['Authorization'] = "Bearer #{project_id}"
+    post :create, legit_body, project_id: 123
+    expect(response.status).to be(201)
+  end
+
+  it 'responds with 422 when Authorization header is not valid' do
+    request.headers['Authorization'] = "incorrect"
+    post :create, legit_body, project_id: 123
+    expect(response.status).to be(422)
   end
 
   it 'responds with 400 when request attributes are not valid' do


### PR DESCRIPTION
This fixes #1236 where airbrake-ruby 2.5.1 added the Authorization header for the project key instead. 

See airbrake/airbrake-ruby#278