### PR TITLE
fix #1233. this just uses the number that makes the test case pass

### DIFF
--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -3,7 +3,10 @@ require 'recurse'
 class Notice
   UNAVAILABLE = 'N/A'
 
-  MESSAGE_LENGTH_LIMIT = 964
+  # Mongo will not accept index keys larger than 1,024 bytes and that includes
+  # some amount of BSON encoding overhead, so keep it under 1,000 bytes to be
+  # safe.
+  MESSAGE_LENGTH_LIMIT = 1_000
 
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -36,10 +39,11 @@ class Notice
     where(:err_id.in => errs.all.map(&:id))
   }
 
-  # Overwrite the default setter to make sure the message length is no longer
-  # than the limit we impose
+  # Overwrite the default setter to make sure the message length is no larger
+  # than the limit we impose.
   def message=(m)
-    super(m.is_a?(String) ? m[0, MESSAGE_LENGTH_LIMIT] : m)
+    truncated_m = m.mb_chars.compose.limit(MESSAGE_LENGTH_LIMIT).to_s
+    super(m.is_a?(String) ? truncated_m : m)
   end
 
   def user_agent

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -2,7 +2,8 @@ require 'recurse'
 
 class Notice
   UNAVAILABLE = 'N/A'
-  MESSAGE_LENGTH_LIMIT = 1000
+
+  MESSAGE_LENGTH_LIMIT = 964
 
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -46,8 +46,33 @@ describe Notice, type: 'model' do
 
     it 'truncates the message' do
       notice = Fabricate(:notice, message: long_message)
-      expect(long_message.length).to be > 1000
-      expect(notice.message.length).to eq 1000
+      expect(long_message.length).to be > Notice::MESSAGE_LENGTH_LIMIT
+      expect(notice.message.length).to eq Notice::MESSAGE_LENGTH_LIMIT
+    end
+
+    let(:long_es_message) do
+      'Elasticsearch::Transport::Transport::Errors::InternalServerError: ' \
+      '[500] {"error":"SearchPhaseExecutionException[Failed to execute phase ' \
+      '[query_fetch], all shards failed; shardFailures {[abc][test][0]: ' \
+      'QueryPhaseExecutionException[[test][0]: query[function score ' \
+      '(_all:t4t44äöäöäööäöäöäöäöäälüöläpläfdälfäpdlsfaäpldspsadpfäsdkfasdö' \
+      'äkfadsökfjaädsfjsdaäfjadsklfldslsäfjkläsdajfläaslhfldskhfasljdhfl444' \
+      '44t44t4t4t4t44t4444tt444tt4þt444t4gt4t444t44t444g4444t4g44g4tt444g44' \
+      '44tgt444ggþ444þ4t4þ4t44444t4444g4444t44gþt4t4tþg4t44t4t4444gt44t444t' \
+      '4t4t444tt44t44þt4t4þt4444444þgþ4tt4t4g444gt4t4t444þ44g4t44g4tgþ4t4t4' \
+      '44t4þþ444t44t4t44~2,function=script[_score * _source.boost], params ' \
+      '[null])],from[0],size[10]: Query Failed [Failed to execute main ' \
+      'query]]; nested: RuntimeException[org.apache.lucene.util.automaton.' \
+      'TooComplexToDeterminizeException: Determinizing automaton would ' \
+      'result in more than 10000 states.]; nested: TooComplexToDeterminize' \
+      'Exception[Determinizing automaton would result in more than 10000 ' \
+      'states.]; }]","status":500}'
+    end
+
+    it 'truncates the long es message' do
+      notice = Fabricate(:notice, message: long_es_message)
+      expect(long_es_message.length).to be > Notice::MESSAGE_LENGTH_LIMIT
+      expect(notice.message.length).to eq Notice::MESSAGE_LENGTH_LIMIT
     end
   end
 

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -50,7 +50,7 @@ describe Notice, type: 'model' do
       expect(notice.message.length).to eq Notice::MESSAGE_LENGTH_LIMIT
     end
 
-    let(:long_es_message) do
+    let(:long_mb_message) do
       'Elasticsearch::Transport::Transport::Errors::InternalServerError: ' \
       '[500] {"error":"SearchPhaseExecutionException[Failed to execute phase ' \
       '[query_fetch], all shards failed; shardFailures {[abc][test][0]: ' \
@@ -69,10 +69,10 @@ describe Notice, type: 'model' do
       'states.]; }]","status":500}'
     end
 
-    it 'truncates the long es message' do
-      notice = Fabricate(:notice, message: long_es_message)
-      expect(long_es_message.length).to be > Notice::MESSAGE_LENGTH_LIMIT
-      expect(notice.message.length).to eq Notice::MESSAGE_LENGTH_LIMIT
+    it 'truncates the long multibyte string message' do
+      notice = Fabricate(:notice, message: long_mb_message)
+      expect(long_mb_message.bytesize).to be > Notice::MESSAGE_LENGTH_LIMIT
+      expect(notice.message.bytesize).to eq Notice::MESSAGE_LENGTH_LIMIT
     end
   end
 


### PR DESCRIPTION
#1233 includes a test case with a long message that blows up mongo. one of the messages that was blowing up our mongo instance could be fixed with a truncation threshold of 995, but it feels better to fix more cases. this will affect all new messages with sizes between 964 and 1000, but doesn't really feel like it will break much. and it feels a lot better to store the notice and index *something* rather than blowing up. i wish i understood the details of what was going on here a bit better. i tried calling message.bytes.size on the test case message, but the number that came out didn't match exactly up with the number in the exception that was raised (it was closer than message.size, though):

````
message.size: 1000
message.bytes.size: 1047
# note that mongo sees 1059 below. note sure where the extra 12 bytes come from.

Failures:

  1) Notice#message= truncates the long es message
     Failure/Error:
       Problem.where('_id' => id).find_one_and_update({
         '$set' => {
           'environment'                            => notice.environment_name,
           'error_class'                            => notice.error_class,
           'last_notice_at'                         => notice.created_at.utc,
           'message'                                => notice.message,
           'resolved'                               => false,
           'resolved_at'                            => nil,
           'where'                                  => notice.where,
           "messages.#{message_digest}.value"       => notice.message,

     Mongo::Error::OperationFailure:
       WiredTigerIndex::insert: key too large to index, failing  1059 { : "Elasticsearch::Transport::Transport::Errors::InternalServerError: [500] {"error":"SearchPhaseExecutionException[Failed to execute phase [query_fetch],..." } (17280)
     # ./app/models/problem.rb:84:in `cache_notice'
     # ./spec/fabricators/notice_fabricator.rb:12:in `block (2 levels) in <top (required)>'
     # ./spec/models/notice_spec.rb:73:in `block (3 levels) in <top (required)>'
````