### PR TITLE
Document how to disable polling airbrake remote config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Errbit is a tool for collecting and managing errors from other applications.
 It is [Airbrake](http://airbrake.io) API compliant, so if you are already using
-Airbrake, you can just point the `airbrake` gem to your Errbit server.
+Airbrake, you can just point the `airbrake` gem to your Errbit server (see [howto](#configure-airbrake-gem)).
 
 <table>
   <tr>
@@ -234,6 +234,46 @@ it will be displayed under the *User Details* tab:
 ![User details tab](https://errbit.com/images/error_user_information.png)
 
 This tab will be hidden if no user information is available.
+
+Configure Airbrake gem
+--------------------------
+
+## Bundler
+
+Add the Airbrake gem to your Gemfile:
+
+```ruby
+gem 'airbrake'
+```
+
+## Manual
+
+Invoke the following command from your terminal:
+
+```bash
+gem install airbrake
+```
+
+### Configuration
+
+```bash
+rails g airbrake
+```
+
+This command will generate a configuration file under
+`config/initializers/airbrake.rb`.
+
+Airbrake supports polling a remote config from airbrake.io, enabled by default. However, since you are using Errbit and not Airbrake, this request will fail and generate an XML error message on stdout. To disable polling the remote config, add the following flag to `config/initializers/airbrake.rb`.
+
+```ruby
+c.remote_config = false
+```
+
+
+Configuration
+-------------
+
+https://github.com/airbrake/airbrake
 
 Javascript error notifications
 --------------------------------------


### PR DESCRIPTION
Following the readme, I used the `airbrake` gem and followed the airbrake docs for configuration. I ran `gem install airbrake` and pointed airbrake to my errbit instance.

In the `development` Rails environment, this worked fine. In the `production` Rails environment, this yielded the following error:

```
E, [2022-03-25T10:10:04.695662 #1] ERROR -- : <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access
Denied</Message><RequestId>WD57Y1AJCJ74WRKH</RequestId><HostId>W+P5KTtP4PAuz+U6mxLhJ5bbKzPuOPcvBRQTGezTtWb5oPtEyz8w+Z+WSedYdOYF3aif72tIcEY=</HostId></Error>
```

After quite a bit of searching and reading/patching airbrake code with @branch14, we saw that airbrake supports a feature called "[remote config](https://github.com/airbrake/airbrake-ruby/pull/636)", enabled by default. When using Errbit, there's no need to poll from airbrake.io, so disabling this feature is readily available.
