### PR TITLE
Chore/emit version details

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Installation
 Rails applications.
 
 * [Install MongoDB](https://www.mongodb.org/downloads)
-* git clone https://github.com/errbit/errbit.git
-* bundle install
-* bundle exec rake errbit:bootstrap
-* bundle exec rails server
+* `git clone https://github.com/errbit/errbit.git`
+* `bundle install`
+* `bundle exec rake errbit:bootstrap`
+* `bundle exec rails server`
 
 Configuration
 -------------

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,6 +29,7 @@ puts "-- email:    #{admin_email}"
 puts "-- password: #{admin_pass}"
 puts ""
 puts "Be sure to note down these credentials now!"
+puts "\nNOTE: DEMO instance, not for production use!" if heroku_pr_review_app?
 
 user = User.find_or_initialize_by(email: admin_email)
 

--- a/lib/errbit/version.rb
+++ b/lib/errbit/version.rb
@@ -1,9 +1,20 @@
 # frozen_string_literal: true
 
 module Errbit
-  VERSION = [
-    '0.8.0',
-    'dev',
-    ENV.fetch('SOURCE_VERSION', '')[0..8]
-  ].compact.join('-')
+  class Version
+    def full_version
+      [
+        '0.8.0',
+        'dev',
+        source_version
+      ].compact.join('-')
+    end
+
+    def source_version
+      source_version = ENV['SOURCE_VERSION']
+      source_version[0...8] if source_version.present?
+    end
+  end
+
+  VERSION = Version.new.full_version
 end

--- a/lib/errbit/version.rb
+++ b/lib/errbit/version.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
 module Errbit
-  VERSION = '0.8.0-dev'
+  VERSION = [
+    '0.8.0',
+    'dev',
+    ENV.fetch('SOURCE_VERSION', '')[0..8]
+  ].compact.join('-')
 end

--- a/lib/tasks/errbit/bootstrap.rake
+++ b/lib/tasks/errbit/bootstrap.rake
@@ -2,9 +2,5 @@ require 'fileutils'
 
 namespace :errbit do
   desc "Seed and index the DB"
-  task :bootstrap do
-    Rake::Task['db:seed'].invoke
-    puts "\n"
-    Rake::Task['db:mongoid:create_indexes'].invoke
-  end
+  task bootstrap: %w(db:seed db:mongoid:create_indexes)
 end

--- a/spec/lib/errbit/version_spec.rb
+++ b/spec/lib/errbit/version_spec.rb
@@ -1,0 +1,13 @@
+describe Errbit::VERSION do
+  subject { Errbit::Version.new.full_version }
+
+  it 'handles a missing commit sha' do
+    allow(ENV).to receive(:[]).with('SOURCE_VERSION') { nil }
+    expect(subject).to end_with('dev')
+  end
+
+  it 'shortens a present commit sha' do
+    allow(ENV).to receive(:[]).with('SOURCE_VERSION') { 'abcd1234efgh56789' }
+    expect(subject).to end_with('dev-abcd1234')
+  end
+end


### PR DESCRIPTION
This adds the first eight characters of the git version number to the UI (when available). Should make it easier to pin-point what version users are on when reporting issues.