### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ user.save!
 When upgrading Errbit, please run:
 
 ```bash
-git pull origin master # assuming origin is the github.com/errbit/errbit repo
+git pull origin main # assuming origin is the github.com/errbit/errbit repo
 bundle install
 rake db:migrate
 rake db:mongoid:remove_undefined_indexes


### PR DESCRIPTION
Adjust README after changing the default branch name to `main`