### PR TITLE
Added badges to apps

### DIFF
--- a/app/controllers/badges_controller.rb
+++ b/app/controllers/badges_controller.rb
@@ -1,0 +1,20 @@
+require_dependency 'badges/base'
+require_dependency 'badges/last_error'
+require_dependency 'badges/recent_errors'
+
+class BadgesController < ApplicationController
+  expose(:app)
+
+  def index
+    @badges = Badges::Base.descendants
+  end
+
+  def show
+    badge_class = Badges::Base.find_badge_for_key(params[:badge_type])
+    if badge_class
+      @badge = badge_class.new(app)
+    else
+      head :not_found
+    end
+  end
+end

--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -21,6 +21,7 @@
     = link_to t('.unwatch'), app_watcher_path(app_id: app, id: current_user.id), method: :delete, class: 'button'
   - else
     = link_to t('.watch'), app_watcher_path(app_id: app, id: current_user.id), method: :put, class: 'button'
+  = link_to t('.badges'), badges_app_path(app), class: 'button'
 
 %h3#watchers_toggle
   =t('.watchers')

--- a/app/views/badges/index.html.haml
+++ b/app/views/badges/index.html.haml
@@ -1,0 +1,28 @@
+- content_for :title, app.name + " - Badges"
+
+- @badges.each do |badge_class|
+  %h3= badge_class.title
+  - path = badge_app_url(app, badge_type: badge_class.key, User.token_authentication_key => current_user.authentication_token, format: 'svg')
+  = link_to path do
+    = image_tag path
+
+  %div.badge-code-block
+    %strong Markdown
+    %pre
+      %code
+        [![#{badge_class.title}](#{path})](#{app_url(app)})
+
+  %div.badge-code-block
+    %strong HTML
+    %pre
+      %code
+        :escaped
+          <a href="#{app_url(app)}"><img src="#{path}" alt="#{badge_class.title}" height="18"></a>
+
+:css
+  .badge-code-block {
+    margin-top: 15px;
+  }
+  .badge-code-block pre {
+    white-space: pre-wrap;
+  }

--- a/app/views/badges/show.svg.erb
+++ b/app/views/badges/show.svg.erb
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="<%= @badge.width %>" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <mask id="a">
+    <rect width="<%= @badge.width %>" height="20" rx="3" fill="#fff"/>
+  </mask>
+
+  <g mask="url(#a)">
+    <path fill="<%= @badge.key_color %>"
+          d="M0 0 h<%= @badge.key_width %> v20 H0 z"/>
+    <path fill="<%= @badge.value_color %>"
+          d="M<%= @badge.key_width %> 0 h<%= @badge.value_width %> v20 H<%= @badge.key_width %> z"/>
+    <path fill="url(#b)"
+          d="M0 0 h<%= @badge.width %> v20 H0 z"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle">
+    <g font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+      <text x="<%= @badge.key_text_anchor %>" y="15" fill="#010101" fill-opacity=".3">
+        <%= @badge.key_text %>
+      </text>
+      <text x="<%= @badge.key_text_anchor %>" y="14">
+        <%= @badge.key_text %>
+      </text>
+      <text x="<%= @badge.value_text_anchor %>" y="15" fill="#010101" fill-opacity=".3">
+        <%= @badge.value_text %>
+      </text>
+      <text x="<%= @badge.value_text_anchor %>" y="14">
+        <%= @badge.value_text %>
+      </text>
+    </g>
+  </g>
+</svg>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register "image/svg+xml", :svg

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,7 @@ en:
       api_key: "API Key:"
       are_you_sure: 'Are you sure?'
       atom_title: "Errbit notices for %{name} at %{host}"
+      badges: badges
       edit: edit
       environment: Environment
       errors: Errors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
     resources :watchers, only: [:destroy, :update]
     member do
       post :regenerate_api_key
+      get 'badges', as: :badges, to: 'badges#index'
+      get 'badges/:badge_type', format: :svg, as: :badge, to: 'badges#show'
     end
     collection do
       get :search

--- a/lib/badges/base.rb
+++ b/lib/badges/base.rb
@@ -1,0 +1,60 @@
+module Badges
+  class Base
+    include ActiveSupport::DescendantsTracker
+
+    class << self
+      attr_accessor :title
+
+      def key
+        name.underscore.split('/').last
+      end
+
+      def find_badge_for_key(key)
+        descendants.find { |badge_class| badge_class.key == key }
+      end
+    end
+
+    COLORS = {
+      green:  '#4c1',
+      red:    '#e05d44',
+      yellow: '#dfb317',
+      grey:   '#9f9f9f'
+    }.freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def key_color
+      '#555'
+    end
+
+    def key_text_anchor
+      key_width / 2
+    end
+
+    def value_text_anchor
+      key_width + (value_width / 2)
+    end
+
+    def width
+      key_width + value_width
+    end
+
+    def key_width
+      raise NotImplementedError
+    end
+
+    def key_text
+      raise NotImplementedError
+    end
+
+    def value_color
+      raise NotImplementedError
+    end
+
+    def value_text
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/badges/last_error.rb
+++ b/lib/badges/last_error.rb
@@ -1,0 +1,54 @@
+module Badges
+  class LastError < Base
+    self.title = 'Last unresolved error'
+
+    def key_width
+      62
+    end
+
+    def value_width
+      40
+    end
+
+    def value_color
+      if last_notice.blank?
+        Base::COLORS[:grey]
+      else
+        case hours_till_last_notice
+        when 0..6 then Base::COLORS[:red]
+        when 6..24 then Base::COLORS[:yellow]
+        else Base::COLORS[:green]
+        end
+      end
+    end
+
+    def value_text
+      if last_notice.nil?
+        "n/a"
+      elsif hours_till_last_notice < 1
+        "<1h"
+      elsif hours_till_last_notice < 24
+        "#{hours_till_last_notice.round}h"
+      elsif hours_till_last_notice < (30.days / 1.hour)
+        "#{(hours_till_last_notice / 24.hours).round}d"
+      else
+        ">30d"
+      end
+    end
+
+    def key_text
+      "last error"
+    end
+
+  private
+
+    def hours_till_last_notice
+      @hours_till_last_notice ||=
+        (Time.zone.now - last_notice) / 1.hour
+    end
+
+    def last_notice
+      @last_notice ||= @app.problems.unresolved.order_by(%w[last_notice_at desc]).first.try(:last_notice_at)
+    end
+  end
+end

--- a/lib/badges/recent_errors.rb
+++ b/lib/badges/recent_errors.rb
@@ -1,0 +1,35 @@
+module Badges
+  class RecentErrors < Base
+    self.title = 'Problems in last 24h'
+
+    def key_width
+      62
+    end
+
+    def value_width
+      40
+    end
+
+    def value_color
+      case problem_count
+      when 0..1 then COLORS[:green]
+      when 2..10 then COLORS[:yellow]
+      else COLORS[:red]
+      end
+    end
+
+    def value_text
+      @problem_count
+    end
+
+    def key_text
+      "# in 24h"
+    end
+
+  private
+
+    def problem_count
+      @problem_count ||= @app.problems.unresolved.where(:last_notice_at.gte => 24.hours.ago).count
+    end
+  end
+end

--- a/spec/controllers/badges_controller_spec.rb
+++ b/spec/controllers/badges_controller_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe BadgesController, type: :controller do
+  render_views
+  let(:app) { Fabricate(:app) }
+  let(:user) { Fabricate(:user) }
+  let(:problem) do
+    Fabricate(:problem, app: app)
+  end
+
+  before(:each) do
+    sign_in user
+  end
+  describe "GET /apps/:id/badges" do
+    it "shows all badges" do
+      get :index, id: app.id
+      expect(response).to be_success
+    end
+  end
+
+  describe "GET /apps/:id/badges/:badge_type" do
+    it "shows last_error badge" do
+      get :show, id: app.id, badge_type: 'last_error', format: 'svg'
+      expect(response).to be_success
+    end
+
+    it "shows recent_errors badge" do
+      get :show, id: app.id, badge_type: 'recent_errors', format: 'svg'
+      expect(response).to be_success
+    end
+  end
+end


### PR DESCRIPTION
I've added 2 badge types that are available for each app.
Badges are a nice way to communicate quality in a README etc.

Thinks that I am not so sure/could be optimized (if somebody wants to help, please feel free!)

- authenticated key -> I've reused the key usage from the atom feed... that makes the token quasi public, and might be a problem when the Atom feed contain sensitive info. Maybe generate a new token per app only for badge usage?
  - Right now, we will only use the badges in private projects, so for us not urgent, but definitely preferable
- Badge Ranges... I've just made some guesses. Not sure how merged problems fell into that etc.
  - Would be great to make the ranges configurable via ENV config etc. (maybe later)
- only added 2 smoke tests, had not the time to add thorough test of the logic (as ranges not sure right now)
- other badge ideas? class infrastructure is there to add other badge types easily

![bildschirmfoto 2019-01-29 um 22 46 25](https://user-images.githubusercontent.com/147175/51942824-4c558980-2418-11e9-88db-055748d8cb5d.png)
![bildschirmfoto 2019-01-29 um 22 46 29](https://user-images.githubusercontent.com/147175/51942826-4cee2000-2418-11e9-9872-56c27d7bffe5.png)
