### PR TITLE
Remove email Auto-Submitted header

### DIFF
--- a/app/mailers/mailer.rb
+++ b/app/mailers/mailer.rb
@@ -9,8 +9,7 @@ class Mailer < ActionMailer::Base
           'X-Errbit-Host'            => Errbit::Config.host,
           'X-Mailer'                 => 'Errbit',
           'X-Auto-Response-Suppress' => 'OOF, AutoReply',
-          'Precedence'               => 'bulk',
-          'Auto-Submitted'           => 'auto-generated'
+          'Precedence'               => 'bulk'
 
   def err_notification(error_report)
     @notice   = NoticeDecorator.new error_report.notice

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -11,10 +11,6 @@ shared_examples "a notification email" do
     expect(email).to have_header('Precedence', 'bulk')
   end
 
-  it "should have Auto-Submitted header" do
-    expect(email).to have_header('Auto-Submitted', 'auto-generated')
-  end
-
   it "should have X-Auto-Response-Suppress header" do
     # http://msdn.microsoft.com/en-us/library/ee219609(v=EXCHG.80).aspx
     expect(email).to have_header('X-Auto-Response-Suppress', 'OOF, AutoReply')


### PR DESCRIPTION
When for example sending email to a Jira service desk all emails with
this value and header will be ignored becouse it's considered an
auto-reply.