### PR TITLE
fix yaml extention typo in kubernetes deployment docs

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -8,10 +8,10 @@ cd errbit
 
 ### Create replication controller
 ```bash
-kubectl create -f docs/deployment/example/kubernetes/rc.yaml
+kubectl create -f docs/deployment/example/kubernetes/rc.yml
 ```
 
 ### Create svc
 ```bash
-kubectl create -f docs/deployment/example/kubernetes/svc.yaml
+kubectl create -f docs/deployment/example/kubernetes/svc.yml
 ```


### PR DESCRIPTION
the file is `docs/deployment/example/kubernetes/rc.yml` not `docs/deployment/example/kubernetes/rc.yaml`, etc.