### PR TITLE
Spec: Fix SimpleCov::Formatter::MultiFormatter warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,10 +10,10 @@ if ENV['COVERAGE']
   Coveralls.wear!('rails') do
     add_filter 'bundle'
   end
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     Coveralls::SimpleCov::Formatter
-  ]
+  ])
   SimpleCov.start('rails') do
     add_filter 'bundle'
   end


### PR DESCRIPTION
Warning this fixes:

```
/home/travis/build/errbit/errbit/spec/spec_helper.rb:13:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
```