### PR TITLE
remove cve-2013-0156.rb

### DIFF
--- a/config/initializers/cve-2013-0156.rb
+++ b/config/initializers/cve-2013-0156.rb
@@ -1,3 +1,0 @@
-# ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::YAML)
-ActiveSupport::XmlMini::PARSING.delete("symbol")
-ActiveSupport::XmlMini::PARSING.delete("yaml")

--- a/config/initializers/cve-2013-0156.rb
+++ b/config/initializers/cve-2013-0156.rb
@@ -1,3 +1,3 @@
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::YAML)
+# ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::YAML)
 ActiveSupport::XmlMini::PARSING.delete("symbol")
 ActiveSupport::XmlMini::PARSING.delete("yaml")


### PR DESCRIPTION
https://github.com/errbit/errbit/pull/353
This vulnerability is found in Rails 3.x, not required in Rails 4.x.