### PR TITLE
Ensure user_attributes returns a Hash

### DIFF
--- a/lib/airbrake_api/v3/notice_parser.rb
+++ b/lib/airbrake_api/v3/notice_parser.rb
@@ -69,7 +69,8 @@ module AirbrakeApi
       end
 
       def user_attributes
-        return context['user'] if context['user']
+        user = context['user']
+        return user.is_a?(Hash) ? user : { user: user } if user
 
         {
           'id'       => context['userId'],

--- a/spec/lib/airbrake_api/v3/notice_parser_spec.rb
+++ b/spec/lib/airbrake_api/v3/notice_parser_spec.rb
@@ -105,6 +105,20 @@ describe AirbrakeApi::V3::NoticeParser do
     expect(parser.attributes[:server_environment]['hostname']).to eq('app01.infra.example.com')
   end
 
+  describe '#user_attributes' do
+    it 'returns a user context hash' do
+      user_hash = { id: 1, name: 'John Doe' }
+      parser = described_class.new({ 'context' => { 'user' => user_hash } })
+      expect(parser.send(:user_attributes)).to eq(user_hash)
+    end
+
+    it 'returns a hash for a user context string' do
+      user_string = '[Filtered]'
+      parser = described_class.new({ 'context' => { 'user' => user_string } })
+      expect(parser.send(:user_attributes)).to eq({ user: user_string })
+    end
+  end
+
   def build_params_for(fixture, options = {})
     json = Rails.root.join('spec', 'fixtures', fixture).read
     data = JSON.parse(json)

--- a/spec/lib/airbrake_api/v3/notice_parser_spec.rb
+++ b/spec/lib/airbrake_api/v3/notice_parser_spec.rb
@@ -108,14 +108,14 @@ describe AirbrakeApi::V3::NoticeParser do
   describe '#user_attributes' do
     it 'returns a user context hash' do
       user_hash = { id: 1, name: 'John Doe' }
-      parser = described_class.new({ 'context' => { 'user' => user_hash } })
+      parser = described_class.new('context' => { 'user' => user_hash })
       expect(parser.send(:user_attributes)).to eq(user_hash)
     end
 
     it 'returns a hash for a user context string' do
       user_string = '[Filtered]'
-      parser = described_class.new({ 'context' => { 'user' => user_string } })
-      expect(parser.send(:user_attributes)).to eq({ user: user_string })
+      parser = described_class.new('context' => { 'user' => user_string })
+      expect(parser.send(:user_attributes)).to eq(user: user_string)
     end
   end
 


### PR DESCRIPTION
My Airbrake config blacklists all keys: `config.blacklist_keys = [/.*/]` so `user_attributes` returns a String `"[Filtered]"` instead of a Hash. 

When trying to save this String to a `Notice` model, ErrBit throws:

    Mongoid::Errors::InvalidValue: message: Value of type String cannot be written to a field of type Hash
    [PROJECT_ROOT]/models/error_report.rb:65→ new
    [PROJECT_ROOT]/models/error_report.rb:65→ make_notice
    [PROJECT_ROOT]/models/error_report.rb:54→ generate_notice!
    [PROJECT_ROOT]/controllers/api/v3/notices_controller.rb:24→ create

This PR ensures that `user_attributes` always returns a Hash.