### PR TITLE
Fix docker healthcheck for mutiple networks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ RUN chown -R errbit:errbit /app
 
 USER errbit
 
-HEALTHCHECK CMD curl --fail "http://$(/sbin/ip route | /usr/bin/awk '/src/{print $NF}'):8080/users/sign_in" ||  exit 1
+HEALTHCHECK CMD curl --fail "http://$(/sbin/ip route | /usr/bin/awk '/src/{print $NF}' | head -n1):8080/users/sign_in" ||  exit 1
 
 CMD ["bundle","exec","puma","-C","config/puma.default.rb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ RUN chown -R errbit:errbit /app
 
 USER errbit
 
-HEALTHCHECK CMD curl --fail "http://$(/sbin/ip route | /usr/bin/awk '/src/{print $NF}' | head -n1):8080/users/sign_in" ||  exit 1
+HEALTHCHECK CMD curl --fail "http://$(/sbin/ip route | /usr/bin/awk '/src/{print $NF}' | /usr/bin/head -n1):8080/users/sign_in" ||  exit 1
 
 CMD ["bundle","exec","puma","-C","config/puma.default.rb"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ RUN chown -R errbit:errbit /app
 
 USER errbit
 
-HEALTHCHECK CMD curl --fail "http://$(/sbin/ip route | /usr/bin/awk '/src/{print $NF}' | /usr/bin/head -n1):8080/users/sign_in" ||  exit 1
+HEALTHCHECK CMD curl --fail "http://$(/bin/hostname -i | /usr/bin/awk '{ print $1 }'):8080/users/sign_in" ||  exit 1
 
 CMD ["bundle","exec","puma","-C","config/puma.default.rb"]


### PR DESCRIPTION
If you attach multiple networks to the docker container the `/sbin/ip route | /usr/bin/awk '/src/{print $NF}'` will print something like this:
```
172.18.0.4
172.20.0.3
172.21.0.3
```

And the HEALTHCHECK command will fail with the following:
```
curl: (3) Illegal characters found in URL
```

This fix picks the first IP and uses this for checking if the service is available or not