### PR TITLE
do not show app in table when already on an app/show page

### DIFF
--- a/app/controllers/problems_searcher.rb
+++ b/app/controllers/problems_searcher.rb
@@ -3,7 +3,7 @@ module ProblemsSearcher
 
   included do
     expose(:params_sort) do
-      if %w(app message last_notice_at count).member?(params[:sort])
+      if %w(environment app message last_notice_at count).member?(params[:sort])
         params[:sort]
       else
         "last_notice_at"

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -213,6 +213,7 @@ class Problem
   def self.ordered_by(sort, order)
     case sort
     when "app"            then order_by(["app_name", order])
+    when "environment"    then order_by(["environment", order])
     when "message"        then order_by(["message", order])
     when "last_notice_at" then order_by(["last_notice_at", order])
     when "count"          then order_by(["notices_count", order])

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -249,3 +249,4 @@ private
     Digest::MD5.hexdigest(value.to_s)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -2,6 +2,7 @@
 # reported as various Errs, but the user has grouped the
 # Errs together as belonging to the same problem.
 
+# rubocop:disable Metrics/ClassLength. At some point we need to break up this class, but I think it doesn't have to be right now.
 class Problem
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/app/views/problems/_table.html.haml
+++ b/app/views/problems/_table.html.haml
@@ -4,7 +4,10 @@
     %thead
       %tr
         %th= check_box_tag "toggle_problems_checkboxes"
-        %th= link_for_sort t('.app')
+        - if current_page?(:controller => 'problems')
+          %th= link_for_sort t('.app')
+        - else
+          %th= link_for_sort t('.env')
         %th= link_for_sort t('.what_&_where').html_safe, "message"
         %th= link_for_sort t('.latest'), "last_notice_at"
         %th= link_for_sort t('.count')
@@ -19,8 +22,8 @@
               = check_box_tag "problems[]", problem.id, selected_problems.member?(problem.id.to_s)
           %td.app
             %div.td-container
-              = link_to problem.app.name, app_path(problem.app), class: 'name nowrap', title: problem.app.name
               - if current_page?(:controller => 'problems')
+                = link_to problem.app.name, app_path(problem.app), class: 'name nowrap', title: problem.app.name
                 %span.environment{class: 'nowrap', title: problem.environment}
                   = link_to problem.environment, problems_path(:environment => problem.environment)
               - else

--- a/app/views/problems/_table.html.haml
+++ b/app/views/problems/_table.html.haml
@@ -7,7 +7,7 @@
         - if current_page?(:controller => 'problems')
           %th= link_for_sort t('.app')
         - else
-          %th= link_for_sort t('.env')
+          %th= link_for_sort t('.env'), 'environment'
         %th= link_for_sort t('.what_&_where').html_safe, "message"
         %th= link_for_sort t('.latest'), "last_notice_at"
         %th= link_for_sort t('.count')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
       show_resolved: "show resolved"
     table:
         app: App
+        env: Env
         what_&_where: 'Where & What'
         latest: Latest
         count: Count
@@ -113,7 +114,6 @@ en:
       summary: Summary
       backtrace: Backtrace
       user: User
-      environment: Environment
       parameters: Parameters
       session: Session
       ago_by: ago by

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -84,6 +84,7 @@ pt-BR:
       show_resolved: "exibir resolvidos"
     table:
         app: Aplicação
+        env: Ambiente
         what_&_where: 'O quê & onde'
         latest: Último
         count: Total
@@ -111,7 +112,6 @@ pt-BR:
       summary: Resumo
       backtrace: Backtrace
       user: Usuário
-      environment: Ambiente
       parameters: Parâmetros
       session: Sessão
       ago_by: atrás por
@@ -143,7 +143,7 @@ pt-BR:
       name: Nome
       email: E-mail
       entries: Registros por página
-      time_zone: Fuso horário 
+      time_zone: Fuso horário
       password: Senha
       password_confirmation: Confirmação de Senha
       admin: Adminstrador?


### PR DESCRIPTION
this updates pages like /apps/5a78bd63b33eb400a20e88dd, like this.

before:

![image](https://user-images.githubusercontent.com/18027/38819909-a88d7960-416a-11e8-9e20-50e0767aff17.png)

after:

![image](https://user-images.githubusercontent.com/18027/38819926-b26ac5dc-416a-11e8-8d71-de47d2b25e12.png)

Sorting by environments (which is implied as a feature by having an "ENV" column) now seems to work.

this table partial in question is used by two actions:
 * apps/show
 * problems/index

the conditional (which was already being used elsewhere in the same partial) makes it so problems/index continues to be rendered as before (show the app as well as the env).

this feels slightly higher risk than the other two PRs I just filed, but still very low risk, and hopefully it's a pure UX improvement and not at all controversial. but let me know!