### PR TITLE
Handle empty environment variables

### DIFF
--- a/lib/configurator.rb
+++ b/lib/configurator.rb
@@ -58,11 +58,7 @@ class Configurator
       @overrides[key] = values.pop if values.last.is_a? Proc
       env_name = values.find { |v| ENV[v] }
       if env_name
-        if ENV[env_name].empty?
-          @storage[key] = ''
-        else
-          @storage[key] = YAML.parse(ENV[env_name]).to_ruby
-        end
+        @storage[key] = ENV[env_name].empty? ? '' : YAML.parse(ENV[env_name]).to_ruby
       else
         @storage[key] = nil
       end

--- a/lib/configurator.rb
+++ b/lib/configurator.rb
@@ -57,11 +57,9 @@ class Configurator
     @mapping.each do |key, values|
       @overrides[key] = values.pop if values.last.is_a? Proc
       env_name = values.find { |v| ENV[v] }
-      if env_name
-        @storage[key] = ENV[env_name].empty? ? '' : YAML.parse(ENV[env_name]).to_ruby
-      else
-        @storage[key] = nil
-      end
+      @storage[key] = if env_name
+                        ENV[env_name].empty? ? '' : YAML.parse(ENV[env_name]).to_ruby
+                      end
     end
   end
 

--- a/lib/configurator.rb
+++ b/lib/configurator.rb
@@ -57,7 +57,15 @@ class Configurator
     @mapping.each do |key, values|
       @overrides[key] = values.pop if values.last.is_a? Proc
       env_name = values.find { |v| ENV[v] }
-      @storage[key] = YAML.parse(ENV[env_name]).to_ruby if env_name
+      if env_name
+        if ENV[env_name].empty?
+          @storage[key] = ''
+        else
+          @storage[key] = YAML.parse(ENV[env_name]).to_ruby
+        end
+      else
+        @storage[key] = nil
+      end
     end
   end
 

--- a/spec/lib/configurator_spec.rb
+++ b/spec/lib/configurator_spec.rb
@@ -54,4 +54,10 @@ describe Configurator do
     result = Configurator.run(mynumber: ['MYNUMBER'])
     expect(result.mynumber).to be(0)
   end
+
+  it 'parses empty variables' do
+    allow(ENV).to receive(:[]).with('EMPTYVAR').and_return('')
+    result = Configurator.run(emptyvar: ['EMPTYVAR'])
+    expect(result.emptyvar).to be('')
+  end
 end

--- a/spec/lib/configurator_spec.rb
+++ b/spec/lib/configurator_spec.rb
@@ -58,6 +58,6 @@ describe Configurator do
   it 'parses empty variables' do
     allow(ENV).to receive(:[]).with('EMPTYVAR').and_return('')
     result = Configurator.run(emptyvar: ['EMPTYVAR'])
-    expect(result.emptyvar).to be('')
+    expect(result.emptyvar).to eq('')
   end
 end


### PR DESCRIPTION
`YAML.parse` for an empty value `''` returns `false` instead of an expected object, thus directly feeding that into `to_ruby` method fails. This handles the case where environment variable is empty.

Fixes #1261 