### PR TITLE
add new health api that can be used to test client config, including api_key

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -12,6 +12,13 @@ class HealthController < ActionController::Base
     render json: { ok: true }, status: :ok
   end
 
+  def api_key_tester
+    app = App.where(api_key: params[:api_key]).first
+    is_good_result = app ? true : false
+    response_status = is_good_result ? :ok : :error
+    render json: { ok: is_good_result }, status: response_status
+  end
+
 private
 
   def run_mongo_check

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -15,7 +15,7 @@ class HealthController < ActionController::Base
   def api_key_tester
     app = App.where(api_key: params[:api_key]).first
     is_good_result = app ? true : false
-    response_status = is_good_result ? :ok : :error
+    response_status = is_good_result ? :ok : :forbidden
     render json: { ok: is_good_result }, status: response_status
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,7 @@ Rails.application.routes.draw do
 
   get 'health/readiness' => 'health#readiness'
   get 'health/liveness' => 'health#liveness'
+  get 'health/api-key-tester' => 'health#api_key_tester'
 
   namespace :api do
     namespace :v1 do

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -29,7 +29,7 @@ describe "Health", type: 'request' do
   describe "api_key_tester" do
     it 'will let you know when the api_key is not valid' do
       get "/health/api-key-tester?api_key=garbagekey"
-      expect(response).to be_error
+      expect(response).to be_forbidden
       parsed_response = JSON.parse(response.body)
       expect(parsed_response['ok']).to eq false
     end

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -1,4 +1,6 @@
 describe "Health", type: 'request' do
+  let(:errbit_app) { Fabricate(:app, api_key: 'APIKEY') }
+
   describe "readiness" do
     it 'can let you know when the app is ready to receive requests' do
       get '/health/readiness'
@@ -21,6 +23,22 @@ describe "Health", type: 'request' do
     it 'can let you know that the app is still alive' do
       get '/health/liveness'
       expect(response).to be_success
+    end
+  end
+
+  describe "api_key_tester" do
+    it 'will let you know when the api_key is not valid' do
+      get "/health/api-key-tester?api_key=garbagekey"
+      expect(response).to be_error
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['ok']).to eq false
+    end
+
+    it 'can let you know that the api_key is valid' do
+      get "/health/api-key-tester?api_key=#{errbit_app.api_key}"
+      expect(response).to be_success
+      parsed_response = JSON.parse(response.body)
+      expect(parsed_response['ok']).to eq true
     end
   end
 end


### PR DESCRIPTION
we have existing checks for errbit clients that actually use the normal "send-a-notice" api, but it's a bit suboptimal that errbit then ends up sending emails and whatnot. this new API provides pretty much the same assurance that the errbit client is configured correctly, but with fewer side effects. working with @jasquat .