### PR TITLE
add first notice date to problem show page

### DIFF
--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -232,7 +232,7 @@ class Problem
 
 private
 
-  def attribute_count_descrease(name, value)
+  def attribute_count_decrease(name, value)
     counter = send(name)
     index = attribute_index(value)
     if counter[index] && counter[index]['count'] > 1

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -9,7 +9,9 @@
   %br
   %strong= t('.environment') + ':'
   = problem.environment
-  %strong= t('.last_notice') + ':'
+  %strong= t('.first_notice') + ':'
+  = problem.first_notice_at.to_s(:precise)
+  %strong= t('.last_notice') + '::'
   = problem.last_notice_at.to_s(:precise)
 - content_for :action_bar do
   - if problem.unresolved?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,7 @@ en:
       session: Session
       ago_by: ago by
       ago_by_unkown_user: ago by [Unkown User]
+      first_notice: First Notice
       last_notice: Last Notice
       environment: Environment
       app: App

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -116,6 +116,7 @@ pt-BR:
       session: Sessão
       ago_by: atrás por
       ago_by_unkown_user: atrás por [Usuário Desconhecido]
+      first_notice: Primeiro notificação
       last_notice: Última notificação
       environment: Ambiente
       app: Aplicação
@@ -143,7 +144,7 @@ pt-BR:
       name: Nome
       email: E-mail
       entries: Registros por página
-      time_zone: Fuso horário 
+      time_zone: Fuso horário
       password: Senha
       password_confirmation: Confirmação de Senha
       admin: Adminstrador?


### PR DESCRIPTION
i think it looks ok, it seems to be nice and indexed and available/quick to query (along with last_notice_at), and i'm pretty sure it's useful.

includes portuguese translation for new UI text.

also fixed typo in unused method instead of deleting the unused method, like a boss.

before:

![image](https://user-images.githubusercontent.com/18027/38816847-02e98896-4165-11e8-8e32-0c86191d3d36.png)

after:

![image](https://user-images.githubusercontent.com/18027/38816869-0f09104c-4165-11e8-92d4-ad8ac6e9cc2f.png)
