### PR TITLE
allow showing problem by id

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -56,6 +56,11 @@ class ProblemsController < ApplicationController
     @comment = Comment.new
   end
 
+  def show_by_id
+    problem = Problem.find(params[:id])
+    redirect_to app_problem_path(problem.app, problem)
+  end
+
   def xhr_sparkline
     render partial: 'problems/sparkline', layout: false
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,8 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'problems/:id' => 'problems#show_by_id'
+
   get 'health/readiness' => 'health#readiness'
   get 'health/liveness' => 'health#liveness'
   get 'health/api-key-tester' => 'health#api_key_tester'

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -122,6 +122,21 @@ describe ProblemsController, type: 'controller' do
     end
   end
 
+  # you do not need an app id, strictly speaking, to find
+  # a problem, and if your metrics system does not happen
+  # to know the app id, but does know the problem id,
+  # it can be handy to have a way to link in to errbit.
+  describe "GET /problems/:id" do
+    before do
+      sign_in user
+    end
+
+    it "should redirect to the standard problems page" do
+      get :show_by_id, id: err.problem.id
+      expect(response).to redirect_to(app_problem_path(app, err.problem.id))
+    end
+  end
+
   describe "GET /apps/:app_id/problems/:id" do
     before do
       sign_in user


### PR DESCRIPTION
you do not need an app id, strictly speaking, to find a problem, and if your metrics system does not happen to know the app id, but does know the problem id, it can be handy to have a way to link in to errbit.

hopefully this is small and uncontroversial enough to merge fast, but don't be afraid to merge my other--more controversial--branches too, which we've been running with for many months in production. ;)

thanks for this awesome project and let us know how we can help!