### PR TITLE
adding health check endpoints. w/ burnettk

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -1,0 +1,24 @@
+class HealthController < ActionController::Base
+  def readiness
+    check_results = [run_mongo_check]
+    all_ok = check_results.all? do |check|
+      check[:ok]
+    end
+    render json: { ok: all_ok, details: check_results }, status: :ok
+  end
+
+  def liveness
+    render json: { ok: true }, status: :ok
+  end
+
+private
+
+  def run_mongo_check
+    Timeout.timeout(3) do
+      Mongoid.default_client.database_names.present?
+    end
+    { check_name: 'mongo', ok: true }
+  rescue StandardError => e
+    { check_name: 'mongo', ok: false, error_details: "#{e.class}: #{e.message}" }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,9 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'health/readiness' => 'health#readiness'
+  get 'health/liveness' => 'health#liveness'
+
   namespace :api do
     namespace :v1 do
       resources :problems, only: [:index, :show], defaults: { format: 'json' }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -35,3 +35,12 @@ bundle exec puma -b "ssl://0.0.0.0:443?key=server.key&cert=server.crt" -C config
 ```
 Where `server.key` is a path to the TLS private key and `server.crt` is the path
 to the TLS certificate.
+
+## Health Checks
+
+If deploying with a system that can check if the app is running as expected then
+there are two endpoints that can be used:
+- `/health/readiness` - suitable for checking if app is ready to receive
+  requests. If response body contains `{ "ok": true, "details": [etc...] }` then app is ready.
+- `/health/liveness` - suitable for pinging periodically to check if app is still
+  alive. Expected result is `{ "ok": true }`

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -1,0 +1,26 @@
+describe "Health", type: 'request' do
+  describe "readiness" do
+    it 'can let you know when the app is ready to receive requests' do
+      get '/health/readiness'
+      expect(response).to be_success
+    end
+
+    it 'can indicate if a check fails' do
+      expect(Mongoid.default_client).to receive(:database_names).and_raise(Mongo::Error::NoServerAvailable)
+      get '/health/readiness'
+      expect(response).to be_success
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['ok']).to eq false
+      expect(parsed_response['details'].first['check_name']).to eq 'mongo'
+      expect(parsed_response['details'].first['ok']).to eq false
+      expect(parsed_response['details'].first['error_details']).to_not be_nil
+    end
+  end
+
+  describe "liveness" do
+    it 'can let you know that the app is still alive' do
+      get '/health/liveness'
+      expect(response).to be_success
+    end
+  end
+end


### PR DESCRIPTION
Adding health check endpoints. We need this in order to configure load balancers and orchestration tools like kubernetes.