### PR TITLE
Avoid require memory leak with pathnames in load path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module Errbit
     # -- all .rb files in that directory are automatically loaded.
 
     # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths += [Rails.root.join('lib')]
+    config.autoload_paths << Rails.root.join('lib').to_s
 
     config.before_initialize do
       config.secret_key_base = Errbit::Config.secret_key_base


### PR DESCRIPTION
Any ruby requires that occur in your application will leak with
Pathnames in the $LOAD_PATH in ruby 2.3/2.4. Beyond that, it's faster
to use strings in the load path. Please join this bug and add your
support for a fix:

https://bugs.ruby-lang.org/issues/14372

Same problem found here: https://github.com/lobsters/lobsters/pull/449
and
https://github.com/opf/openproject/pull/6148