### PR TITLE
allow for viewing a specific notice by id. w/ jasquat

### DIFF
--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -33,6 +33,12 @@ class NoticesController < ApplicationController
     redirect_to app_problem_path(problem.app, problem)
   end
 
+  def show_by_id
+    notice = Notice.find(params[:id])
+    problem = notice.problem
+    redirect_to app_problem_path(problem.app, problem, notice_id: notice.id)
+  end
+
 private
 
   def notice_params

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -49,10 +49,15 @@ class ProblemsController < ApplicationController
   def index; end
 
   def show
-    @notices = problem.object.notices.reverse_ordered.
-      page(params[:notice]).per(1)
-    first_notice = @notices.first
-    @notice  = first_notice ? NoticeDecorator.new(first_notice) : nil
+    notice =
+      if params[:notice_id]
+        Notice.find(params[:notice_id])
+      else
+        @notices = problem.object.notices.reverse_ordered.
+          page(params[:notice]).per(1)
+        @notices.first
+      end
+    @notice  = notice ? NoticeDecorator.new(notice) : nil
     @comment = Comment.new
   end
 

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -53,7 +53,10 @@
 
 %h4= @notice.try(:message)
 
-= paginate @notices, :param_name => :notice, :theme => :notices
+- if params[:notice_id]
+  %p= t('.notice_by_id', notice_id: params[:notice_id])
+- else
+  = paginate @notices, :param_name => :notice, :theme => :notices
 
 .tab-bar
   %ul

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,7 @@ en:
       where: Where
       up: up
       resolve: resolve
+      notice_by_id: "Notice: %{notice_id}"
   comments:
     confirm_delete: "Permanently delete this comment?"
   users:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -123,6 +123,7 @@ pt-BR:
       where: Onde
       up: subir
       resolve: resolver
+      notice_by_id: "notificação: %{notice_id}"
   comments:
     confirm_delete: "Excluir permanentemente este comentário?"
   users:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   # Hoptoad Notifier Routes
   match '/notifier_api/v2/notices' => 'notices#create', via: [:get, :post]
   get '/locate/:id' => 'notices#locate', :as => :locate
+  get '/notices/:id' => 'notices#show_by_id', :as => :show_notice_by_id
 
   resources :notices, only: [:show]
   resources :users do

--- a/docs/notices.md
+++ b/docs/notices.md
@@ -1,0 +1,17 @@
+# Notices
+
+This page describes how to look up notices in the Errbit UI.
+
+## /locate/[notice_id]
+
+Errbit points clients to this path (in the response body) when they successfully
+submit a notice. When you hit this path in a browser (you have to be
+authenticated), it will redirect you to the associated Problem. Using the
+language used in Errbit code, Notices belong to Errs, Problems can have many
+Errs, and Problems belong to Apps.
+
+## /notices/[notice_id]
+
+If you happen to know the specific notice_id (perhaps you are a javascript
+client, and the server told you, like above), you can look up the specific
+notice using this path in a browser.

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -84,4 +84,20 @@ describe NoticesController, type: 'controller' do
       end
     end
   end
+
+  describe "GET /notices/:id" do
+    context 'when logged in as an admin' do
+      before(:each) do
+        @user = Fabricate(:admin)
+        sign_in @user
+      end
+
+      it "should locate notice and redirect to problem with notice_id" do
+        problem = Fabricate(:problem, app: app, environment: "production")
+        notice = Fabricate(:notice, err: Fabricate(:err, problem: problem))
+        get :show_by_id, id: notice.id
+        expect(response).to redirect_to(app_problem_path(problem.app, problem, notice_id: notice.id))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds path /notice/:id, which takes you to the specific notice, unlike /locate/:id