### PR TITLE
 avoid truncating count where it is a four digit number

### DIFF
--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -659,7 +659,7 @@ td.count .td-container, td.issue_link .td-container, td.resolve .td-container {
 
 .count a {
   display: inline-block;
-  padding: 0.1em 0.6em;
+  padding: 0.1em 0.7em;
   margin-top: 3px;
   color: #fff;
   background-color: #cc0033;
@@ -707,6 +707,12 @@ table.errs .td-container {
   min-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+table.errs .count .td-container {
+  width: auto;
+}
+table.errs .count-header {
+  text-align: center;
 }
 table.errs td.message em {
   color: #727272;

--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -659,7 +659,7 @@ td.count .td-container, td.issue_link .td-container, td.resolve .td-container {
 
 .count a {
   display: inline-block;
-  padding: 0.1em 0.7em;
+  padding: 0.1em 0.6em;
   margin-top: 3px;
   color: #fff;
   background-color: #cc0033;

--- a/app/views/problems/_table.html.haml
+++ b/app/views/problems/_table.html.haml
@@ -7,7 +7,7 @@
         %th= link_for_sort t('.app')
         %th= link_for_sort t('.what_&_where').html_safe, "message"
         %th= link_for_sort t('.latest'), "last_notice_at"
-        %th= link_for_sort t('.count')
+        %th.count-header= link_for_sort t('.count')
         - if any_issue_links
           %th Issue
         %th= t('.resolve')


### PR DESCRIPTION
does not really affect the look to my untrained eye.

before:

![image](https://user-images.githubusercontent.com/18027/38815107-29bf324e-4161-11e8-888c-45e66a654626.png)

after:

![image](https://user-images.githubusercontent.com/18027/38815122-3492a62e-4161-11e8-9f95-8542028c393b.png)

there is no similar easy fix for five-digit numbers. :)