### PR TITLE
Rails: eager-load all of lib/

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,8 +15,8 @@ module Errbit
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # Custom directories with classes and modules you want to be autoloadable.
-    config.autoload_paths << Rails.root.join('lib').to_s
+    # Custom directories with classes and modules you want to eager load.
+    config.eager_load_paths << Rails.root.join('lib').to_s
 
     config.before_initialize do
       config.secret_key_base = Errbit::Config.secret_key_base


### PR DESCRIPTION
Class loading is not thread-safe, and using autoloading doesn't work reliably with a multithreaded puma server.

Fixes #1308