### PR TITLE
Bump mimemagic to version 0.3.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.2)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.1)
     mini_portile2 (2.5.0)
     minitest (5.14.0)


### PR DESCRIPTION
Mimemagic has [yanked all versions previous to version 0.3.7](https://rubygems.org/gems/mimemagic/versions). Since the Gemfile.lock included version 0.3.2, running `bundle install` failed.

See also:

* [Dependency on mimemagic 0.3.x no longer valid](https://github.com/rails/rails/issues/41750)