### PR TITLE
Fixes #1462 - backtrace does not expand after ajax pagination

### DIFF
--- a/app/assets/javascripts/errbit.js
+++ b/app/assets/javascripts/errbit.js
@@ -120,7 +120,7 @@ $(function() {
     $('td.backtrace_separator').hide();
   }
   // Show external backtrace lines when clicking separator
-  $('td.backtrace_separator span').on('click', show_external_backtrace);
+  $(document).on('click', 'td.backtrace_separator span', show_external_backtrace);
   // Hide external backtrace on page load
   hide_external_backtrace();
 


### PR DESCRIPTION
Binding the click event on document with a selector keeps the functionality working after replacing the error details DOM (i.e. ajax older/newer links). Alternatively we could add the listener on the span after each replacement but I personally don't see a reason to overcomplicate it that way.

Fixes #1462 