### PR TITLE
Update mini_racer gem to 0.6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
 jobs:
   mongo-ruby:
     environment:
-      CIRCLECI_RUBYGEMS_CACHE_KEY: '2021082301'
+      CIRCLECI_RUBYGEMS_CACHE_KEY: '2022060523'
       RUBYGEMS_VERSION: 3.3.15
       BUNDLER_VERSION: 2.3.15
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ commands:
           keys:
             - rubygems-{{ checksum "_rubygems_cache_key" }}-{{ checksum "Gemfile.lock" }}
             - rubygems-{{ checksum "_rubygems_cache_key" }}-
-            - rubygems-
   create_cache_key_files:
     steps:
       - run: echo $CIRCLECI_RUBYGEMS_CACHE_KEY
@@ -33,7 +32,7 @@ commands:
 jobs:
   mongo-ruby:
     environment:
-      CIRCLECI_RUBYGEMS_CACHE_KEY: '2022060523'
+      CIRCLECI_RUBYGEMS_CACHE_KEY: '2022060600'
       RUBYGEMS_VERSION: 3.3.15
       BUNDLER_VERSION: 2.3.15
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ commands:
           key: rubygems-{{ checksum "_rubygems_cache_key" }}-{{ checksum "Gemfile.lock" }}
   install_gems:
     steps:
-      - run: gem update --system
-      - run: gem install bundler -v $BUNDLER_VERSION
+      - run: gem update --system "$RUBYGEMS_VERSION"
+      - run: gem install bundler --version "$BUNDLER_VERSION" --force
       - run: bundle config set clean true --local
       - run: bundle config set jobs 4 --local
       - run: bundle config set path vendor/bundle --local
@@ -34,14 +34,15 @@ jobs:
   mongo-ruby:
     environment:
       CIRCLECI_RUBYGEMS_CACHE_KEY: '2021082301'
-      BUNDLER_VERSION: 2.1.4
+      RUBYGEMS_VERSION: 3.3.15
+      BUNDLER_VERSION: 2.3.15
     parameters:
       ruby_version:
         type: string
       mongo_version:
         type: string
     docker:
-      - image: circleci/ruby:<< parameters.ruby_version >>-browsers-legacy
+      - image: cimg/ruby:<< parameters.ruby_version >>-browsers
       - image: circleci/mongo:<< parameters.mongo_version >>-ram
     steps:
       - checkout
@@ -65,5 +66,5 @@ workflows:
       - mongo-ruby:
           matrix:
             parameters:
-              ruby_version: ["2.7"]
+              ruby_version: ["2.7.6"]
               mongo_version: ["4.0", "4.2", "4.4", "5.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.7.6-alpine
 LABEL maintainer="David Papp <david@ghostmonitor.com>"
 
-ENV BUNDLER_VERSION=2.3.5
-ENV RUBYGEMS_VERSION=3.3.5
+ENV BUNDLER_VERSION=2.3.15
+ENV RUBYGEMS_VERSION=3.3.15
 
 WORKDIR /app
 
@@ -10,8 +10,8 @@ WORKDIR /app
 RUN echo "gem: --no-document" >> /etc/gemrc \
   && bundle config --global frozen 1 \
   && bundle config --global disable_shared_gems false \
-  && gem update --system $RUBYGEMS_VERSION \
-  && gem install bundler --version $BUNDLER_VERSION \
+  && gem update --system "$RUBYGEMS_VERSION" \
+  && gem install bundler --version "$BUNDLER_VERSION" \
   && apk add --no-cache \
     curl \
     less \

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ group :heroku, :production do
 end
 
 group :no_docker, :test, :development do
-  gem 'mini_racer', '~> 0.3.1', platform: :ruby # C Ruby (MRI) or Rubinius, but NOT Windows
+  gem 'mini_racer', platform: :ruby # C Ruby (MRI) or Rubinius, but NOT Windows
 end
 
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,12 +170,11 @@ GEM
       mongoid
     launchy (2.5.0)
       addressable (~> 2.7)
-    libv8 (8.4.255.0)
-    libv8 (8.4.255.0-universal-darwin-20)
-    libv8 (8.4.255.0-x86_64-darwin-18)
-    libv8 (8.4.255.0-x86_64-darwin-19)
-    libv8 (8.4.255.0-x86_64-darwin-20)
-    libv8 (8.4.255.0-x86_64-linux)
+    libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-arm64-darwin)
+    libv8-node (16.10.0.0-x86_64-darwin)
+    libv8-node (16.10.0.0-x86_64-darwin-19)
+    libv8-node (16.10.0.0-x86_64-linux)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -190,8 +189,8 @@ GEM
     mime-types-data (3.2021.0704)
     mini_mime (1.1.1)
     mini_portile2 (2.8.0)
-    mini_racer (0.3.1)
-      libv8 (~> 8.4.255)
+    mini_racer (0.6.2)
+      libv8-node (~> 16.10.0.0)
     minitest (5.15.0)
     mongo (2.15.0)
       bson (>= 4.8.2, < 5.0.0)
@@ -473,7 +472,7 @@ DEPENDENCIES
   kaminari-mongoid
   launchy
   meta_request
-  mini_racer (~> 0.3.1)
+  mini_racer
   mongoid (~> 5.4)
   mongoid-rspec
   omniauth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -509,4 +509,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   2.2.27
+   2.3.15


### PR DESCRIPTION
This is PR update `mini_racer` gem to 0.6.2. Old version doesn't compile anymore on modern systems. Plus, related fixes.

1. Update `mini_racer` gem to 0.6.2. So, on modern systems (like macOS Monterey 12.4) project can be bundled. git clone + bundle == works!
2. Remove cache restore by key `rubygems-`. We should not restore cache from e.g. old ruby version.
3. Bump `CIRCLECI_RUBYGEMS_CACHE_KEY` to clear circle ci build cache.
4. Update rubygems (to 3.3.15) and bundler (to 2.3.15). In `Gemfile.lock` and in `Dockerfile`.
5. Replace `circleci/ruby` `-browsers-legacy` image with `cimg/ruby` and `-browsers`. `circleci/ruby` images was [deprecated](https://circleci.com/docs/2.0/next-gen-migration-guide/).