### PR TITLE
[WiP] Replace therubyracer with mini_racer (updates v8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 env:
   global:
     - COVERAGE=true JRUBY_OPTS=--debug
+    - BUNDLER_VERSION=2.1.4
   matrix:
     - MONGODB=ubuntu1604-4.2.3
     - MONGODB=ubuntu1604-4.0.16
@@ -22,6 +23,7 @@ cache:
 
 before_install:
   - gem update --system
+  - gem install bundler --version 2.1.4
 
 before_script:
   - wget --directory-prefix=mongodb-install/ https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz

--- a/Gemfile
+++ b/Gemfile
@@ -86,7 +86,7 @@ group :heroku, :production do
 end
 
 group :no_docker, :test, :development do
-  gem 'therubyracer', platform: :ruby # C Ruby (MRI) or Rubinius, but NOT Windows
+  gem 'mini_racer', platform: :ruby # C Ruby (MRI) or Rubinius, but NOT Windows
 end
 
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
     launchy (2.4.3-java)
       addressable (~> 2.3)
       spoon (~> 0.0.1)
-    libv8 (3.16.14.19)
+    libv8 (8.4.255.0)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -187,6 +187,8 @@ GEM
     mime-types-data (3.2016.0521)
     mini_mime (1.0.1)
     mini_portile2 (2.5.0)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     minitest (5.14.0)
     mongo (2.11.3)
       bson (>= 4.4.2, < 5.0.0)
@@ -301,7 +303,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    ref (2.0.0)
     regexp_parser (1.3.0)
     request_store (1.1.0)
     responders (2.4.1)
@@ -383,9 +384,6 @@ GEM
     temple (0.8.2)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.4)
     thread_safe (0.3.6)
     thread_safe (0.3.6-java)
@@ -450,6 +448,7 @@ DEPENDENCIES
   kaminari-mongoid
   launchy
   meta_request
+  mini_racer
   mongoid (~> 5.4)
   mongoid-rspec
   omniauth
@@ -476,7 +475,6 @@ DEPENDENCIES
   rushover
   sass-rails
   sucker_punch
-  therubyracer
   timecop
   uglifier
   underscore-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,13 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.1-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.1-java)
+      racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-linux)
       racc (~> 1.4)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
@@ -414,8 +420,13 @@ GEM
     yajl-ruby (1.4.1)
 
 PLATFORMS
+  arm64-darwin-20
   java
   ruby
+  x86_64-darwin-18
+  x86_64-darwin-19
+  x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   actionmailer (~> 4.2.10)


### PR DESCRIPTION
Please don't merge yet.

Replacing therubyracer (dead since 2017) with [mini_racer](https://github.com/rubyjs/mini_racer) allows the ancient version of libv8 to get an update from 3.16 to 8.4 which fixes build errors on current systems (#1492 #1494).

- [x] Tests pass (CI fails because it uses bundler 2.2)
- [x] `rails assets:precompile` passes
- [ ] `bundle install` passes with bundler >= 2.2

### Problem with bundler 2.2

As I understand it this is caused by a [bug in libv8](https://github.com/rubyjs/libv8/issues/310) and by a change in bundler which had [unintended side effects](https://github.com/rubygems/rubygems/pull/4127). With how this PR is right now this will cause bundler 2.2 to fail with an error as described in the v8 bug.

As I understand the linked bundler PR should make it so that a lock generated with <2.2 should fallback to old behaviour but I fail to understand what that effectively means as it still fails.

Anyway, for bundler 2.2 we would now need to specify the specific platforms and I'm not sure what to add here. To be able to bundle on my Mac and my Ubuntu machine I need to add the following two:

```sh
bundle lock --add-platform x86_64-darwin-19
bundle lock --add-platform x86_64-linux
```

As I'm not quite sure how backwards compatible this "specific platform" change is, I haven't yet added it to this PR. I just know that darwin alone has 16-19 potentially.

**Maybe we can collect a few common platforms? To get yours: **

```sh
ruby -e 'puts Gem::Platform.local'

# or if that outputs nothing ruby is probably aliased (bundle exec)

\ruby -e 'puts Gem::Platform.local'
```

Let me know what you think.

---

### Update

What irks me a bit is that we don't do any of that in another project which is bundled on 2.2. It still only has the generic "ruby" platform and no darwin/linux specific libv8 versions. When I remove java as a platform from errbit's lock file (so only `ruby` remains) I can bundle without problems on both machines and no platform specific gem versions will be added to the lock file. Unfortunately I have no clue about jruby and Java and why this happens.

### Update 2

There is just something wrong somewhere in libv8 and/bundler. Remember when I said we don't have this problem in another repository? Well...

```sh
$ ruby -v
bundler ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]

$ bundler -v
Bundler version 2.2.15

$ tail -2 Gemfile.lock
BUNDLED WITH
   2.2.14

$ bundle | grep libv8
Using libv8 8.4.255.0 (x86_64-darwin-19)

$ grep libv8 Gemfile.lock
    libv8 (8.4.255.0)
      libv8 (~> 8.4.255)

$ echo "gem 'dle'" >> Gemfile

$ bundle
[..]
Installing libv8 8.4.255.0 with native extensions
Installing dle 1.0.1
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
[..]
An error occurred while installing libv8 (8.4.255.0), and Bundler cannot continue.
Make sure that `gem install libv8 -v '8.4.255.0' --source 'https://www.rubygems.org/'` succeeds before bundling.

In Gemfile:
  mini_racer was resolved to 0.3.1, which depends on
    libv8
```

Almost uncut output: https://gist.github.com/2called-chaos/6025fb23a6cc85bb663e7fe62d7d589c

Bundle is fine and functioning, I add a totally unrelated gem and it fails? 😕 Also downloads 1GB every time you try it 🙄