### PR TITLE
Fix memory leak in readiness health check endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -33,7 +33,7 @@ private
   end
 
   def impatient_mongoid_client
-    @impatient_mongoid_client ||= Mongo::Client.new(
+    @@impatient_mongoid_client ||= Mongo::Client.new(
       Errbit::Config.mongo_url,
       server_selection_timeout: 0.5,
       connect_timeout:          0.5,

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -32,6 +32,7 @@ private
     impatient_mongoid_client.close
   end
 
+  # rubocop:disable Style/ClassVars
   def impatient_mongoid_client
     @@impatient_mongoid_client ||= Mongo::Client.new(
       Errbit::Config.mongo_url,
@@ -40,4 +41,5 @@ private
       socket_timeout:           0.5
     )
   end
+  # rubocop:enable Style/ClassVars
 end

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -19,7 +19,18 @@ class HealthController < ActionController::Base
     render json: { ok: is_good_result }, status: response_status
   end
 
+  def self.impatient_mongoid_client
+    @impatient_mongoid_client ||= Mongo::Client.new(
+      Errbit::Config.mongo_url,
+      server_selection_timeout: 0.5,
+      connect_timeout:          0.5,
+      socket_timeout:           0.5
+    )
+  end
+
 private
+
+  delegate :impatient_mongoid_client, to: :class
 
   def run_mongo_check
     # collections might be empty which is ok but it will raise an exception if
@@ -31,15 +42,4 @@ private
   ensure
     impatient_mongoid_client.close
   end
-
-  # rubocop:disable Style/ClassVars
-  def impatient_mongoid_client
-    @@impatient_mongoid_client ||= Mongo::Client.new(
-      Errbit::Config.mongo_url,
-      server_selection_timeout: 0.5,
-      connect_timeout:          0.5,
-      socket_timeout:           0.5
-    )
-  end
-  # rubocop:enable Style/ClassVars
 end

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -2,6 +2,12 @@ describe "Health", type: 'request' do
   let(:errbit_app) { Fabricate(:app, api_key: 'APIKEY') }
 
   describe "readiness" do
+    before do
+      HealthController.class_variables.each do |name|
+        HealthController.remove_class_variable name
+      end
+    end
+
     it 'can let you know when the app is ready to receive requests' do
       get '/health/readiness'
       expect(response).to be_success

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -3,8 +3,8 @@ describe "Health", type: 'request' do
 
   describe "readiness" do
     before do
-      HealthController.class_variables.each do |name|
-        HealthController.remove_class_variable name
+      if HealthController.instance_variable_defined? :@impatient_mongoid_client
+        HealthController.remove_instance_variable :@impatient_mongoid_client
       end
     end
 


### PR DESCRIPTION
Warm up:

* Docker image boots with 116 MiB used.
* `ab -n 2000 -c 10 localhost:8080/health/liveness` raises memory usage up to 250 MiB.
* Running `ab` again does not change memory usage.

Before this PR:

* `ab -n 2000 -c 10 localhost:8080/health/readiness` raises memory usage up to 370 MiB.
* Further runs result in memory usage of 400 MiB, 480 MiB, 600 MiB.

After this PR:

* `ab -n 2000 -c 10 localhost:8080/health/readiness` raises memory usage up to 261 MiB.
* Running `ab` again does not change memory usage.