### PR TITLE
[DOCKER] Remove requirement for having errbit user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,13 @@
 FROM ruby:2.3.3-alpine
 LABEL maintainer="David Papp <david@ghostmonitor.com>"
 
-ARG UID=101
-ARG GID=101
-
-RUN addgroup -g $GID -S errbit \
-  && adduser -u $UID -S -D -s /bin/false -G errbit -g errbit errbit
-
+WORKDIR /app
 # throw errors if Gemfile has been modified since Gemfile.lock
 RUN echo "gem: --no-document" >> /etc/gemrc \
   && bundle config --global frozen 1 \
   && bundle config --global clean true \
-  && bundle config --global disable_shared_gems false
-
-RUN mkdir -p /app \
-  && chown -R errbit:errbit /app \
-  && chmod 705 /app/
-WORKDIR /app
-
-RUN gem update --system 2.7.4 \
+  && bundle config --global disable_shared_gems false \
+  && gem update --system 2.7.4 \
   && gem install bundler --version 1.16.1 \
   && apk add --no-cache \
     curl \
@@ -28,7 +17,6 @@ RUN gem update --system 2.7.4 \
     nodejs \
     tzdata
 
-EXPOSE 8080
 
 COPY ["Gemfile", "Gemfile.lock", "/app/"]
 
@@ -43,11 +31,12 @@ RUN apk add --no-cache --virtual build-dependencies \
 
 COPY . /app
 
-RUN RAILS_ENV=production bundle exec rake assets:precompile
-RUN chown -R errbit:errbit /app
+RUN RAILS_ENV=production bundle exec rake assets:precompile \
+  && rm -rf /app/tmp/* \
+  && chmod 777 /app/tmp
 
-USER errbit
+EXPOSE 8080
 
-HEALTHCHECK CMD curl --fail "http://$(/bin/hostname -i | /usr/bin/awk '{ print $1 }'):8080/users/sign_in" ||  exit 1
+HEALTHCHECK CMD curl --fail "http://$(/bin/hostname -i | /usr/bin/awk '{ print $1 }'):8080/users/sign_in" || exit 1
 
 CMD ["bundle","exec","puma","-C","config/puma.default.rb"]

--- a/docs/deployment/example/kubernetes/rc.yml
+++ b/docs/deployment/example/kubernetes/rc.yml
@@ -4,7 +4,6 @@ metadata:
   labels:
     name: errbit
   name: errbit
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -15,7 +14,7 @@ spec:
         name: errbit
     spec:
       containers:
-      - image: quay.io/ghostmonitor/errbit:latest
+      - image: errbit/errbit:latest
         name: errbit
         ports:
         - containerPort: 8080

--- a/docs/deployment/example/kubernetes/svc.yml
+++ b/docs/deployment/example/kubernetes/svc.yml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: errbit
-  namespace: default
   labels:
     name: errbit
 spec:


### PR DESCRIPTION
Remove all requirement for users in container because you don't really need those and when running containers in not privileged mode(which openshift is running them as) then it says that it cannot update `/app/tmp` directory because we are not allowed to change files/directories which are owned by errbit user