### PR TITLE
Update docker documentation

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -2,7 +2,7 @@
 
 Errbit provides official [Docker](https://www.docker.com/) images to
 make Docker deployment easy. You can pass all of [Errbit's
-configuration](docs/configuration.md) to the Docker container using
+configuration](/docs/configuration.md) to the Docker container using
 `docker run -e`.
 
 When running Errbit using `docker run` you must specify a MONGO_URL. If you're
@@ -12,7 +12,7 @@ RACK_ENV=production and SECRET_KEY_BASE=some-secret-key.
 If you don't already have one, you can generate a suitable SECRET_KEY_BASE
 with:
 ```bash
-docker run --rm errbit/errbit rake secret
+docker run --rm errbit/errbit bundle exec rake secret
 ```
 
 ## Standalone Errbit App
@@ -28,7 +28,7 @@ docker run \
   errbit/errbit:latest
 ```
 
-Now run `rake errbit:bootstrap` to bootstrap the Errbit db within an ephemeral
+Now run `bundle exec rake errbit:bootstrap` to bootstrap the Errbit db within an ephemeral
 Docker container:
 
 ```bash
@@ -37,7 +37,7 @@ docker run \
   -e "RACK_ENV=production" \
   -e "MONGO_URL=mongodb://my-mongo-host" \
   errbit/errbit:latest \
-  rake errbit:bootstrap
+  bundle exec rake errbit:bootstrap
 ```
 
 ## Errbit + Dependencies via Docker Compose
@@ -49,9 +49,9 @@ Errbit application container and linking the two containers together:
 docker-compose up -e "SECRET_KEY_BASE=my$ecre7key123"
 ```
 
-Now run `rake errbit:bootstrap` to bootstrap the Errbit db within an ephemeral
+Now run `bundle exec rake errbit:bootstrap` to bootstrap the Errbit db within an ephemeral
 Docker container:
 
 ```bash
-docker exec errbit_errbit_1 rake errbit:bootstrap
+docker exec errbit_errbit_1 bundle exec rake errbit:bootstrap
 ```


### PR DESCRIPTION
The path to the configuration file in "docker.md" has been fixed. The actual leads to the page with 404 error. Also added "bundle exec" statement before each rake command. Without it, there is an error related with the wrong version of rake.