### PR TITLE
Order comments in problem views by created_at

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -17,6 +17,8 @@ class Comment
 
   validates :body, presence: true
 
+  scope :ordered, -> { order_by(:created_at.asc) }
+
   def deliver_email
     Mailer.comment_notification(self).deliver_now
   end

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -26,7 +26,7 @@
 
 - content_for :comments do
   %h3= t('.comments')
-  - problem.comments.each do |comment|
+  - problem.comments.ordered.each do |comment|
     .window
       %table.comment
         %tr


### PR DESCRIPTION
This should fix the bug we're seeing where comments are being rendered
in a scrambled order.

This follows the `ordered` scope pattern from notices and problems:
https://github.com/errbit/errbit/blob/9f53eaaa0ee966ea2d8015e8eeacf6dde1709601/app/models/problem.rb#L62
https://github.com/errbit/errbit/blob/9f53eaaa0ee966ea2d8015e8eeacf6dde1709601/app/models/notice.rb#L36

Closes: https://github.com/errbit/errbit/issues/1483

CC @stevecrozz 