### PR TITLE
Prepare for rails 5.0

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---color
 --require spec_helper
 --order random

--- a/app/controllers/api/v1/stats_controller.rb
+++ b/app/controllers/api/v1/stats_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::StatsController < ApplicationController
     end
   end
 
-protected
+private
 
   def require_api_key_or_authenticate_user!
     if params[:api_key].present?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
 
   rescue_from ActionController::RedirectBackError, with: :redirect_to_root
 
-protected
+private
 
   ##
   # Check if the current_user is admin or not and redirect to root url if not

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -99,7 +99,7 @@ class AppsController < ApplicationController
     end
   end
 
-protected
+private
 
   def initialize_subclassed_notification_service
     notification_type = app_params.
@@ -172,8 +172,6 @@ protected
       params[:app][:notice_fingerprinter_attributes] = SiteConfig.document.notice_fingerprinter_attributes
     end
   end
-
-private
 
   def app_params
     params.require(:app).permit!

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -21,10 +21,10 @@ class NoticesController < ApplicationController
         render text: "Notice for old app version ignored"
       end
     else
-      render text: "Your API key is unknown", status: 422
+      render text: "Your API key is unknown", status: :unprocessable_entity
     end
   rescue Nokogiri::XML::SyntaxError
-    render text: 'The provided XML was not well-formed', status: 422
+    render text: 'The provided XML was not well-formed', status: :unprocessable_entity
   end
 
   # Redirects a notice to the problem page. Useful when using User Information at Airbrake gem.

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -153,7 +153,7 @@ class ProblemsController < ApplicationController
     end
   end
 
-protected
+private
 
   ##
   # Redirect :back if no errors selected

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -54,7 +54,7 @@ class UsersController < ApplicationController
     redirect_to user_path(user)
   end
 
-protected
+private
 
   def require_user_edit_priviledges
     can_edit = current_user == user || current_user.admin?

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -195,7 +195,7 @@ class App
     notice_fingerprinter.source == 'site'
   end
 
-protected
+private
 
   def store_cached_attributes_on_problems
     Problem.where(app_id: id).update_all(

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -31,7 +31,7 @@ class Comment
     app.emailable? && notification_recipients.any?
   end
 
-protected
+private
 
   def increase_counter_cache
     err.inc(comments_count: 1)

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -124,7 +124,7 @@ class Notice
     message.gsub(/(#<.+?):[0-9a-f]x[0-9a-f]+(>)/, '\1\2')
   end
 
-protected
+private
 
   def problem_recache
     problem.uncache_notice(self)

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -25,7 +25,7 @@ class Watcher
     user.try(:email) || email
   end
 
-protected
+private
 
   def ensure_user_or_email
     errors.add(:base, "You must specify either a user or an email address") unless user.present? || email.present?

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-use Rack::Deflater
 run Rails.application


### PR DESCRIPTION
Hello,

This PR is prepare for Rails 5.0 migration. I already branch with port errbit to Rails 5.0, but don't tests it well. This is part of changes.

1. [RSpec automatically turn on or off colors](https://rspec.info/blog/2017/05/rspec-3-6-has-been-released/).
2. Don't compress response. Remove `Rack::Deflater`. If anyone really need, they should install and configure proxy for this. E.g. nginx.
3. Replace http status codes with names.
4. Change `protected` to `private`.
