### PR TITLE
avoid 500 error when backtrace object is nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ bundle
 coverage
 *#
 .ruby-version
+.tool-versions
 NOTES

--- a/app/decorators/backtrace_line_decorator.rb
+++ b/app/decorators/backtrace_line_decorator.rb
@@ -15,7 +15,7 @@ class BacktraceLineDecorator < Draper::Decorator
   end
 
   def file
-    object[:file].to_s
+    object.try(:[], :file).to_s
   end
 
   def method

--- a/spec/decorators/backtrace_line_decorator_spec.rb
+++ b/spec/decorators/backtrace_line_decorator_spec.rb
@@ -14,6 +14,9 @@ describe BacktraceLineDecorator, type: :decorator do
   let(:backtrace_line_no_file) do
     described_class.new(number: 884, method: :instance_eval)
   end
+  let(:backtrace_line_no_object) do
+    described_class.new(nil)
+  end
   let(:app) { Fabricate(:app, github_repo: 'foo/bar') }
 
   describe '#to_s' do
@@ -25,6 +28,10 @@ describe BacktraceLineDecorator, type: :decorator do
   describe '#file' do
     it 'returns "" when there is no file' do
       expect(backtrace_line_no_file.file).to eq('')
+    end
+
+    it 'returns "" when there is no object' do
+      expect(backtrace_line_no_object.file).to eq('')
     end
   end
 


### PR DESCRIPTION
we got this exception:

````
NoMethodError: undefined method `[]' for nil:NilClass
````

with this backtrace:

````
[PROJECT_ROOT]/decorators/backtrace_line_decorator.rb:18→ file
--
[PROJECT_ROOT]/decorators/backtrace_line_decorator.rb:5→ in_app?
[PROJECT_ROOT]/views/mailer/err_notification.html.haml:31→ block in _app_views_mailer_err_notification_html_haml___2324961091592232048_70027270895640
[PROJECT_ROOT]/views/mailer/err_notification.html.haml:30→ each
[PROJECT_ROOT]/views/mailer/err_notification.html.haml:30→ _app_views_mailer_err_notification_html_haml___2324961091592232048_70027270895640
actionview-4.2.9/lib/action_view/template.rb:145→ block in render
activesupport-4.2.9/lib/active_support/notifications.rb:166→ instrument
actionview-4.2.9/lib/action_view/template.rb:333→ instrument
actionview-4.2.9/lib/action_view/template.rb:143→ render
````

`BacktraceLineDecorator#to_s` already protected against a nil object, so i'm following that pattern with this change.