### PR TITLE
Devise: conservative upgrade from 3.5.5 to 3.5.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,8 +45,8 @@ GEM
       multi_json
     arel (6.0.4)
     ast (2.3.0)
-    bcrypt (3.1.10)
-    bcrypt (3.1.10-java)
+    bcrypt (3.1.11)
+    bcrypt (3.1.11-java)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
       erubis (>= 2.6.6)
@@ -98,7 +98,7 @@ GEM
     debug_inspector (0.0.2)
     decent_exposure (3.0.2)
       activesupport (>= 4.0)
-    devise (3.5.5)
+    devise (3.5.10)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -314,8 +314,9 @@ GEM
     rake (12.0.0)
     ref (2.0.0)
     request_store (1.1.0)
-    responders (2.1.1)
-      railties (>= 4.2.0, < 5.1)
+    responders (2.4.0)
+      actionpack (>= 4.2.0, < 5.3)
+      railties (>= 4.2.0, < 5.3)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -413,7 +414,7 @@ GEM
     unf_ext (0.0.7.1)
     unicode-display_width (1.3.0)
     useragent (0.14.0)
-    warden (1.2.4)
+    warden (1.2.7)
       rack (>= 1.0)
     websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
@@ -500,4 +501,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Changelog shows only a few bugfixes:
https://github.com/plataformatec/devise/blob/a0af72edfdf2328bcc6586f57748c30422f2cabc/CHANGELOG.md