### PR TITLE
#1385: Can't merge errors after search

### DIFF
--- a/app/assets/javascripts/errbit.js
+++ b/app/assets/javascripts/errbit.js
@@ -25,9 +25,7 @@ $(function() {
                              "?copy_attributes_from=" + $(this).val();
     });
 
-    $('input[type=submit][data-action]').on('click', function() {
-      $(this).closest('form').attr('action', $(this).attr('data-action'));
-    });
+    bindProblemButtonsActions();
 
     $('.notice-pagination').each(function() {
       $.pjax.defaults = {timeout: 2000};
@@ -80,7 +78,13 @@ $(function() {
     });
   }
 
-  function activateSelectableRows() {
+  window.bindProblemButtonsActions = function() {
+      $('input[type=submit][data-action]').on('click', function() {
+          $(this).closest('form').attr('action', $(this).attr('data-action'));
+      });
+  };
+
+    function activateSelectableRows() {
     $('.selectable tr').click(function(event) {
       if(!_.include(['A', 'INPUT', 'BUTTON', 'TEXTAREA'], event.target.nodeName)) {
         var checkbox = $(this).find('input[name="problems[]"]').get(0);

--- a/app/views/problems/search.js.haml
+++ b/app/views/problems/search.js.haml
@@ -1,3 +1,4 @@
 $("#problem_table").empty().append("#{escape_javascript(render('problems/table', :problems => problems))}");
-$("#flash-messages").empty()
-toggleProblemsCheckboxes()
+$("#flash-messages").empty();
+toggleProblemsCheckboxes();
+bindProblemButtonsActions();


### PR DESCRIPTION
The issue is related to the fact that the `#problem_table` is emptied
when the search is run, and a new table is inserted in its place with
the result of the search. The existing click binding of the buttons 
at the end ofthe table (merge/delete/etc) is removed when 
the table is removed.

As a fix, `assets/javascripts/errbit.js` introduces global
`bindProblemButtonsActions` function which is extracted from the
body of `errbit.js`, containing handler of for problem buttons click
event. This function is then added to the result of
`views/problems/search.js.haml` to be run on a new problems table
when the search is returned.

Tried to create a rspec test for this, but had problems getting nokogiri 
to compile. Maybe it's time for Rails 6 update? 😅 