### PR TITLE
Include test dependencies in the `bundle install`.

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "keywords": ["productivity", "tools", "error tracking"],
   "repository": "https://github.com/errbit/errbit",
   "env": {
+    "BUNDLE_WITHOUT": "development",
     "ERRBIT_ENFORCE_SSL": "true",
     "GEMFILE_RUBY_VERSION": "2.5.1",
     "SECRET_KEY_BASE": {


### PR DESCRIPTION
Before this change the postdeploy script was failing due to the :test
dependencies not being installed during the app deployment.

The default value for `$BUNDLE_WITHOUT` is `development:test`.

Fixes #1362.