### PR TITLE
Configure Ruby 2.7 for Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
       "description": "The connection URI to your MongoDB Cluster. If you don't have one, you can create a free plan at https://cloud.mongodb.com . Follow the Heroky deployment docs on the Errbit repo for more information on obtaining this string.",
       "required": true
     },
-    "GEMFILE_RUBY_VERSION": "2.5.1",
+    "GEMFILE_RUBY_VERSION": "2.7.5",
     "SECRET_KEY_BASE": {
       "description": "A secret key for verifying the integrity of signed cookies.",
       "generator": "secret"


### PR DESCRIPTION
Based on the doc update that Errbit now requires Ruby 2.7 (https://github.com/errbit/errbit/commit/c4153cf19c1a7751777ea112fdcd01308bbbb484), update the Heroku config for the currently available Ruby 2.7 version on Heroku (https://devcenter.heroku.com/articles/ruby-support#ruby-versions).

As a side benefit, this allows using the current Heroku stack-20.