### PR TITLE
Fix rake errbit:clear_outdated task

### DIFF
--- a/app/interactors/outdated_problem_clearer.rb
+++ b/app/interactors/outdated_problem_clearer.rb
@@ -22,7 +22,7 @@ private
   end
 
   def criteria
-    @criteria ||= Problem.where(:last_notice_at.lt => Errbit::Config.errbit_problem_destroy_after_days.to_f.days.ago)
+    @criteria ||= Problem.where(:last_notice_at.lt => Errbit::Config.notice_deprecation_days.to_f.days.ago)
   end
 
   def repair_database

--- a/lib/tasks/errbit/database.rake
+++ b/lib/tasks/errbit/database.rake
@@ -13,7 +13,7 @@ namespace :errbit do
   desc "Delete old errors from the database. (Useful for limited heroku databases)"
   task clear_outdated: :environment do
     require 'outdated_problem_clearer'
-    if Errbit.config.errbit_problem_destroy_after_days.present?
+    if Errbit::Config.notice_deprecation_days.present?
       puts "=== Cleared #{OutdatedProblemClearer.new.execute} outdated errors from the database."
     else
       puts "=== ERRBIT_PROBLEM_DESTROY_AFTER_DAYS not set. Old problems will not be destroyed."

--- a/spec/interactors/outdated_problem_clearer_spec.rb
+++ b/spec/interactors/outdated_problem_clearer_spec.rb
@@ -1,6 +1,6 @@
 describe OutdatedProblemClearer do
   before do
-    allow(Errbit::Config).to receive(:errbit_problem_destroy_after_days).and_return(7)
+    allow(Errbit::Config).to receive(:notice_deprecation_days).and_return(7)
   end
 
   let(:outdated_problem_clearer) do


### PR DESCRIPTION
The configuration was probably renamed in the past, but the rake task and service object was not updated