### PR TITLE
Handle old and new backtrace format, fixes #1477

### DIFF
--- a/app/models/backtrace.rb
+++ b/app/models/backtrace.rb
@@ -2,8 +2,8 @@ class Backtrace
   include Mongoid::Document
   include Mongoid::Timestamps
 
-  IN_APP_PATH = %r{^\[PROJECT_ROOT\](?!(\/vendor))/?}
-  GEMS_PATH = %r{\[GEM_ROOT\]\/gems\/([^\/]+)}
+  IN_APP_PATH = %r{^(?:\[|/)PROJECT_ROOT\]?(?!(/vendor))/?}
+  GEMS_PATH = %r{(?:\[|/)GEM_ROOT\]?/gems/([^/]+)}
 
   field :fingerprint
   field :lines

--- a/spec/decorators/backtrace_line_decorator_spec.rb
+++ b/spec/decorators/backtrace_line_decorator_spec.rb
@@ -11,6 +11,12 @@ describe BacktraceLineDecorator, type: :decorator do
       file:   '[PROJECT_ROOT]/path/to/file/ea315ea4.rb',
       method: :instance_eval)
   end
+  let(:backtrace_line_in_app_slashes) do
+    described_class.new(
+      number: 884,
+      file:   '/PROJECT_ROOT/path/to/file/ea315ea4.rb',
+      method: :instance_eval)
+  end
   let(:backtrace_line_no_file) do
     described_class.new(number: 884, method: :instance_eval)
   end
@@ -44,6 +50,16 @@ describe BacktraceLineDecorator, type: :decorator do
   describe '#path' do
     it 'returns "" when there is no file' do
       expect(backtrace_line_no_file.path).to eq ''
+    end
+  end
+
+  describe '#decorated_path' do
+    it 'parses old backtrace format with square brackets' do
+      expect(backtrace_line_in_app.decorated_path).to eq 'path/to/file/'
+    end
+
+    it 'parses new backtrace format with slashes' do
+      expect(backtrace_line_in_app_slashes.decorated_path).to eq 'path/to/file/'
     end
   end
 


### PR DESCRIPTION
I suppose there is a reason why the regex for the gem path wasn't anchored? I didn't change it.

I did remove unnecessary escapes of slashes which are not needed when using `%r` and it was used both escaped and not escaped before. Apart from that it just allows either `[PROJECT_ROOT]` and `/PROJECT_ROOT/` (GEM_ROOT respectively). 

Fixes #1477