### PR TITLE
Update hash_helper.rb

### DIFF
--- a/app/helpers/hash_helper.rb
+++ b/app/helpers/hash_helper.rb
@@ -1,6 +1,6 @@
 module HashHelper
   def pretty_hash(hash, nesting = 0)
-    return '{}' if hash.empty?
+    return hash.to_s unless hash.is_a?(Hash)
 
     tab_size = 2
     nesting += 1


### PR DESCRIPTION
Fix crash if hash is not Hash (for example hash is String)

Feb 13 11:41:18 ip-172-31-15-46 errbit[18087]: ActionView::Template::Error (undefined method `keys' for "Error happen while saving charge and recalculating totals.":String):#012    1: .window#012    2:   .raw_data#012    3:     %pre.hash= pretty_hash notice.params#012  app/helpers/hash_helper.rb:9:in `pretty_hash'#012  app/views/notices/_params.html.haml:3:in `_app_views_notices__params_html_haml__1651385043934122128_47254516850340'#012  app/views/problems/show.html.haml:88:in `_app_views_problems_show_html_haml__203825664179844609_47254504613500'