### PR TITLE
Fix: Atom feed backtrace error

### DIFF
--- a/app/views/notices/_atom_entry.atom.haml
+++ b/app/views/notices/_atom_entry.atom.haml
@@ -25,10 +25,10 @@
   - for line in notice.backtrace_lines
     %tr
       %td
-        = "#{line.number}:"
+        = "#{line['number']}:"
         &nbsp;&nbsp;
       %td
-        = raw "#{h line.file_relative} -> #{content_tag :strong, h(line.method)}"
+        = raw "#{h line['file_relative']} -> #{content_tag :strong, h(line['method'])}"
 
 %h3 Environment
 %table

--- a/spec/views/apps/show.atom.builder_spec.rb
+++ b/spec/views/apps/show.atom.builder_spec.rb
@@ -1,6 +1,7 @@
 describe "apps/show.atom.builder", type: 'view' do
-  let(:app) { stub_model(App) }
-  let(:problems) { [stub_model(Problem, message: 'foo', app: app)] }
+  let(:notice) { Fabricate(:notice) }
+  let(:app) { notice.app }
+  let(:problems) { [notice.problem] }
 
   before do
     allow(view).to receive(:app).and_return(app)


### PR DESCRIPTION
Fixes error: NoMethodError: undefined method `number' for #<BSON::Document:0x00000005e11180> Did you mean? numeric?

Not sure, but my production app, as well as a fresh development snapshot does not displays atom feeds. The format of the Backtrace Lines seems to be changed.
This MR fixes that.