### PR TITLE
👷 Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ jobs:
       - save_caches
       - run: ruby -v
       - run: bundle -v
+      - run: bundle exec rake errbit:bootstrap
       - run: bundle exec rspec
       - run: bundle exec rubocop
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,63 @@
+version: 2.1
+commands:
+  restore_caches:
+    steps:
+      - restore_cache:
+          keys:
+            - rubygems-{{ checksum "_rubygems_cache_key" }}-{{ checksum "Gemfile.lock" }}
+            - rubygems-{{ checksum "_rubygems_cache_key" }}-
+            - rubygems-
+  create_cache_key_files:
+    steps:
+      - run: echo $CIRCLECI_RUBYGEMS_CACHE_KEY
+      - run:
+          name: Write the rubygems cache key to a file
+          command: |
+            echo $CIRCLECI_RUBYGEMS_CACHE_KEY > _rubygems_cache_key
+            cat _rubygems_cache_key
+  save_caches:
+    steps:
+      - save_cache:
+          paths:
+            - vendor
+          key: rubygems-{{ checksum "_rubygems_cache_key" }}-{{ checksum "Gemfile.lock" }}
+  install_gems:
+    steps:
+      - run: gem update --system
+      - run: gem install bundler -v $BUNDLER_VERSION
+      - run: bundle config set clean true --local
+      - run: bundle config set jobs 4 --local
+      - run: bundle config set path vendor/bundle --local
+      - run: bundle config set retry 3 --local
+      - run: bundle install
+jobs:
+  mongo-ruby:
+    environment:
+      CIRCLECI_RUBYGEMS_CACHE_KEY: '2021082301'
+      BUNDLER_VERSION: 2.1.4
+    parameters:
+      ruby_version:
+        type: string
+      mongo_version:
+        type: string
+    docker:
+      - image: circleci/ruby:<< parameters.ruby_version >>-browsers-legacy
+      - image: circleci/mongo:<< parameters.mongo_version >>-ram
+    steps:
+      - checkout
+      - create_cache_key_files
+      - restore_caches
+      - install_gems
+      - save_caches
+      - run: ruby -v
+      - run: bundle -v
+      - run: bundle exec rspec
+      - run: bundle exec rubocop
+workflows:
+  workflow:
+    jobs:
+      - mongo-ruby:
+          matrix:
+            parameters:
+              ruby_version: ["2.5", "2.6"]
+              mongo_version: ["4.0", "4.1", "4.2", "4.4", "5.0"]


### PR DESCRIPTION
Hi, maintainers.

Thank you for publishing a wonderful product on OSS. I used to use other products for a while, but I'm back. When I came back, I noticed that some of the errbit were out of date.

There are a few things to worry about, but [travis-ci.org](https://travis-ci.org), which is used for CI, ended on June 15, 2021 and announced the transition to [travis-ci.com](https://travis-ci.com), but travis-ci.com is credit-based, I thought it would be difficult to use with OSS, so this time I added a setting to run CI with CircleCI. If you prefer [GitHub Actions](https://github.com/features/actions), I would like to add a CI setting in GitHub Actions.

https://circleci.com

If you want CircleCI to work with your errbit organization, someone with errbit organization must create an account on CircleCI and work with GitHub to run that branch of errbit on CircleCI. If you can merge this PR into master first, I think that you can run test on CircleCI just by linking CircleCI and GitHub.

For the time being, I added a setting to test Ruby 2.5 and 2.6, MongoDB v4 or later in a matrix, and confirmed that the test passes in all environments. See also the screenshot below for the test results.

<img width="1439" alt="Screenshot 2021-08-25 10 03 21" src="https://user-images.githubusercontent.com/215381/130709703-8b257d5c-b665-4072-9602-8ad49683b0a9.png">

If you would like to use CircleCI for your CI, I would like to create a PR that removes the Travis CI badge etc. after merging this PR. After that, I would like to update Ruby and various libraries. (Since [Ruby 2.5 is no longer supported with Ruby 2.5.9 released on April 5, 2021](https://www.ruby-lang.org/en/news/2021/04/05/ruby-2-5-9-released/).)

Please confirm it.

Thank you for reading to the end.