### PR TITLE
Resend notifications when generating notices on resolved problems

### DIFF
--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -283,6 +283,14 @@ describe ErrorReport do
           3.times { described_class.new(xml).generate_notice! }
           expect(ActionMailer::Base.deliveries.length).to eq(2)
         end
+
+        it "sends email on all occurrences when problem was resolved" do
+          3.times do
+            notice = described_class.new(xml).generate_notice!
+            notice.problem.resolve!
+          end
+          expect(ActionMailer::Base.deliveries.length).to eq(3)
+        end
       end
     end
 

--- a/spec/models/notice_observer_spec.rb
+++ b/spec/models/notice_observer_spec.rb
@@ -192,5 +192,15 @@ describe "Callback on Notice", type: 'model' do
         to_not receive(:create_notification)
       error_report.generate_notice! # three
     end
+
+    it "should create a campfire notification when problem was resolved" do
+      ErrorReport.new(notice_attrs).generate_notice! # one
+      notice = ErrorReport.new(notice_attrs).generate_notice! # two
+      notice.problem.resolve!
+      error_report = ErrorReport.new(notice_attrs)
+      expect(error_report.app.notification_service).
+        to receive(:create_notification)
+      error_report.generate_notice! # three
+    end
   end
 end


### PR DESCRIPTION
A bit of history:

* #265 introduced a fix which zeroed out the notice count on a problem when it was resolved. This was done to cause notifications to re-trigger when if it were unresolved when recording a notice.
* This behaviour was changed in 13c8b21f91c07e7970029e87fbc6997bcf1e16a6 to instead reset on unresolve to preserve the notice count on resolved problems.
* This behaviour seems to have been lost in f646cf500aef1d37aeb28a4a11f5bf2a4930837c which reduces the number of queries when recording a notice.

This PR restores the desired resending on unresolving behaviour without requiring the notice count to be changed. This is done by checking if the existing problem is resolved before updating it (unresolving and incrementing notice count) and if so, always triggering notifications.