### PR TITLE
Added tracking of problem resolver by new attribute resolved_by

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -82,7 +82,7 @@ class ProblemsController < ApplicationController
   end
 
   def resolve
-    problem.resolve!
+    problem.resolve!(current_user)
     flash[:success] = t('.the_error_has_been_resolved')
     redirect_to :back
   rescue ActionController::RedirectBackError
@@ -90,7 +90,7 @@ class ProblemsController < ApplicationController
   end
 
   def resolve_several
-    selected_problems.each(&:resolve!)
+    selected_problems.each { |problem| problem.resolve!(current_user) }
     flash[:success] = "Great news everyone! #{I18n.t(:n_errs_have, count: selected_problems.count)} #{I18n.t('n_errs_have.been_resolved')}."
     redirect_to :back
   end

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -49,6 +49,7 @@ class Problem
   }, default_language: "english")
 
   belongs_to :app
+  belongs_to :resolved_by, class_name: "User"
   has_many :errs, inverse_of: :problem, dependent: :destroy
   has_many :comments, inverse_of: :err, dependent: :destroy
 
@@ -196,12 +197,12 @@ class Problem
     Notice.for_errs(errs).ordered
   end
 
-  def resolve!
-    self.update_attributes!(resolved: true, resolved_at: Time.zone.now)
+  def resolve!(resolved_by = nil)
+    self.update_attributes!(resolved: true, resolved_at: Time.zone.now, resolved_by: resolved_by)
   end
 
   def unresolve!
-    self.update_attributes!(resolved: false, resolved_at: nil)
+    self.update_attributes!(resolved: false, resolved_at: nil, resolved_by: nil)
   end
 
   def unresolved?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,8 @@ class User
     validates :username, presence: true
   end
 
+  has_many :resolved_problems, class_name: "Problem", inverse_of: :resolved_by
+
   def self.valid_google_domain?(email)
     return true if Errbit::Config.google_authorized_domains.nil?
     match_data = /.+@(?<domain>.+)$/.match(email)
@@ -114,6 +116,14 @@ class User
     self.class.validators_on(:password).map { |v| v.validate_each(self, :password, password) }
     return false if errors.any?
     save(validate: false)
+  end
+
+  def display_name
+    if Errbit::Config.user_has_username
+      username
+    else
+      email
+    end
   end
 
 private

--- a/app/views/problems/_table.html.haml
+++ b/app/views/problems/_table.html.haml
@@ -43,7 +43,11 @@
                   %em= truncate(comment.body, :length => 100, :separator => ' ')
           %td.latest
             - value = "#{time_ago_in_words(problem.last_notice_at)} #{I18n.t('problems.table.ago')}"
-            %div.td-container{class: 'nowrap', title: value}= value
+            %div.td-container{class: 'nowrap', title: value}
+              = value
+              %br
+              - if problem.resolved_by
+                = problem.resolved_by.display_name
           %td.count.narrow-as-possible
             %div.td-container= link_to problem.notices_count, app_problem_path(problem.app, problem)
             - if any_issue_links

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -11,8 +11,12 @@
   = problem.environment
   %strong= t('.first_notice') + ':'
   = problem.first_notice_at.to_s(:precise)
-  %strong= t('.last_notice') + '::'
+  %strong= t('.last_notice') + ':'
   = problem.last_notice_at.to_s(:precise)
+  - if problem.resolved_by
+    %br
+    %strong= t('.resolved_by') + ':'
+    = problem.resolved_by.display_name
 - content_for :action_bar do
   - if problem.unresolved?
     %span= link_to t('.resolve'), [:resolve, app, problem], :method => :put,

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -200,6 +200,7 @@ describe ProblemsController, type: 'controller' do
     it "should resolve the issue" do
       put :resolve, app_id: @err.app.id, id: @err.problem.id
       expect(@err.problem.reload.resolved).to be(true)
+      expect(@err.problem.reload.resolved_by).to eq user
     end
 
     it "should display a message" do
@@ -403,6 +404,7 @@ describe ProblemsController, type: 'controller' do
       it "should resolve the issue" do
         post :resolve_several, problems: [@problem2.id.to_s]
         expect(@problem2.reload.resolved?).to eq true
+        expect(@problem2.resolved_by).to eq user
       end
 
       it "should display a message about 1 err" do


### PR DESCRIPTION
When using Errbit with multiple users it would be nice to see, who solved a particular issue, for instance to ask for more details.

I've added a field to Problem.
I am not familiar with Mongoid though, so I am not sure if that part is correct or idiomatic.

Looking forward for feedback!


![bildschirmfoto 2019-01-28 um 23 05 17](https://user-images.githubusercontent.com/147175/51906742-1dfa8e80-23c5-11e9-9765-b1dbb1a64a68.png)
![bildschirmfoto 2019-01-28 um 23 05 22](https://user-images.githubusercontent.com/147175/51906743-1e932500-23c5-11e9-9e32-1f863d58ae2e.png)
