### PR TITLE
Add publish GitHub action workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,8 @@ name: build-and-publish
 
 on:
   push:
+    branches:
+      - main
     tags:
       - '*'
 
@@ -25,6 +27,7 @@ jobs:
         with:
           images: ${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}
           tags: |
+            type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: build-and-publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Addresses #1512 

This PR adds a workflow definition file that will build and publish the image to dockerhub when you push a tagged version.

You can see a demo of how this worked on my fork:

```
git commit -m "Add publish GitHub action workflow"
git tag v9.9.0
git push --tags
```

Which triggered [this build](https://github.com/shreve/errbit/runs/5760542942), and pushed the image to [this Docker Hub repo](https://hub.docker.com/repository/docker/shreve/errbit/tags).

As you can see, it creates the layered semver tags: `9`, `9.9`, `9.9.0`, and the ever-useful `latest`.

The only configuration I needed to add was `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in the repo actions secrets.