### PR TITLE
CI: require ruby 2.5 passing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - MONGODB=3.2.20
     - MONGODB=3.4.15
     - MONGODB=3.6.6
+    - MONGODB=4.0.0
 
 sudo: false
 
@@ -41,3 +42,4 @@ script:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - env: MONGODB=4.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   matrix:
     - MONGODB=3.6.6
     - MONGODB=3.4.15
-    - MONGODB=3.2.20
     # not yet working:
     - MONGODB=4.0.0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   matrix:
     - MONGODB=3.6.6
     - MONGODB=3.4.15
-    # not yet working:
     - MONGODB=4.0.0
 
 sudo: false
@@ -43,4 +42,3 @@ script:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - env: MONGODB=4.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - ruby-head
 
 env:
   global:
@@ -39,4 +40,4 @@ script:
 
 matrix:
   allow_failures:
-    - rvm: 2.5
+    - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ env:
   global:
     - COVERAGE=true JRUBY_OPTS=--debug
   matrix:
-    - MONGODB=3.2.18
-    - MONGODB=3.4.10
-    - MONGODB=3.6.2
+    - MONGODB=3.2.20
+    - MONGODB=3.4.15
+    - MONGODB=3.6.6
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
   global:
     - COVERAGE=true JRUBY_OPTS=--debug
   matrix:
+    - MONGODB=4.0.0
     - MONGODB=3.6.6
     - MONGODB=3.4.15
-    - MONGODB=4.0.0
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: ruby
 
 rvm:
-  - 2.3
-  - 2.4
+  # Let's build with the most relevant versions first:
   - 2.5
+  - 2.4
+  - 2.3
   - ruby-head
 
 env:
   global:
     - COVERAGE=true JRUBY_OPTS=--debug
   matrix:
-    - MONGODB=3.2.20
-    - MONGODB=3.4.15
     - MONGODB=3.6.6
+    - MONGODB=3.4.15
+    - MONGODB=3.2.20
+    # not yet working:
     - MONGODB=4.0.0
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ updates and notifications.
 
 The list of requirements to install Errbit are:
 
-* Ruby 2.3.x-2.5.x (>= 2.6.x not yet supported)
+* Ruby >= 2.3.x
 * MongoDB 3.4.x-4.0.x
 
 Installation

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ updates and notifications.
 
 The list of requirements to install Errbit are:
 
-* Ruby 2.3.x-2.4.x (>= 2.5.x not yet supported)
+* Ruby 2.3.x-2.5.x (>= 2.6.x not yet supported)
 * MongoDB 3.4.x-3.6.x (>= 4.0.x not yet supported)
 
 Installation

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ updates and notifications.
 The list of requirements to install Errbit are:
 
 * Ruby 2.3.x-2.4.x (>= 2.5.x not yet supported)
-* MongoDB 3.2.x-3.6.x (>= 4.0.x not yet supported)
+* MongoDB 3.4.x-3.6.x (>= 4.0.x not yet supported)
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ updates and notifications.
 The list of requirements to install Errbit are:
 
 * Ruby 2.3.x-2.5.x (>= 2.6.x not yet supported)
-* MongoDB 3.4.x-3.6.x (>= 4.0.x not yet supported)
+* MongoDB 3.4.x-4.0.x
 
 Installation
 ------------


### PR DESCRIPTION
Also, cleanup MongoDB versions used for testing:

* Bump minor versions to be latest for each major release
* Remove MongoDB 3.2.x from testing, is EOL as of September 2018 
* Add MongoDB 4.0.0 to testing, just so we can gather experience

For the curious I've also added ruby-head to the build matrix, just so any issues can be seen and fixed.