### PR TITLE
🔥 Delete MongoDB v4.1 on CiecleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,4 +61,4 @@ workflows:
           matrix:
             parameters:
               ruby_version: ["2.5", "2.6"]
-              mongo_version: ["4.0", "4.1", "4.2", "4.4", "5.0"]
+              mongo_version: ["4.0", "4.2", "4.4", "5.0"]


### PR DESCRIPTION
Hi,

I deleted MongoDB v4.1 on CircleCI. (Because it seems that the version with an odd number of minor versions was out of the official surport. Refs: https://www.mongodb.com/support-policy/lifecycles)

I've already confirmed that the test passes with CircleCI.

<img width="1184" alt="スクリーンショット 2021-08-28 11 25 00" src="https://user-images.githubusercontent.com/215381/131203508-3da81081-f73f-41ba-958c-d86bae34e813.png">

Since v4.0 or later is still supported by the official status, I personally think that it is better to keep it supported as errbit. Because some users may have applications and DBs running as separate servers, instances or services. I leave the decision to the maintainers.

I'll continue to work on adding ruby 2.7 and updating the library.

Thank you.