### PR TITLE
Update Nokogiri: v1.10.9 -> v1.11.0 to fix CVE-2020-26247

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.0)
     mongo (2.11.3)
       bson (>= 4.4.2, < 5.0.0)
@@ -209,9 +209,11 @@ GEM
     netrc (0.11.0)
     nio4r (2.5.2)
     nio4r (2.5.2-java)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.9-java)
+    nokogiri (1.11.1)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.1-java)
+      racc (~> 1.4)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
       jwt (>= 1.0, < 3.0)
@@ -270,6 +272,8 @@ GEM
       nio4r (~> 2.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
+    racc (1.5.2)
+    racc (1.5.2-java)
     rack (1.6.13)
     rack-contrib (1.8.0)
       rack (~> 1.4)
@@ -486,4 +490,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
Nokogiri v1.11.0 was released on 2021-01-03, which contains a fix for CVE-2020-26247, fully described at https://github.com/advisories/GHSA-vr8q-g5c7-m54m. That security advisory is reproduced here for your convenience.

**Severity**
Nokogiri maintainers have evaluated this as Low Severity (CVSS3 2.6).

**Description**
In Nokogiri versions <= 1.11.0.rc3, XML Schemas parsed by Nokogiri::XML::Schema are trusted by default, allowing external resources to be accessed over the network, potentially enabling XXE or SSRF attacks.

This behavior is counter to the security policy followed by Nokogiri maintainers, which is to treat all input as untrusted by default whenever possible.

Please note that this security fix was pushed into a new minor version, 1.11.x, rather than a patch release to the 1.10.x branch, because it is a breaking change for some schemas and the risk was assessed to be "Low Severity".

**Affected Versions**
Nokogiri <= 1.10.10 as well as prereleases 1.11.0.rc1, 1.11.0.rc2, and 1.11.0.rc3

**Mitigation**
There are no known workarounds for affected versions. Upgrade to Nokogiri 1.11.0.rc4 or later.

If, after upgrading to 1.11.0.rc4 or later, you wish to re-enable network access for resolution of external resources (i.e., return to the previous behavior):

1. Ensure the input is trusted. Do not enable this option for untrusted input.
2. When invoking the Nokogiri::XML::Schema constructor, pass as the second parameter an instance of Nokogiri::XML::ParseOptions with the NONET flag turned off.

So if your previous code was:
- in v1.11.0.rc3 and earlier, this call allows resources to be accessed over the network
- but in v1.11.0.rc4 and later, this call will disallow network access for external resources
schema = Nokogiri::XML::Schema.new(schema)
- in v1.11.0.rc4 and later, the following is equivalent to the code above
- (the second parameter is optional, and this demonstrates its default value)
schema = Nokogiri::XML::Schema.new(schema, Nokogiri::XML::ParseOptions::DEFAULT_SCHEMA)

Then you can add the second parameter to indicate that the input is trusted by changing it to:

- in v1.11.0.rc3 and earlier, this would raise an ArgumentError 
- but in v1.11.0.rc4 and later, this allows resources to be accessed over the network
schema = Nokogiri::XML::Schema.new(trusted_schema, Nokogiri::XML::ParseOptions.new.nononet)