### PR TITLE
Implement /health/readiness without using Timeout.timeout

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -27,7 +27,7 @@ private
     impatient_mongoid_client.collections
     { check_name: 'mongo', ok: true }
   rescue StandardError => e
-    { check_name: 'mongo', ok: false, error_details: "#{e.class}" }
+    { check_name: 'mongo', ok: false, error_details: e.class.to_s }
   end
 
   def impatient_mongoid_client

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -27,7 +27,7 @@ private
     impatient_mongoid_client.collections
     { check_name: 'mongo', ok: true }
   rescue StandardError => e
-    { check_name: 'mongo', ok: false, error_details: "#{e.class}: #{e.message}" }
+    { check_name: 'mongo', ok: false, error_details: "#{e.class}" }
   end
 
   def impatient_mongoid_client

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -22,13 +22,20 @@ class HealthController < ActionController::Base
 private
 
   def run_mongo_check
-    Timeout.timeout(0.75) do
-      # collections might be empty which is ok but it will raise an exception if
-      # database cannot be contacted
-      Mongoid.default_client.collections
-    end
+    # collections might be empty which is ok but it will raise an exception if
+    # database cannot be contacted
+    impatient_mongoid_client.collections
     { check_name: 'mongo', ok: true }
   rescue StandardError => e
     { check_name: 'mongo', ok: false, error_details: "#{e.class}: #{e.message}" }
+  end
+
+  def impatient_mongoid_client
+    Mongo::Client.new(
+      Errbit::Config.mongo_url,
+      server_selection_timeout: 0.5,
+      connect_timeout:          0.5,
+      socket_timeout:           0.5
+    )
   end
 end

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -8,7 +8,9 @@ describe "Health", type: 'request' do
     end
 
     it 'can indicate if a check fails' do
-      expect(Mongoid.default_client).to receive(:collections).and_raise(Mongo::Error::NoServerAvailable)
+      expect(Errbit::Config).to receive(:mongo_url) {
+        'mongodb://localhost:27000'
+      }
       get '/health/readiness'
       expect(response).to be_error
       parsed_response = JSON.parse(response.body)


### PR DESCRIPTION
For more on why this pattern is problematic, read https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts and https://www.mikeperham.com/2015/05/08/timeout-rubys-most-dangerous-api/