### PR TITLE
close mongo connection after creating

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -28,10 +28,12 @@ private
     { check_name: 'mongo', ok: true }
   rescue StandardError => e
     { check_name: 'mongo', ok: false, error_details: e.class.to_s }
+  ensure
+    impatient_mongoid_client.close
   end
 
   def impatient_mongoid_client
-    Mongo::Client.new(
+    @impatient_mongoid_client ||= Mongo::Client.new(
       Errbit::Config.mongo_url,
       server_selection_timeout: 0.5,
       connect_timeout:          0.5,


### PR DESCRIPTION
without this fix, when errbit upgraded mongoid from 5.0.2 to 5.4.0 (https://github.com/errbit/errbit/pull/1278), our mongo servers started seeing a new connection on every `readiness` request, and for some reason the connections were no longer closed implicitly (not sure how that was happening in 5.0.2). in our context, readiness is run every five seconds by kubernetes, so it was creating many connections pretty quickly, and this ultimately took down mongo servers on a few environments.