### PR TITLE
GitHub Auth: Show error msg on empty email

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -111,7 +111,7 @@ private
     end
 
     # Try to get email from public profile
-    if !env["omniauth.auth"].extra.raw_info.email.nil? && env["omniauth.auth"].extra.raw_info.email != ""
+    if env["omniauth.auth"].extra.raw_info.email.present?
       return env["omniauth.auth"].extra.raw_info.email
     end
 

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,15 +1,22 @@
 describe Users::OmniauthCallbacksController, type: 'controller' do
-  def stub_env_for_github_omniauth(login, token = nil)
+  def stub_env_for_github_omniauth(login, token = nil, email = "user@example.com")
     # This a Devise specific thing for functional tests. See https://github.com/plataformatec/devise/issues/closed#issue/608
     request.env["devise.mapping"] = Devise.mappings[:user]
     env = {
       "omniauth.auth" => Hashie::Mash.new(
         provider:    'github',
-        extra:       { raw_info: { login: login } },
+        extra:       { raw_info: { login: login, email: email } },
         credentials: { token: token }
       )
     }
     allow(@controller).to receive(:env).and_return(env)
+  end
+
+  def stub_client_for_github_omniauth
+    mock_gh_client = double
+    expect(mock_gh_client).to receive(:organizations) { [OpenStruct.new(id: 42), OpenStruct.new(id: 43)] }
+    expect(mock_gh_client).to receive(:api_endpoint=)
+    expect(Octokit::Client).to receive(:new) { mock_gh_client }
   end
 
   context 'Linking a GitHub account to a signed in user' do
@@ -32,6 +39,39 @@ describe Users::OmniauthCallbacksController, type: 'controller' do
 
       expect(request.flash[:success]).to include('Successfully linked')
       expect(response).to redirect_to(user_path(@user))
+    end
+  end
+
+  context 'Creating a new user via Github authentication' do
+    before do
+      Errbit::Config.github_org_id = 42
+    end
+    after do
+      Errbit::Config.github_org_id = nil
+    end
+
+    context 'User has an email defined and selected in GitHub profile' do
+      it "should log in the user" do
+        stub_env_for_github_omniauth("new_user_with_proper_email", nil, "email@example.com")
+        stub_client_for_github_omniauth
+
+        get :github
+
+        expect(request.flash[:success]).to include('Successfully authenticated from GitHub account')
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'User has no email defined and selected in GitHub profile' do
+      it 'should return an error' do
+        stub_env_for_github_omniauth("new_user_with_no_email", nil, nil)
+        stub_client_for_github_omniauth
+
+        get :github
+
+        expect(request.flash[:error]).to include('You need to define and select a valid email in your Github profile')
+        expect(response).to redirect_to(user_session_path)
+      end
     end
   end
 


### PR DESCRIPTION
When using GITHUB_ORG_ID to automatically sign up new users, if the user has no email selected in his public profile, i.e, settings/profile looks like this:

<img width="778" alt="image" src="https://user-images.githubusercontent.com/1515768/39410160-ca3333f0-4bf3-11e8-93e7-149791c3e72d.png">

Errbit won't receive any email and won't be able to create a new user, redirecting back to the sign in page without displaying any message.

This PR makes Errbit show a "Flash Error" message with the text: "You need to define and select a valid email in your Github profile"