### PR TITLE
Change deprecated mongodb repairDatabase command to compact

### DIFF
--- a/app/interactors/outdated_problem_clearer.rb
+++ b/app/interactors/outdated_problem_clearer.rb
@@ -10,7 +10,7 @@ class OutdatedProblemClearer
         criteria.each do |problem|
           ProblemDestroy.new(problem).execute
         end
-        repair_database
+        compact_database
       end
     end
   end
@@ -25,7 +25,10 @@ private
     @criteria ||= Problem.where(:last_notice_at.lt => Errbit::Config.notice_deprecation_days.to_f.days.ago)
   end
 
-  def repair_database
-    Mongoid.default_client.command repairDatabase: 1
+  def compact_database
+    collections = Mongoid.default_client.collections
+    collections.map(&:name).map do |collection|
+      Mongoid.default_client.command compact: collection
+    end
   end
 end

--- a/app/interactors/resolved_problem_clearer.rb
+++ b/app/interactors/resolved_problem_clearer.rb
@@ -10,7 +10,7 @@ class ResolvedProblemClearer
         criteria.each do |problem|
           ProblemDestroy.new(problem).execute
         end
-        repair_database
+        compact_database
       end
     end
   end
@@ -25,7 +25,10 @@ private
     @criteria = Problem.resolved
   end
 
-  def repair_database
-    Mongoid.default_client.command repairDatabase: 1
+  def compact_database
+    collections = Mongoid.default_client.collections
+    collections.map(&:name).map do |collection|
+      Mongoid.default_client.command compact: collection
+    end
   end
 end

--- a/spec/interactors/outdated_problem_clearer_spec.rb
+++ b/spec/interactors/outdated_problem_clearer_spec.rb
@@ -22,9 +22,9 @@ describe OutdatedProblemClearer do
           Problem.count
         }
       end
-      it 'not repair database' do
+      it 'not compact database' do
         allow(Mongoid.default_client).to receive(:command).and_call_original
-        expect(Mongoid.default_client).to_not receive(:command).with(repairDatabase: 1)
+        expect(Mongoid.default_client).to_not receive(:command).with(compact: an_instance_of(String))
         outdated_problem_clearer.execute
       end
     end
@@ -32,7 +32,7 @@ describe OutdatedProblemClearer do
     context "with old problems" do
       before do
         allow(Mongoid.default_client).to receive(:command).and_call_original
-        allow(Mongoid.default_client).to receive(:command).with(repairDatabase: 1)
+        allow(Mongoid.default_client).to receive(:command).with(compact: an_instance_of(String)).at_least(1)
         problems.first.update(last_notice_at: Time.zone.at(946_684_800.0))
         problems.second.update(last_notice_at: Time.zone.at(946_684_800.0))
       end
@@ -47,8 +47,8 @@ describe OutdatedProblemClearer do
         expect(Problem.where(_id: problems.second.id).first).to be_nil
       end
 
-      it 'repair database' do
-        expect(Mongoid.default_client).to receive(:command).with(repairDatabase: 1)
+      it 'compact database' do
+        expect(Mongoid.default_client).to receive(:command).with(compact: an_instance_of(String)).at_least(1)
         outdated_problem_clearer.execute
       end
     end

--- a/spec/interactors/resolved_problem_clearer_spec.rb
+++ b/spec/interactors/resolved_problem_clearer_spec.rb
@@ -18,9 +18,9 @@ describe ResolvedProblemClearer do
           Problem.count
         }
       end
-      it 'not repair database' do
+      it 'not compact database' do
         allow(Mongoid.default_client).to receive(:command).and_call_original
-        expect(Mongoid.default_client).to_not receive(:command).with(repairDatabase: 1)
+        expect(Mongoid.default_client).to_not receive(:command).with(compact: an_instance_of(String))
         resolved_problem_clearer.execute
       end
     end
@@ -28,7 +28,7 @@ describe ResolvedProblemClearer do
     context "with problem resolve" do
       before do
         allow(Mongoid.default_client).to receive(:command).and_call_original
-        allow(Mongoid.default_client).to receive(:command).with(repairDatabase: 1)
+        allow(Mongoid.default_client).to receive(:command).with(compact: an_instance_of(String)).at_least(1)
         problems.first.resolve!
         problems.second.resolve!
       end
@@ -43,8 +43,8 @@ describe ResolvedProblemClearer do
         expect(Problem.where(_id: problems.second.id).first).to be_nil
       end
 
-      it 'repair database' do
-        expect(Mongoid.default_client).to receive(:command).with(repairDatabase: 1)
+      it 'compact database' do
+        expect(Mongoid.default_client).to receive(:command).with(compact: an_instance_of(String)).at_least(1)
         resolved_problem_clearer.execute
       end
     end


### PR DESCRIPTION
when I was trying to run `bundle exec rake errbit:clear_outdated` I've got following error:
```
rake aborted!
Mongo::Error::OperationFailure: This command has been removed. If you would like to compact your data, use the 'compact' command. If you would like to rebuild indexes, use the 'reIndex' command. If you need to recover data, please see the documentation for repairing your database offline: http://dochub.mongodb.org/core/repair (59) (on consul.qtravel.ai)
```
This PR fixes it.