### PR TITLE
Upgrade rails to 5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,15 +33,15 @@ jobs:
   mongo-ruby:
     environment:
       CIRCLECI_RUBYGEMS_CACHE_KEY: '2022060600'
-      RUBYGEMS_VERSION: 3.3.15
-      BUNDLER_VERSION: 2.3.15
+      RUBYGEMS_VERSION: 3.3.19
+      BUNDLER_VERSION: 2.3.19
     parameters:
       ruby_version:
         type: string
       mongo_version:
         type: string
     docker:
-      - image: cimg/ruby:<< parameters.ruby_version >>-browsers
+      - image: cimg/ruby:2.7.6-browsers
       - image: circleci/mongo:<< parameters.mongo_version >>-ram
     steps:
       - checkout
@@ -49,9 +49,6 @@ jobs:
       - restore_caches
       - install_gems
       - save_caches
-      # NOTE: Add .ruby-version for rubocop
-      - run: echo << parameters.ruby_version >> > .ruby-version
-      - run: cat .ruby-version
       - run: ruby -v
       - run: gem -v
       - run: bundle -v
@@ -65,5 +62,4 @@ workflows:
       - mongo-ruby:
           matrix:
             parameters:
-              ruby_version: ["2.7.6"]
               mongo_version: ["4.0", "4.2", "4.4", "5.0"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,6 @@ jobs:
       RUBYGEMS_VERSION: 3.3.19
       BUNDLER_VERSION: 2.3.19
     parameters:
-      ruby_version:
-        type: string
       mongo_version:
         type: string
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,15 @@ RUN RAILS_ENV=production bundle exec rake assets:precompile \
   && rm -rf /app/tmp/* \
   && chmod 777 /app/tmp
 
+ENV RAILS_ENV production
+
+ENV RAILS_LOG_TO_STDOUT true
+
+ENV RAILS_SERVE_STATIC_FILES true
+
 EXPOSE 8080
 
 HEALTHCHECK CMD curl --fail "http://$(/bin/hostname -i | /usr/bin/awk '{ print $1 }'):${PORT:-8080}/users/sign_in" || exit 1
 
-CMD ["bundle","exec","puma","-C","config/puma.default.rb"]
+CMD ["bundle", "exec", "puma", "-C", "config/puma.default.rb"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.7.6-alpine
 LABEL maintainer="David Papp <david@ghostmonitor.com>"
 
-ENV BUNDLER_VERSION=2.3.15
-ENV RUBYGEMS_VERSION=3.3.15
+ENV BUNDLER_VERSION=2.3.19
+ENV RUBYGEMS_VERSION=3.3.19
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.7.6-alpine
 LABEL maintainer="David Papp <david@ghostmonitor.com>"
 
-ENV BUNDLER_VERSION=2.3.19
 ENV RUBYGEMS_VERSION=3.3.19
+ENV BUNDLER_VERSION=2.3.19
 
 WORKDIR /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,6 @@ group :test do
 end
 
 group :heroku, :production do
-  gem 'rails_12factor', require: ENV.key?("HEROKU")
 end
 
 group :no_docker, :test, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ gem 'httparty'
 gem 'flowdock'
 
 gem 'ri_cal'
-gem 'yajl-ruby', platform: 'ruby'
 gem 'json', platform: 'jruby'
 
 # For Ruby 2.7

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'listen', '~> 3.0.5'
   gem 'better_errors'
   gem 'binding_of_caller', platform: 'ruby'
   gem 'meta_request'

--- a/Gemfile
+++ b/Gemfile
@@ -87,9 +87,6 @@ group :test do
   gem 'coveralls', require: false
 end
 
-group :heroku, :production do
-end
-
 group :no_docker, :test, :development do
   gem 'mini_racer', platform: :ruby # C Ruby (MRI) or Rubinius, but NOT Windows
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'actionmailer', RAILS_VERSION
 gem 'actionpack', RAILS_VERSION
 gem 'railties', RAILS_VERSION
 
+gem 'activemodel-serializers-xml'
 gem 'actionmailer_inline_css'
 gem 'decent_exposure'
 gem 'devise'

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development do
 end
 
 group :test do
+  gem 'rails-controller-testing'
   gem 'rake'
   gem 'rspec'
   gem 'rspec-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,11 +301,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.7.2)
       actionpack (= 5.0.7.2)
       activesupport (= 5.0.7.2)
@@ -488,7 +483,6 @@ DEPENDENCIES
   rack-ssl
   rack-ssl-enforcer
   rails-controller-testing
-  rails_12factor
   railties (= 5.0.7.2)
   rake
   ri_cal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,6 +446,7 @@ DEPENDENCIES
   actionmailer (= 5.0.7.2)
   actionmailer_inline_css
   actionpack (= 5.0.7.2)
+  activemodel-serializers-xml
   airbrake (~> 4.3.5)
   better_errors
   bigdecimal (~> 1.4.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,10 @@ GEM
     rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -483,6 +487,7 @@ DEPENDENCIES
   puma
   rack-ssl
   rack-ssl-enforcer
+  rails-controller-testing
   rails_12factor
   railties (= 5.0.7.2)
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,6 @@ GEM
     xmpp4r (0.5.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yajl-ruby (1.4.3)
 
 PLATFORMS
   arm64-darwin-20
@@ -508,7 +507,6 @@ DEPENDENCIES
   underscore-rails
   useragent
   xmpp4r
-  yajl-ruby
 
 RUBY VERSION
    ruby 2.7.6p219

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,9 @@ GEM
     libv8-node (16.10.0.0-x86_64-darwin)
     libv8-node (16.10.0.0-x86_64-darwin-19)
     libv8-node (16.10.0.0-x86_64-linux)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -309,6 +312,9 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.1.1)
     rake (13.0.6)
+    rb-fsevent (0.11.1)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     regexp_parser (2.5.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -468,6 +474,7 @@ DEPENDENCIES
   kaminari
   kaminari-mongoid
   launchy
+  listen (~> 3.0.5)
   meta_request
   mini_racer
   mongoid (= 6.0.3)

--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-# These rake tasks should always be run in the 'test' environment and the
-# environment name must be set before loading the Rails application
-test_env_tasks = %w(default spec)
-if Rake.application.top_level_tasks.any? { |t| test_env_tasks.include?(t) }
-  ENV['RAILS_ENV'] = 'test'
-end
-
-require File.expand_path('../config/application', __FILE__)
+require_relative 'config/application'
 
 Rails.application.load_tasks
-
-begin
-  require 'rspec/core/rake_task'
-  RSpec::Core::RakeTask.new(:spec)
-  task default: :spec
-rescue LoadError
-  warn "Notice: no rspec tasks available in this environment"
-end

--- a/app/controllers/api/v1/notices_controller.rb
+++ b/app/controllers/api/v1/notices_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::NoticesController < ApplicationController
     end
 
     results = benchmark("[api/v1/notices_controller] query time") do
-      Notice.where(query).with(consistency: :strong).only(fields).to_a
+      Notice.where(query).only(fields).to_a
     end
 
     respond_to do |format|

--- a/app/controllers/api/v1/problems_controller.rb
+++ b/app/controllers/api/v1/problems_controller.rb
@@ -28,7 +28,7 @@ class Api::V1::ProblemsController < ApplicationController
     end
 
     results = benchmark("[api/v1/problems_controller/index] query time") do
-      Problem.where(query).with(consistency: :strong).only(FIELDS).to_a
+      Problem.where(query).only(FIELDS).to_a
     end
 
     respond_to do |format|

--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -10,7 +10,7 @@ class Api::V3::NoticesController < ApplicationController
   def create
     response.headers['Access-Control-Allow-Origin'] = '*'
     response.headers['Access-Control-Allow-Headers'] = 'origin, content-type, accept'
-    return render(status: :ok, text: '') if request.method == 'OPTIONS'
+    return render(status: :ok, body: '') if request.method == 'OPTIONS'
 
     merged_params = params.merge!(JSON.parse(request.raw_post) || {})
     # merge makes a copy, merge! edits in place
@@ -18,8 +18,8 @@ class Api::V3::NoticesController < ApplicationController
     merged_params = merged_params.merge!('key' => authorization_token) if authorization_token
     report = AirbrakeApi::V3::NoticeParser.new(merged_params).report
 
-    return render text: UNKNOWN_API_KEY, status: :unprocessable_entity unless report.valid?
-    return render text: VERSION_TOO_OLD, status: :unprocessable_entity unless report.should_keep?
+    return render body: UNKNOWN_API_KEY, status: :unprocessable_entity unless report.valid?
+    return render body: VERSION_TOO_OLD, status: :unprocessable_entity unless report.should_keep?
 
     report.generate_notice!
     render status: :created, json: {
@@ -27,7 +27,7 @@ class Api::V3::NoticesController < ApplicationController
       url: report.problem.url
     }
   rescue AirbrakeApi::ParamsError
-    render text: 'Invalid request', status: :bad_request
+    render body: 'Invalid request', status: :bad_request
   end
 
 private

--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -12,11 +12,11 @@ class Api::V3::NoticesController < ApplicationController
     response.headers['Access-Control-Allow-Headers'] = 'origin, content-type, accept'
     return render(status: :ok, body: '') if request.method == 'OPTIONS'
 
-    if request.raw_post.present?
-      merged_params = params.merge!(JSON.parse(request.raw_post))
-    else
-      merged_params = params
-    end
+    merged_params = if request.raw_post.present?
+                      params.merge!(JSON.parse(request.raw_post))
+                    else
+                      params
+                    end
 
     # merge makes a copy, merge! edits in place
     merged_params = merged_params.merge!('key' => request.headers['X-Airbrake-Token']) if request.headers['X-Airbrake-Token']

--- a/app/controllers/api/v3/notices_controller.rb
+++ b/app/controllers/api/v3/notices_controller.rb
@@ -12,7 +12,12 @@ class Api::V3::NoticesController < ApplicationController
     response.headers['Access-Control-Allow-Headers'] = 'origin, content-type, accept'
     return render(status: :ok, body: '') if request.method == 'OPTIONS'
 
-    merged_params = params.merge!(JSON.parse(request.raw_post) || {})
+    if request.raw_post.present?
+      merged_params = params.merge!(JSON.parse(request.raw_post))
+    else
+      merged_params = params
+    end
+
     # merge makes a copy, merge! edits in place
     merged_params = merged_params.merge!('key' => request.headers['X-Airbrake-Token']) if request.headers['X-Airbrake-Token']
     merged_params = merged_params.merge!('key' => authorization_token) if authorization_token

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,8 +5,6 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   before_action :set_time_zone
 
-  rescue_from ActionController::RedirectBackError, with: :redirect_to_root
-
 private
 
   ##
@@ -16,11 +14,8 @@ private
     return if user_signed_in? && current_user.admin?
 
     flash[:error] = "Sorry, you don't have permission to do that"
-    redirect_to_root
-  end
 
-  def redirect_to_root
-    redirect_to(root_path)
+    redirect_to root_path
   end
 
   def set_time_zone

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -64,7 +64,7 @@ class AppsController < ApplicationController
   def update
     process_fingerprinter_choice
     initialize_subclassed_notification_service
-    app.update_attributes(app_params)
+    app.update(app_params)
 
     if app.save
       redirect_to app_url(app), flash: { success: I18n.t('controllers.apps.flash.update.success') }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,9 +4,9 @@ class CommentsController < ApplicationController
   expose :comment
 
   def create
-    if comment.valid?
-      problem.comments << comment
-      problem.save
+    problem.comments << comment
+
+    if problem.save
       flash[:success] = "Comment saved!"
     else
       flash[:error] = "I'm sorry, your comment was blank! Try again?"

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -19,7 +19,7 @@ class HealthController < ActionController::Base
     all_ok = check_results.all? do |check|
       check[:ok]
     end
-    response_status = all_ok ? :ok : :error
+    response_status = all_ok ? :ok : :internal_server_error
     render json: { ok: all_ok, details: check_results }, status: response_status
   end
 

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -18,13 +18,13 @@ class NoticesController < ApplicationController
         end
         render xml: api_xml
       else
-        render text: "Notice for old app version ignored"
+        render body: "Notice for old app version ignored"
       end
     else
-      render text: "Your API key is unknown", status: :unprocessable_entity
+      render body: "Your API key is unknown", status: :unprocessable_entity
     end
   rescue Nokogiri::XML::SyntaxError
-    render text: 'The provided XML was not well-formed', status: :unprocessable_entity
+    render body: 'The provided XML was not well-formed', status: :unprocessable_entity
   end
 
   # Redirects a notice to the problem page. Useful when using User Information at Airbrake gem.
@@ -51,6 +51,6 @@ private
   end
 
   def bad_params(exception)
-    render text: exception.message, status: :bad_request
+    render body: exception.message, status: :bad_request
   end
 end

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -95,6 +95,8 @@ class ProblemsController < ApplicationController
     problem.resolve!
     flash[:success] = t('.the_error_has_been_resolved')
     redirect_to :back
+
+    # TODO: remove this
   rescue ActionController::RedirectBackError
     redirect_to app_path(app)
   end
@@ -140,10 +142,10 @@ class ProblemsController < ApplicationController
 
   def destroy_all
     DestroyProblemsByAppJob.perform_later(app.id)
+
     flash[:success] = "#{I18n.t(:n_errs, count: app.problems.count)} #{I18n.t('n_errs.will_be_deleted')}."
-    redirect_to :back
-  rescue ActionController::RedirectBackError
-    redirect_to app_path(app)
+
+    redirect_to edit_app_path(app)
   end
 
   def search

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -88,56 +88,60 @@ class ProblemsController < ApplicationController
 
   def unlink_issue
     problem.update_attribute :issue_link, nil
+
     redirect_to app_problem_path(app, problem)
   end
 
   def resolve
     problem.resolve!
-    flash[:success] = t('.the_error_has_been_resolved')
-    redirect_to :back
 
-    # TODO: remove this
-  rescue ActionController::RedirectBackError
-    redirect_to app_path(app)
+    flash[:success] = t('.the_error_has_been_resolved')
+
+    redirect_back fallback_location: root_path
   end
 
   def resolve_several
     selected_problems.each(&:resolve!)
+
     flash[:success] = "Great news everyone! #{I18n.t(:n_errs_have, count: selected_problems.count)} #{I18n.t('n_errs_have.been_resolved')}."
-    redirect_to :back
+
+    redirect_back fallback_location: root_path
   end
 
   def unresolve_several
     selected_problems.each(&:unresolve!)
+
     flash[:success] = "#{I18n.t(:n_errs_have, count: selected_problems.count)} #{I18n.t('n_errs_have.been_unresolved')}."
-    redirect_to :back
+
+    redirect_back fallback_location: root_path
   end
 
-  ##
-  # Action to merge several Problem in One problem
-  #
-  # @param [ Array<String> ] :problems the list of problem ids
-  #
   def merge_several
     if selected_problems.length < 2
       flash[:notice] = I18n.t('controllers.problems.flash.need_two_errors_merge')
     else
       ProblemMerge.new(selected_problems).merge
+
       flash[:notice] = I18n.t('controllers.problems.flash.merge_several.success', nb: selected_problems.count)
     end
-    redirect_to :back
+
+    redirect_back fallback_location: root_path
   end
 
   def unmerge_several
     all = selected_problems.flat_map(&:unmerge!)
+
     flash[:success] = "#{I18n.t(:n_errs_have, count: all.length)} #{I18n.t('n_errs_have.been_unmerged')}."
-    redirect_to :back
+
+    redirect_back fallback_location: root_path
   end
 
   def destroy_several
     DestroyProblemsByIdJob.perform_later(selected_problems_ids)
+
     flash[:notice] = "#{I18n.t(:n_errs, count: selected_problems.size)} #{I18n.t('n_errs.will_be_deleted')}."
-    redirect_to :back
+
+    redirect_back fallback_location: root_path
   end
 
   def destroy_all
@@ -145,7 +149,7 @@ class ProblemsController < ApplicationController
 
     flash[:success] = "#{I18n.t(:n_errs, count: app.problems.count)} #{I18n.t('n_errs.will_be_deleted')}."
 
-    redirect_to edit_app_path(app)
+    redirect_back fallback_location: root_path
   end
 
   def search
@@ -157,13 +161,11 @@ class ProblemsController < ApplicationController
 
 private
 
-  ##
-  # Redirect :back if no errors selected
-  #
   def need_selected_problem
     return if err_ids.any?
 
     flash[:notice] = I18n.t('controllers.problems.flash.no_select_problem')
-    redirect_to :back
+
+    redirect_back fallback_location: root_path
   end
 end

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -87,7 +87,7 @@ class ProblemsController < ApplicationController
   end
 
   def unlink_issue
-    problem.update_attribute :issue_link, nil
+    problem.update_attribute(:issue_link, nil)
 
     redirect_to app_problem_path(app, problem)
   end

--- a/app/controllers/site_config_controller.rb
+++ b/app/controllers/site_config_controller.rb
@@ -6,8 +6,8 @@ class SiteConfigController < ApplicationController
   end
 
   def update
-    SiteConfig.document
-      .update(notice_fingerprinter: filtered_update_params.to_h)
+    SiteConfig.document.
+      update(notice_fingerprinter: filtered_update_params.to_h)
 
     flash[:success] = 'Updated site config'
 
@@ -17,9 +17,9 @@ class SiteConfigController < ApplicationController
 private
 
   def filtered_update_params
-    params.require(:site_config)
-      .require(:notice_fingerprinter_attributes)
-      .permit(:error_class, :message, :backtrace_lines, :component, :action,
-        :environment_name)
+    params.require(:site_config).
+      require(:notice_fingerprinter_attributes).
+      permit(:error_class, :message, :backtrace_lines, :component, :action,
+             :environment_name)
   end
 end

--- a/app/controllers/site_config_controller.rb
+++ b/app/controllers/site_config_controller.rb
@@ -17,9 +17,15 @@ class SiteConfigController < ApplicationController
 private
 
   def filtered_update_params
-    params.require(:site_config).
+    params.
+      require(:site_config).
       require(:notice_fingerprinter_attributes).
-      permit(:error_class, :message, :backtrace_lines, :component, :action,
-             :environment_name)
+      permit(
+        :error_class,
+        :message,
+        :backtrace_lines,
+        :component,
+        :action,
+        :environment_name)
   end
 end

--- a/app/controllers/site_config_controller.rb
+++ b/app/controllers/site_config_controller.rb
@@ -6,24 +6,20 @@ class SiteConfigController < ApplicationController
   end
 
   def update
-    SiteConfig.document.update_attributes(
-      notice_fingerprinter: filtered_update_params)
+    SiteConfig.document
+      .update(notice_fingerprinter: filtered_update_params.to_h)
+
     flash[:success] = 'Updated site config'
+
     redirect_to action: :index
   end
 
 private
 
   def filtered_update_params
-    params.
-      require(:site_config).
-      require(:notice_fingerprinter_attributes).
-      permit(
-        :error_class,
-        :message,
-        :backtrace_lines,
-        :component,
-        :action,
+    params.require(:site_config)
+      .require(:notice_fingerprinter_attributes)
+      .permit(:error_class, :message, :backtrace_lines, :component, :action,
         :environment_name)
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -92,7 +92,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 private
 
   def update_user_with_github_attributes(user, login, token)
-    user.update_attributes(
+    user.update(
       github_login:       login,
       github_oauth_token: token
     )

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,8 +21,9 @@ class UsersController < ApplicationController
   end
 
   def update
-    if user.update_attributes(user_params)
+    if user.update(user_params)
       flash[:success] = I18n.t('controllers.users.flash.update.success', name: user.name)
+
       redirect_to user_path(user)
     else
       render :edit
@@ -45,12 +46,14 @@ class UsersController < ApplicationController
   end
 
   def unlink_github
-    user.update_attributes github_login: nil, github_oauth_token: nil
+    user.update(github_login: nil, github_oauth_token: nil)
+
     redirect_to user_path(user)
   end
 
   def unlink_google
     user.update(google_uid: nil)
+
     redirect_to user_path(user)
   end
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -52,7 +52,7 @@ class Issue
     return false if errors.present?
 
     url = issue_tracker.create_issue(title, body, user: user.as_document)
-    problem.update_attributes(issue_link: url, issue_type: tracker.class.label)
+    problem.update(issue_link: url, issue_type: tracker.class.label)
 
     errors.empty?
   rescue => ex

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -1,6 +1,8 @@
 require 'recurse'
 
 class Notice
+  include ActiveModel::Serializers::Xml
+
   UNAVAILABLE = 'N/A'
 
   # Mongo will not accept index keys larger than 1,024 bytes and that includes

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -205,11 +205,11 @@ class Problem
   end
 
   def resolve!
-    self.update_attributes!(resolved: true, resolved_at: Time.zone.now)
+    self.update!(resolved: true, resolved_at: Time.zone.now)
   end
 
   def unresolve!
-    self.update_attributes!(resolved: false, resolved_at: nil)
+    self.update!(resolved: false, resolved_at: nil)
   end
 
   def unresolved?

--- a/app/models/site_config.rb
+++ b/app/models/site_config.rb
@@ -23,8 +23,7 @@ class SiteConfig
       f = app.notice_fingerprinter
       next if f.source && f.source != CONFIG_SOURCE_SITE
 
-      app.update_attributes(
-        notice_fingerprinter: notice_fingerprinter_attributes)
+      app.update(notice_fingerprinter: notice_fingerprinter_attributes)
     end
   end
 

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -5,7 +5,7 @@ class Watcher
   field :email
 
   embedded_in :app, inverse_of: :watchers
-  belongs_to :user
+  belongs_to :user, optional: true
 
   validate :ensure_user_or_email
 

--- a/autotest/discover.rb
+++ b/autotest/discover.rb
@@ -1,2 +1,0 @@
-Autotest.add_discovery { "rails" }
-Autotest.add_discovery { "rspec2" }

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-APP_PATH = File.expand_path('../../config/application', __FILE__)
+APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require_relative 'config/environment'
+
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require File.expand_path('../boot', __FILE__)
+require_relative 'boot'
 
 require 'action_controller/railtie'
 require 'action_mailer/railtie'

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module Errbit
 
     config.before_initialize do
       config.secret_key_base = Errbit::Config.secret_key_base
-      config.serve_static_files = Errbit::Config.serve_static_assets
+      config.public_file_server.enabled = Errbit::Config.serve_static_assets
     end
 
     initializer 'errbit.mongoid', before: 'mongoid.load-config' do

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,22 +1,3 @@
-require 'rubygems'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-detected_ruby_version = Gem::Version.new(RUBY_VERSION.dup)
-required_ruby_version = Gem::Version.new('2.1.0') # minimum supported version
-
-if detected_ruby_version < required_ruby_version
-  fail "RUBY_VERSION must be at least #{required_ruby_version}, " \
-       "detected RUBY_VERSION #{RUBY_VERSION}"
-end
-
-# Set up gems listed in the Gemfile.
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
-
-require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
-require 'json'
-
-begin
-  # try to use Yajl, the json_gem compatibility layer must be loaded after json
-  require 'yajl/json_gem'
-rescue LoadError
-  warn "JSON: unable to load Yajl; just using the json gem"
-end
+require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require File.expand_path('../application', __FILE__)
+require_relative 'application'
 
 # Load up Errbit::Config with values from the environment
 require Rails.root.join('config/load')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # Enable/disable caching. By default caching is disabled.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
+  if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,12 +9,27 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # Show full error reports.
+  config.consider_all_requests_local = true
+
+  # Enable/disable caching. By default caching is disabled.
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.action_controller.perform_caching = true
+
+    config.cache_store = :memory_store
+    config.public_file_server.headers = {
+      'Cache-Control' => 'public, max-age=172800'
+    }
+  else
+    config.action_controller.perform_caching = false
+
+    config.cache_store = :null_store
+  end
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -27,11 +42,13 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = false
+  # Suppress logger output for asset requests.
+  config.assets.quiet = true
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Use an evented file watcher to asynchronously detect changes in source code,
+  # routes, locales, etc. This feature depends on the listen gem.
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,9 +34,6 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
-  # Raise an error on page load if there are pending migrations.
-  # config.active_record.migration_error = :page_load
-
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
@@ -50,5 +47,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,6 +14,10 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
@@ -76,7 +80,4 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
-
-  # Do not dump schema after migrations.
-  # config.active_record.dump_schema_after_migration = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,29 +21,37 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Generate digests for assets URLs.
-  config.assets.digest = true
-
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
-  # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = "http://assets.example.com"
 
-  # Set to :debug to see everything in the log.
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+  # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
-
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = "http://assets.example.com"
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "errbit_#{Rails.env}"
+  config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
@@ -56,11 +64,18 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Disable automatic flushing of the log to improve performance.
-  # config.autoflush_log = false
-
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,9 +12,11 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
-  # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_files = true
-  config.static_cache_control = 'public, max-age=3600'
+  # Configure public file server for tests with Cache-Control for performance.
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=3600'
+  }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
@@ -25,6 +27,7 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
+  config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/config/initializers/application_controller_renderer.rb
+++ b/config/initializers/application_controller_renderer.rb
@@ -1,0 +1,8 @@
+# Be sure to restart your server when you modify this file.
+
+# ActiveSupport::Reloader.to_prepare do
+#   ApplicationController.renderer.defaults.merge!(
+#     http_host: 'example.org',
+#     https: false
+#   )
+# end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,6 +3,9 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
+# Add additional assets to the asset load path
+# Rails.application.config.assets.paths << Emoji.images_path
+
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+# Specify a serializer for the signed and encrypted cookie jars.
+# Valid options are :json, :marshal, and :hybrid.
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -1,0 +1,25 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file contains migration options to ease your Rails 5.0 upgrade.
+#
+# Once upgraded flip defaults one by one to migrate to the new default.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+
+Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
+
+# Enable per-form CSRF tokens. Previous versions had false.
+Rails.application.config.action_controller.per_form_csrf_tokens = false
+
+# Enable origin-checking CSRF mitigation. Previous versions had false.
+Rails.application.config.action_controller.forgery_protection_origin_check = false
+
+# Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
+# Previous versions had false.
+ActiveSupport.to_time_preserves_timezone = false
+
+# Require `belongs_to` associations by default. Previous versions had false.
+# Rails.application.config.active_record.belongs_to_required_by_default = false
+
+# Do not halt callback chains when a callback returns false. Previous versions had true.
+ActiveSupport.halt_callback_chains_on_return_false = true

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -2,24 +2,22 @@
 #
 # This file contains migration options to ease your Rails 5.0 upgrade.
 #
-# Once upgraded flip defaults one by one to migrate to the new default.
-#
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
 Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
 
 # Enable per-form CSRF tokens. Previous versions had false.
-Rails.application.config.action_controller.per_form_csrf_tokens = false
+Rails.application.config.action_controller.per_form_csrf_tokens = true
 
 # Enable origin-checking CSRF mitigation. Previous versions had false.
-Rails.application.config.action_controller.forgery_protection_origin_check = false
+Rails.application.config.action_controller.forgery_protection_origin_check = true
 
 # Make Ruby 2.4 preserve the timezone of the receiver when calling `to_time`.
 # Previous versions had false.
-ActiveSupport.to_time_preserves_timezone = false
-
-# Require `belongs_to` associations by default. Previous versions had false.
-# Rails.application.config.active_record.belongs_to_required_by_default = false
+ActiveSupport.to_time_preserves_timezone = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true
+ActiveSupport.halt_callback_chains_on_return_false = false
+
+# Configure SSL options to enable HSTS with subdomains. Previous versions had false.
+Rails.application.config.ssl_options = { hsts: { subdomains: true } }

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,8 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_errbit_session'
-
-# Use the database for sessions instead of the cookie-based default,
-# which shouldn't be used to store highly confidential information
-# (create the session table with "rake db:sessions:create")
-# Rails.application.config.session_store :active_record_store

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -5,10 +5,10 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json] if respond_to?(:wrap_parameters)
+  wrap_parameters format: [:json]
 end
 
 # To enable root element in JSON for ActiveRecord objects.
 # ActiveSupport.on_load(:active_record) do
-#  self.include_root_in_json = true
+#   self.include_root_in_json = true
 # end

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -7,8 +7,3 @@
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json]
 end
-
-# To enable root element in JSON for ActiveRecord objects.
-# ActiveSupport.on_load(:active_record) do
-#   self.include_root_in_json = true
-# end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,23 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
 
 en:
   flash:

--- a/lib/airbrake_api/v3/notice_parser.rb
+++ b/lib/airbrake_api/v3/notice_parser.rb
@@ -5,8 +5,8 @@ module AirbrakeApi
 
       attr_reader :params, :error
 
-      def initialize(params)
-        @params = params.to_unsafe_h || {}
+      def initialize(params = {})
+        @params = params.is_a?(ActionController::Parameters) ? params.to_unsafe_h : params
       end
 
       def attributes

--- a/lib/airbrake_api/v3/notice_parser.rb
+++ b/lib/airbrake_api/v3/notice_parser.rb
@@ -6,7 +6,7 @@ module AirbrakeApi
       attr_reader :params, :error
 
       def initialize(params)
-        @params = params || {}
+        @params = params.to_unsafe_h || {}
       end
 
       def attributes

--- a/public/404.html
+++ b/public/404.html
@@ -2,25 +2,66 @@
 <html>
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-    div.dialog {
-      width: 25em;
-      padding: 0 4em;
-      margin: 4em auto 0 auto;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
-    }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
   </style>
 </head>
 
-<body>
+<body class="rails-default-error-page">
   <!-- This file lives in public/404.html -->
   <div class="dialog">
-    <h1>The page you were looking for doesn't exist.</h1>
-    <p>You may have mistyped the address or the page may have moved.</p>
+    <div>
+      <h1>The page you were looking for doesn't exist.</h1>
+      <p>You may have mistyped the address or the page may have moved.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
   </div>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -2,25 +2,66 @@
 <html>
 <head>
   <title>The change you wanted was rejected (422)</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-    div.dialog {
-      width: 25em;
-      padding: 0 4em;
-      margin: 4em auto 0 auto;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
-    }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
   </style>
 </head>
 
-<body>
+<body class="rails-default-error-page">
   <!-- This file lives in public/422.html -->
   <div class="dialog">
-    <h1>The change you wanted was rejected.</h1>
-    <p>Maybe you tried to change something you didn't have access to.</p>
+    <div>
+      <h1>The change you wanted was rejected.</h1>
+      <p>Maybe you tried to change something you didn't have access to.</p>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
   </div>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -2,25 +2,65 @@
 <html>
 <head>
   <title>We're sorry, but something went wrong (500)</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-    div.dialog {
-      width: 25em;
-      padding: 0 4em;
-      margin: 4em auto 0 auto;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
-    }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  .rails-default-error-page {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+    margin: 0;
+  }
+
+  .rails-default-error-page div.dialog {
+    width: 95%;
+    max-width: 33em;
+    margin: 4em auto 0;
+  }
+
+  .rails-default-error-page div.dialog > div {
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 12% 0;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+
+  .rails-default-error-page h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  .rails-default-error-page div.dialog > p {
+    margin: 0 0 1em;
+    padding: 1em;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
+  }
   </style>
 </head>
 
-<body>
+<body class="rails-default-error-page">
   <!-- This file lives in public/500.html -->
   <div class="dialog">
-    <h1>We're sorry, but something went wrong.</h1>
-    <p>We've been notified about this issue and we'll take a look at it shortly.</p>
+    <div>
+      <h1>We're sorry, but something went wrong.</h1>
+    </div>
+    <p>If you are the application owner check the logs for more information.</p>
   </div>
 </body>
 </html>

--- a/spec/controllers/api/v1/notices_controller_spec.rb
+++ b/spec/controllers/api/v1/notices_controller_spec.rb
@@ -13,23 +13,23 @@ describe Api::V1::NoticesController, type: 'controller' do
       end
 
       it "should return JSON if JSON is requested" do
-        get :index, auth_token: @user.authentication_token, format: "json"
+        get :index, params: { auth_token: @user.authentication_token, format: "json" }
         expect { JSON.load(response.body) }.not_to raise_error # JSON::ParserError)
       end
 
       it "should return XML if XML is requested" do
-        get :index, auth_token: @user.authentication_token, format: "xml"
+        get :index, params: { auth_token: @user.authentication_token, format: "xml" }
         expect(Nokogiri::XML(response.body).errors).to be_empty
       end
 
       it "should return JSON by default" do
-        get :index, auth_token: @user.authentication_token
+        get :index, params: { auth_token: @user.authentication_token }
         expect { JSON.load(response.body) }.not_to raise_error # JSON::ParserError)
       end
 
       describe "given a date range" do
         it "should return only the notices created during the date range" do
-          get :index, auth_token: @user.authentication_token, start_date: "2012-08-01", end_date: "2012-08-27"
+          get :index, params: { auth_token: @user.authentication_token, start_date: "2012-08-01", end_date: "2012-08-27" }
           expect(response).to be_success
           notices = JSON.load response.body
           expect(notices.length).to eq 3
@@ -37,7 +37,7 @@ describe Api::V1::NoticesController, type: 'controller' do
       end
 
       it "should return all notices" do
-        get :index, auth_token: @user.authentication_token
+        get :index, params: { auth_token: @user.authentication_token }
         expect(response).to be_success
         notices = JSON.load response.body
         expect(notices.length).to eq 4

--- a/spec/controllers/api/v1/problems_controller_spec.rb
+++ b/spec/controllers/api/v1/problems_controller_spec.rb
@@ -12,29 +12,29 @@ describe Api::V1::ProblemsController, type: 'controller' do
       end
 
       it "should return JSON if JSON is requested" do
-        get :show, auth_token: @user.authentication_token, format: "json", id: Problem.first.id
+        get :show, params: { auth_token: @user.authentication_token, format: "json", id: Problem.first.id }
         expect { JSON.load(response.body) }.not_to raise_error # JSON::ParserError
       end
 
       it "should return XML if XML is requested" do
-        get :index, auth_token: @user.authentication_token, format: "xml", id: @problem.id
+        get :index, params: { auth_token: @user.authentication_token, format: "xml", id: @problem.id }
         expect(Nokogiri::XML(response.body).errors).to be_empty
       end
 
       it "should return JSON by default" do
-        get :show, auth_token: @user.authentication_token, id: @problem.id
+        get :show, params: { auth_token: @user.authentication_token, id: @problem.id }
         expect { JSON.load(response.body) }.not_to raise_error # JSON::ParserError)
       end
 
       it "should return the correct problem" do
-        get :show, auth_token: @user.authentication_token, format: "json", id: @problem.id
+        get :show, params: { auth_token: @user.authentication_token, format: "json", id: @problem.id }
 
         returned_problem = JSON.parse(response.body)
         expect(returned_problem["_id"]).to eq(@problem.id.to_s)
       end
 
       it "should return only the correct fields" do
-        get :show, auth_token: @user.authentication_token, format: "json", id: @problem.id
+        get :show, params: { auth_token: @user.authentication_token, format: "json", id: @problem.id }
         returned_problem = JSON.parse(response.body)
 
         expect(returned_problem.keys).to match_array(%w(
@@ -52,7 +52,7 @@ describe Api::V1::ProblemsController, type: 'controller' do
       end
 
       it "returns a 404 if the problem cannot be found" do
-        get :show, auth_token: @user.authentication_token, format: "json", id: 'IdontExist'
+        get :show, params: { auth_token: @user.authentication_token, format: "json", id: 'IdontExist' }
         expect(response.status).to eq(404)
       end
     end
@@ -66,23 +66,23 @@ describe Api::V1::ProblemsController, type: 'controller' do
       end
 
       it "should return JSON if JSON is requested" do
-        get :index, auth_token: @user.authentication_token, format: "json"
+        get :index, params: { auth_token: @user.authentication_token, format: "json" }
         expect { JSON.load(response.body) }.not_to raise_error # JSON::ParserError)
       end
 
       it "should return XML if XML is requested" do
-        get :index, auth_token: @user.authentication_token, format: "xml"
+        get :index, params: { auth_token: @user.authentication_token, format: "xml" }
         expect(Nokogiri::XML(response.body).errors).to be_empty
       end
 
       it "should return JSON by default" do
-        get :index, auth_token: @user.authentication_token
+        get :index, params: { auth_token: @user.authentication_token }
         expect { JSON.load(response.body) }.not_to raise_error # JSON::ParserError)
       end
 
       describe "given a date range" do
         it "should return only the problems open during the date range" do
-          get :index, auth_token: @user.authentication_token, start_date: "2012-08-20", end_date: "2012-08-27"
+          get :index, params: { auth_token: @user.authentication_token, start_date: "2012-08-20", end_date: "2012-08-27" }
           expect(response).to be_success
           problems = JSON.load response.body
           expect(problems.length).to eq 2
@@ -90,7 +90,7 @@ describe Api::V1::ProblemsController, type: 'controller' do
       end
 
       it "should return all problems" do
-        get :index, auth_token: @user.authentication_token
+        get :index, params: { auth_token: @user.authentication_token }
         expect(response).to be_success
         problems = JSON.load response.body
         expect(problems.length).to eq 4

--- a/spec/controllers/api/v3/notices_controller_spec.rb
+++ b/spec/controllers/api/v3/notices_controller_spec.rb
@@ -7,7 +7,7 @@ describe Api::V3::NoticesController, type: :controller do
   end
 
   it 'sets CORS headers on POST request' do
-    post :create, project_id: 'invalid id'
+    post :create, params: { project_id: 'invalid id' }
     expect(response.headers['Access-Control-Allow-Origin']).to eq('*')
     expect(response.headers['Access-Control-Allow-Headers']).to eq('origin, content-type, accept')
   end
@@ -19,7 +19,7 @@ describe Api::V3::NoticesController, type: :controller do
   end
 
   it 'returns created notice id in json format' do
-    post :create, legit_body, legit_params
+    post :create, body: legit_body, params: { **legit_params }
     notice = Notice.last
     expect(JSON.parse(response.body)).to eq(
       'id'  => notice.id.to_s,
@@ -28,32 +28,32 @@ describe Api::V3::NoticesController, type: :controller do
   end
 
   it 'responds with 201 created on success' do
-    post :create, legit_body, legit_params
+    post :create, body: legit_body, params: { **legit_params }
     expect(response.status).to be(201)
   end
 
   it 'responds with 201 created on success with token in Airbrake Token header' do
     request.headers['X-Airbrake-Token'] = project_id
-    post :create, legit_body, project_id: 123
+    post :create, body: legit_body, params: { project_id: 123 }
     expect(response.status).to be(201)
   end
 
   it 'responds with 201 created on success with token in Authorization header' do
     request.headers['Authorization'] = "Bearer #{project_id}"
-    post :create, legit_body, project_id: 123
+    post :create, body: legit_body, params: { project_id: 123 }
     expect(response.status).to be(201)
   end
 
   it 'responds with 422 when Authorization header is not valid' do
     request.headers['Authorization'] = "incorrect"
-    post :create, legit_body, project_id: 123
+    post :create, body: legit_body, params: { project_id: 123 }
     expect(response.status).to be(422)
   end
 
   it 'responds with 400 when request attributes are not valid' do
     allow_any_instance_of(AirbrakeApi::V3::NoticeParser).
       to receive(:report).and_raise(AirbrakeApi::ParamsError)
-    post :create, project_id: 'ID'
+    post :create, params: { project_id: 'ID' }
     expect(response.status).to eq(400)
     expect(response.body).to eq('Invalid request')
   end
@@ -61,12 +61,12 @@ describe Api::V3::NoticesController, type: :controller do
   it 'responds with 422 when notice comes from an old app' do
     app.current_app_version = '1.1.0'
     app.save!
-    post :create, legit_body, legit_params
+    post :create, body: legit_body, params: { **legit_params }
     expect(response.status).to eq(422)
   end
 
   it 'responds with 422 when project_id is invalid' do
-    post :create, legit_body, project_id: 'hm?', key: 'wha?'
+    post :create, body: legit_body, params: { project_id: 'hm?', key: 'wha?' }
 
     expect(response.status).to eq(422)
     expect(response.body).to eq('Your API key is unknown')
@@ -74,7 +74,7 @@ describe Api::V3::NoticesController, type: :controller do
 
   it 'ignores notices for older api' do
     app = Fabricate(:app, current_app_version: '2.0')
-    post :create, legit_body, project_id: app.api_key, key: app.api_key
+    post :create, body: legit_body, params: { project_id: app.api_key, key: app.api_key }
     expect(response.body).to eq('Notice for old app version ignored')
     expect(Notice.count).to eq(0)
   end

--- a/spec/controllers/api/v3/notices_controller_spec.rb
+++ b/spec/controllers/api/v3/notices_controller_spec.rb
@@ -13,7 +13,7 @@ describe Api::V3::NoticesController, type: :controller do
   end
 
   it 'responds to an OPTIONS request' do
-    process :create, 'OPTIONS', project_id: 'nothingspecial'
+    process :create, method: 'OPTIONS', params: { project_id: 'nothingspecial' }
     expect(response.headers['Access-Control-Allow-Origin']).to eq('*')
     expect(response.headers['Access-Control-Allow-Headers']).to eq('origin, content-type, accept')
   end

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -310,11 +310,18 @@ describe AppsController, type: 'controller' do
 
       context "selecting 'use site fingerprinter'" do
         before(:each) do
-          SiteConfig.document.update_attributes(notice_fingerprinter: notice_fingerprinter)
-          put :update, params: { id: @app.id, app: {
-            notice_fingerprinter_attributes: { backtrace_lines: 42 },
-            use_site_fingerprinter:          '1'
-          } }
+          SiteConfig.document.update!(notice_fingerprinter: notice_fingerprinter)
+
+          put :update, params: {
+            id: @app.id,
+            app: {
+              notice_fingerprinter_attributes: {
+                backtrace_lines: 42
+              },
+              use_site_fingerprinter: '1'
+            }
+          }
+
           @app.reload
         end
 

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -313,12 +313,12 @@ describe AppsController, type: 'controller' do
           SiteConfig.document.update!(notice_fingerprinter: notice_fingerprinter)
 
           put :update, params: {
-            id: @app.id,
+            id:  @app.id,
             app: {
               notice_fingerprinter_attributes: {
                 backtrace_lines: 42
               },
-              use_site_fingerprinter: '1'
+              use_site_fingerprinter:          '1'
             }
           }
 

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -61,17 +61,17 @@ describe AppsController, type: 'controller' do
       end
 
       it 'finds the app' do
-        get :show, id: app.id
+        get :show, params: { id: app.id }
         expect(controller.app).to eq app
       end
 
       it "should not raise errors for app with err without notices" do
         err
-        expect { get :show, id: app.id }.to_not raise_error
+        expect { get :show, params: { id: app.id } }.to_not raise_error
       end
 
       it "should list atom feed successfully" do
-        get :show, id: app.id, format: "atom"
+        get :show, params: { id: app.id, format: "atom" }
         expect(response).to be_success
       end
 
@@ -80,7 +80,7 @@ describe AppsController, type: 'controller' do
         Fabricate(:user, name: "Alice")
         Fabricate(:user, name: "Betty")
 
-        get :show, id: app.id
+        get :show, params: { id: app.id }
 
         expect(controller.users.to_a).to eq(User.all.to_a.sort_by(&:name))
       end
@@ -91,13 +91,13 @@ describe AppsController, type: 'controller' do
         end
 
         it "should have default per_page value for user" do
-          get :show, id: app.id
+          get :show, params: { id: app.id }
           expect(controller.problems.to_a.size).to eq User::PER_PAGE
         end
 
         it "should be able to override default per_page value" do
           admin.update_attribute :per_page, 10
-          get :show, id: app.id
+          get :show, params: { id: app.id }
           expect(controller.problems.to_a.size).to eq 10
         end
       end
@@ -109,14 +109,14 @@ describe AppsController, type: 'controller' do
 
         context 'and no params' do
           it 'shows only unresolved problems' do
-            get :show, id: app.id
+            get :show, params: { id: app.id }
             expect(controller.problems.size).to eq 1
           end
         end
 
         context 'and all_problems=true params' do
           it 'shows all errors' do
-            get :show, id: app.id, all_errs: true
+            get :show, params: { id: app.id, all_errs: true }
             expect(controller.problems.size).to eq 2
           end
         end
@@ -132,35 +132,35 @@ describe AppsController, type: 'controller' do
 
         context 'no params' do
           it 'shows errs for all environments' do
-            get :show, id: app.id
+            get :show, params: { id: app.id }
             expect(controller.problems.size).to eq 20
           end
         end
 
         context 'environment production' do
           it 'shows errs for just production' do
-            get :show, id: app.id, environment: 'production'
+            get :show, params: { id: app.id, environment: 'production' }
             expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment staging' do
           it 'shows errs for just staging' do
-            get :show, id: app.id, environment: 'staging'
+            get :show, params: { id: app.id, environment: 'staging' }
             expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment development' do
           it 'shows errs for just development' do
-            get :show, id: app.id, environment: 'development'
+            get :show, params: { id: app.id, environment: 'development' }
             expect(controller.problems.size).to eq 5
           end
         end
 
         context 'environment test' do
           it 'shows errs for just test' do
-            get :show, id: app.id, environment: 'test'
+            get :show, params: { id: app.id, environment: 'test' }
             expect(controller.problems.size).to eq 5
           end
         end
@@ -172,7 +172,7 @@ describe AppsController, type: 'controller' do
         sign_in Fabricate(:user)
         app = Fabricate(:app)
 
-        get :show, id: app.id
+        get :show, params: { id: app.id }
         expect(controller.app).to eq app
       end
     end
@@ -194,7 +194,7 @@ describe AppsController, type: 'controller' do
       it "should copy attributes from an existing app" do
         @app = Fabricate(:app, name:        "do not copy",
                                github_repo: "test/example")
-        get :new, copy_attributes_from: @app.id
+        get :new, params: { copy_attributes_from: @app.id }
         expect(controller.app).to be_a(App)
         expect(controller.app).to be_new_record
         expect(controller.app.name).to be_blank
@@ -205,7 +205,7 @@ describe AppsController, type: 'controller' do
     describe "GET /apps/:id/edit" do
       it 'finds the correct app' do
         app = Fabricate(:app)
-        get :edit, id: app.id
+        get :edit, params: { id: app.id }
         expect(controller.app).to eq app
       end
     end
@@ -222,12 +222,12 @@ describe AppsController, type: 'controller' do
         end
 
         it "should redirect to the app page" do
-          post :create, app: app_params
+          post :create, params: { app: app_params }
           expect(response).to redirect_to(app_path(@app))
         end
 
         it "should display a message" do
-          post :create, app: app_params
+          post :create, params: { app: app_params }
           expect(request.flash[:success]).to match(/success/)
         end
       end
@@ -240,12 +240,12 @@ describe AppsController, type: 'controller' do
 
       context "when the update is successful" do
         it "should redirect to the app page" do
-          put :update, id: @app.id, app: app_params
+          put :update, params: { id: @app.id, app: app_params }
           expect(response).to redirect_to(app_path(@app))
         end
 
         it "should display a message" do
-          put :update, id: @app.id, app: app_params
+          put :update, params: { id: @app.id, app: app_params }
           expect(request.flash[:success]).to match(/success/)
         end
       end
@@ -253,14 +253,14 @@ describe AppsController, type: 'controller' do
       context "changing name" do
         it "should redirect to app page" do
           id = @app.id
-          put :update, id: id, app: { name: "new name" }
+          put :update, params: { id: id, app: { name: "new name" } }
           expect(response).to redirect_to(app_path(id))
         end
       end
 
       context "when the update is unsuccessful" do
         it "should render the edit page" do
-          put :update, id: @app.id, app: { name: '' }
+          put :update, params: { id: @app.id, app: { name: '' } }
           expect(response).to render_template(:edit)
         end
       end
@@ -272,7 +272,7 @@ describe AppsController, type: 'controller' do
         end
 
         it "should parse legal csv values" do
-          put :update, id: @app.id, app: { email_at_notices: '1,   4,      7,8,  10' }
+          put :update, params: { id: @app.id, app: { email_at_notices: '1,   4,      7,8,  10' } }
           @app.reload
           expect(@app.email_at_notices).to eq [1, 4, 7, 8, 10]
         end
@@ -280,24 +280,25 @@ describe AppsController, type: 'controller' do
         context "failed parsing of CSV" do
           it "should set the default value" do
             @app = Fabricate(:app, email_at_notices: [1, 2, 3, 4])
-            put :update, id: @app.id, app: { email_at_notices: 'asdf, -1,0,foobar,gd00,0,abc' }
+            put :update, params: { id: @app.id, app: { email_at_notices: 'asdf, -1,0,foobar,gd00,0,abc' } }
             @app.reload
             expect(@app.email_at_notices).to eq Errbit::Config.email_at_notices
           end
 
           it "should display a message" do
-            put :update, id: @app.id, app: { email_at_notices: 'qwertyuiop' }
+            put :update, params: { id: @app.id, app: { email_at_notices: 'qwertyuiop' } }
             expect(request.flash[:error]).to match(/Couldn't parse/)
           end
         end
       end
 
+      # TODO: what is `cur`?
       context "setting up issue tracker", cur: true do
         context "unknown tracker type" do
           before(:each) do
-            put :update, id: @app.id, app: { issue_tracker_attributes: {
+            put :update, params: { id: @app.id, app: { issue_tracker_attributes: {
               type_tracker: 'unknown', options: { project_id: '1234', api_token: '123123', account: 'myapp' }
-            } }
+            } } }
             @app.reload
           end
 
@@ -310,10 +311,10 @@ describe AppsController, type: 'controller' do
       context "selecting 'use site fingerprinter'" do
         before(:each) do
           SiteConfig.document.update_attributes(notice_fingerprinter: notice_fingerprinter)
-          put :update, id: @app.id, app: {
+          put :update, params: { id: @app.id, app: {
             notice_fingerprinter_attributes: { backtrace_lines: 42 },
             use_site_fingerprinter:          '1'
-          }
+          } }
           @app.reload
         end
 
@@ -327,10 +328,10 @@ describe AppsController, type: 'controller' do
       context "not selecting 'use site fingerprinter'" do
         before(:each) do
           SiteConfig.document.update_attributes(notice_fingerprinter: notice_fingerprinter)
-          put :update, id: @app.id, app: {
+          put :update, params: { id: @app.id, app: {
             notice_fingerprinter_attributes: { backtrace_lines: 42 },
             use_site_fingerprinter:          '0'
-          }
+          } }
           @app.reload
         end
 
@@ -349,24 +350,24 @@ describe AppsController, type: 'controller' do
       end
 
       it "should find the app" do
-        delete :destroy, id: @app.id
+        delete :destroy, params: { id: @app.id }
         expect(controller.app).to eq @app
       end
 
       it "should destroy the app" do
-        delete :destroy, id: @app.id
+        delete :destroy, params: { id: @app.id }
         expect do
           @app.reload
         end.to raise_error(Mongoid::Errors::DocumentNotFound)
       end
 
       it "should display a message" do
-        delete :destroy, id: @app.id
+        delete :destroy, params: { id: @app.id }
         expect(request.flash[:success]).to match(/success/)
       end
 
       it "should redirect to the apps page" do
-        delete :destroy, id: @app.id
+        delete :destroy, params: { id: @app.id }
         expect(response).to redirect_to(apps_path)
       end
     end
@@ -379,7 +380,7 @@ describe AppsController, type: 'controller' do
       end
 
       it 'redirect to root with flash error' do
-        post :regenerate_api_key, id: 'foo'
+        post :regenerate_api_key, params: { id: 'foo' }
         expect(request).to redirect_to root_path
       end
     end
@@ -391,7 +392,7 @@ describe AppsController, type: 'controller' do
 
       it 'redirect_to app view' do
         expect do
-          post :regenerate_api_key, id: app.id
+          post :regenerate_api_key, params: { id: app.id }
           expect(request).to redirect_to edit_app_path(app)
         end.to change { app.reload.api_key }
       end
@@ -416,13 +417,13 @@ describe AppsController, type: 'controller' do
     end
 
     it "searches problems for given string" do
-      get :search, search: "\"Foo\""
+      get :search, params: { search: "\"Foo\"" }
       expect(controller.apps).to include(@app1)
       expect(controller.apps).to_not include(@app2)
     end
 
     it "works when given string is empty" do
-      get :search, search: ""
+      get :search, params: { search: "" }
       expect(controller.apps).to include(@app1)
       expect(controller.apps).to include(@app2)
     end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -14,8 +14,8 @@ describe CommentsController, type: 'controller' do
       let(:user) { Fabricate(:user) }
 
       before(:each) do
-        post :create, app_id: problem.app.id, problem_id: problem.id,
-             comment: { body: "One test comment", user_id: user.id }
+        post :create, params: { app_id: problem.app.id, problem_id: problem.id,
+             comment: { body: "One test comment", user_id: user.id } }
         problem.reload
       end
 
@@ -41,7 +41,7 @@ describe CommentsController, type: 'controller' do
       let(:comment) { problem.reload.comments.first }
 
       before(:each) do
-        delete :destroy, app_id: problem.app.id, problem_id: problem.id, id: comment.id.to_s
+        delete :destroy, params: { app_id: problem.app.id, problem_id: problem.id, id: comment.id.to_s }
         problem.reload
       end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -15,10 +15,10 @@ describe CommentsController, type: 'controller' do
 
       before(:each) do
         post :create, params: {
-          app_id: problem.app.id,
+          app_id:     problem.app.id,
           problem_id: problem.id,
-          comment: {
-            body: "One test comment",
+          comment:    {
+            body:    "One test comment",
             user_id: user.id
           }
         }
@@ -48,9 +48,9 @@ describe CommentsController, type: 'controller' do
 
       before(:each) do
         delete :destroy, params: {
-          app_id: problem.app.id,
+          app_id:     problem.app.id,
           problem_id: problem.id,
-          id: comment.id.to_s
+          id:         comment.id.to_s
         }
         problem.reload
       end

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -14,13 +14,19 @@ describe CommentsController, type: 'controller' do
       let(:user) { Fabricate(:user) }
 
       before(:each) do
-        post :create, params: { app_id: problem.app.id, problem_id: problem.id,
-             comment: { body: "One test comment", user_id: user.id } }
+        post :create, params: {
+          app_id: problem.app.id,
+          problem_id: problem.id,
+          comment: {
+            body: "One test comment",
+            user_id: user.id
+          }
+        }
         problem.reload
       end
 
       it "should create the comment" do
-        expect(problem.comments.size).to eq 1
+        expect(problem.comments.size).to eq(1)
       end
 
       it "should redirect to problem page" do
@@ -41,7 +47,11 @@ describe CommentsController, type: 'controller' do
       let(:comment) { problem.reload.comments.first }
 
       before(:each) do
-        delete :destroy, params: { app_id: problem.app.id, problem_id: problem.id, id: comment.id.to_s }
+        delete :destroy, params: {
+          app_id: problem.app.id,
+          problem_id: problem.id,
+          id: comment.id.to_s
+        }
         problem.reload
       end
 

--- a/spec/controllers/devise_sessions_controller_spec.rb
+++ b/spec/controllers/devise_sessions_controller_spec.rb
@@ -10,12 +10,12 @@ describe Devise::SessionsController, type: 'controller' do
     let(:user) { Fabricate(:user) }
 
     it 'redirects to app index page if there are no apps for the user' do
-      post :create, user: { 'email' => user.email, 'password' => user.password }
+      post :create, params: { user: { 'email' => user.email, 'password' => user.password } }
       expect(response).to redirect_to(root_path)
     end
 
     it 'displays a friendly error when credentials are invalid' do
-      post :create, user: { 'email' => 'whatever', 'password' => 'somethinginvalid' }
+      post :create, params: { user: { 'email' => 'whatever', 'password' => 'somethinginvalid' } }
       expect(request.flash["alert"]).to eq(I18n.t 'devise.failure.user.email_invalid')
     end
   end

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -37,7 +37,7 @@ describe NoticesController, type: 'controller' do
       end
 
       it "generates a notice from xml in a data param [POST]" do
-        post :create, data: xml, format: :xml
+        post :create, params: { data: xml, format: :xml }
         expect(response).to be_success
         # Same RegExp from Airbrake::Sender#send_to_airbrake (https://github.com/airbrake/airbrake/blob/master/lib/airbrake/sender.rb#L53)
         # Inspired by https://github.com/airbrake/airbrake/blob/master/test/sender_test.rb
@@ -46,7 +46,7 @@ describe NoticesController, type: 'controller' do
       end
 
       it "generates a notice from xml [GET]" do
-        get :create, data: xml, format: :xml
+        get :create, params: { data: xml, format: :xml }
         expect(response).to be_success
         expect(response.body).to match(%r{<id[^>]*>#{notice.id}</id>})
         expect(response.body).to match(%r{<url[^>]*>(.+)#{locate_path(notice.id)}</url>})
@@ -54,7 +54,7 @@ describe NoticesController, type: 'controller' do
       context "with an invalid API_KEY" do
         let(:error_report) { double(valid?: false) }
         it 'return 422' do
-          post :create, format: :xml, data: xml
+          post :create, params: { format: :xml, data: xml }
           expect(response.status).to eq 422
         end
       end
@@ -79,7 +79,7 @@ describe NoticesController, type: 'controller' do
       it "should locate notice and redirect to problem" do
         problem = Fabricate(:problem, app: app, environment: "production")
         notice = Fabricate(:notice, err: Fabricate(:err, problem: problem))
-        get :locate, id: notice.id
+        get :locate, params: { id: notice.id }
         expect(response).to redirect_to(app_problem_path(problem.app, problem))
       end
     end
@@ -95,7 +95,7 @@ describe NoticesController, type: 'controller' do
       it "should locate notice and redirect to problem with notice_id" do
         problem = Fabricate(:problem, app: app, environment: "production")
         notice = Fabricate(:notice, err: Fabricate(:err, problem: problem))
-        get :show_by_id, id: notice.id
+        get :show_by_id, params: { id: notice.id }
         expect(response).to redirect_to(app_problem_path(problem.app, problem, notice_id: notice.id))
       end
     end

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -9,8 +9,7 @@ describe NoticesController, type: 'controller' do
   context 'notices API' do
     context "with bogus xml" do
       it "returns an error" do
-        expect(request).to receive(:raw_post).and_return('<r><b>notxml</r>')
-        post :create, format: :xml
+        post :create, body: '<r><b>notxml</r>', format: :xml
         expect(response.status).to eq(422)
         expect(response.body).to eq('The provided XML was not well-formed')
       end
@@ -23,8 +22,7 @@ describe NoticesController, type: 'controller' do
 
       context "with xml pass in raw_port" do
         before do
-          expect(request).to receive(:raw_post).and_return(xml)
-          post :create, format: :xml
+          post :create, body: xml, format: :xml
         end
 
         it "generates a notice from raw xml [POST]" do

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -223,6 +223,7 @@ describe ProblemsController, type: 'controller' do
     end
 
     it "should redirect to the app page" do
+      request.env["HTTP_REFERER"] = app_path(@err.app)
       put :resolve, params: { app_id: @err.app.id, id: @err.problem.id }
       expect(response).to redirect_to(app_path(@err.app))
     end

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -49,28 +49,28 @@ describe ProblemsController, type: 'controller' do
 
       context 'environment production' do
         it 'shows problems for just production' do
-          get :index, environment: 'production'
+          get :index, params: { environment: 'production' }
           expect(controller.problems.size).to eq 6
         end
       end
 
       context 'environment staging' do
         it 'shows problems for just staging' do
-          get :index, environment: 'staging'
+          get :index, params: { environment: 'staging' }
           expect(controller.problems.size).to eq 5
         end
       end
 
       context 'environment development' do
         it 'shows problems for just development' do
-          get :index, environment: 'development'
+          get :index, params: { environment: 'development' }
           expect(controller.problems.size).to eq 5
         end
       end
 
       context 'environment test' do
         it 'shows problems for just test' do
-          get :index, environment: 'test'
+          get :index, params: { environment: 'test' }
           expect(controller.problems.size).to eq 5
         end
       end
@@ -86,7 +86,7 @@ describe ProblemsController, type: 'controller' do
       expect(Problem).to receive(:ordered_by).and_return(
         double('proxy', page: double('other_proxy', per: problems))
       )
-      get :index, all_errs: true
+      get :index, params: { all_errs: true }
       expect(controller.problems).to eq problems
     end
   end
@@ -110,13 +110,13 @@ describe ProblemsController, type: 'controller' do
     end
 
     it "searches problems for given string" do
-      get :search, search: "\"Most important\""
+      get :search, params: { search: "\"Most important\"" }
       expect(controller.problems).to include(@problem1)
       expect(controller.problems).to_not include(@problem2)
     end
 
     it "works when given string is empty" do
-      get :search, search: ""
+      get :search, params: { search: "" }
       expect(controller.problems).to include(@problem1)
       expect(controller.problems).to include(@problem2)
     end
@@ -132,7 +132,7 @@ describe ProblemsController, type: 'controller' do
     end
 
     it "should redirect to the standard problems page" do
-      get :show_by_id, id: err.problem.id
+      get :show_by_id, params: { id: err.problem.id }
       expect(response).to redirect_to(app_problem_path(app, err.problem.id))
     end
   end
@@ -143,17 +143,17 @@ describe ProblemsController, type: 'controller' do
     end
 
     it "finds the app" do
-      get :show, app_id: app.id, id: err.problem.id
+      get :show, params: { app_id: app.id, id: err.problem.id }
       expect(controller.app).to eq app
     end
 
     it "finds the problem" do
-      get :show, app_id: app.id, id: err.problem.id
+      get :show, params: { app_id: app.id, id: err.problem.id }
       expect(controller.problem).to eq err.problem
     end
 
     it "successfully render page" do
-      get :show, app_id: app.id, id: err.problem.id
+      get :show, params: { app_id: app.id, id: err.problem.id }
       expect(response).to be_success
     end
 
@@ -162,7 +162,7 @@ describe ProblemsController, type: 'controller' do
 
       it "successfully renders the view even when there are no notices attached to the problem" do
         expect(err.problem.notices).to be_empty
-        get :show, app_id: app.id, id: err.problem.id
+        get :show, params: { app_id: app.id, id: err.problem.id }
         expect(response).to be_success
       end
     end
@@ -175,13 +175,13 @@ describe ProblemsController, type: 'controller' do
       end
 
       it "paginates the notices 1 at a time, starting with the most recent" do
-        get :show, app_id: app.id, id: err.problem.id
+        get :show, params: { app_id: app.id, id: err.problem.id }
         expect(assigns(:notices).entries.count).to eq 1
         expect(assigns(:notices)).to include(notices.last)
       end
 
       it "paginates the notices 1 at a time, based on then notice param" do
-        get :show, app_id: app.id, id: err.problem.id, notice: 3
+        get :show, params: { app_id: app.id, id: err.problem.id, notice: 3 }
         expect(assigns(:notices).entries.count).to eq 1
         expect(assigns(:notices)).to include(notices.first)
       end
@@ -194,7 +194,7 @@ describe ProblemsController, type: 'controller' do
     end
 
     it "renders without error" do
-      get :xhr_sparkline, app_id: app.id, id: err.problem.id
+      get :xhr_sparkline, params: { app_id: app.id, id: err.problem.id }
       expect(response).to be_success
     end
   end
@@ -207,29 +207,29 @@ describe ProblemsController, type: 'controller' do
     end
 
     it 'finds the app and the problem' do
-      put :resolve, app_id: @err.app.id, id: @err.problem.id
+      put :resolve, params: { app_id: @err.app.id, id: @err.problem.id }
       expect(controller.app).to eq @err.app
       expect(controller.problem).to eq @err.problem
     end
 
     it "should resolve the issue" do
-      put :resolve, app_id: @err.app.id, id: @err.problem.id
+      put :resolve, params: { app_id: @err.app.id, id: @err.problem.id }
       expect(@err.problem.reload.resolved).to be(true)
     end
 
     it "should display a message" do
-      put :resolve, app_id: @err.app.id, id: @err.problem.id
+      put :resolve, params: { app_id: @err.app.id, id: @err.problem.id }
       expect(request.flash[:success]).to match(/Great news/)
     end
 
     it "should redirect to the app page" do
-      put :resolve, app_id: @err.app.id, id: @err.problem.id
+      put :resolve, params: { app_id: @err.app.id, id: @err.problem.id }
       expect(response).to redirect_to(app_path(@err.app))
     end
 
     it "should redirect back to problems page" do
       request.env["HTTP_REFERER"] = problems_path
-      put :resolve, app_id: @err.app.id, id: @err.problem.id
+      put :resolve, params: { app_id: @err.app.id, id: @err.problem.id }
       expect(response).to redirect_to(problems_path)
     end
   end
@@ -253,25 +253,25 @@ describe ProblemsController, type: 'controller' do
       end
 
       it "should redirect to problem page" do
-        post :create_issue, app_id: problem.app.id, id: problem.id
+        post :create_issue, params: { app_id: problem.app.id, id: problem.id }
         expect(response).to redirect_to(app_problem_path(problem.app, problem))
         expect(flash[:error]).to be_blank
       end
 
       it "should save the right title" do
-        post :create_issue, app_id: problem.app.id, id: problem.id
+        post :create_issue, params: { app_id: problem.app.id, id: problem.id }
         title = "[#{problem.environment}][#{problem.where}] #{problem.message.to_s.truncate(100)}"
         line = issue_tracker.tracker.output.shift
         expect(line[0]).to eq(title)
       end
 
       it "should renders the issue body" do
-        post :create_issue, app_id: problem.app.id, id: problem.id, format: 'html'
+        post :create_issue, params: { app_id: problem.app.id, id: problem.id, format: 'html' }
         expect(response).to render_template("issue_trackers/issue")
       end
 
       it "should update the problem" do
-        post :create_issue, app_id: problem.app.id, id: problem.id
+        post :create_issue, params: { app_id: problem.app.id, id: problem.id }
         expect(problem.issue_link).to eq("http://example.com/mock-errbit")
         expect(problem.issue_type).to eq("mock")
       end
@@ -280,7 +280,7 @@ describe ProblemsController, type: 'controller' do
         render_views
 
         it "should save the right body" do
-          post :create_issue, app_id: problem.app.id, id: problem.id, format: 'html'
+          post :create_issue, params: { app_id: problem.app.id, id: problem.id, format: 'html' }
           line = issue_tracker.tracker.output.shift
           expect(line[1]).to include(app_problem_url problem.app, problem)
         end
@@ -288,7 +288,7 @@ describe ProblemsController, type: 'controller' do
         it "should render whatever the issue tracker says" do
           allow_any_instance_of(Issue).to receive(:render_body_args).and_return(
             [{ inline: 'one <%= problem.id %> two' }])
-          post :create_issue, app_id: problem.app.id, id: problem.id, format: 'html'
+          post :create_issue, params: { app_id: problem.app.id, id: problem.id, format: 'html' }
           line = issue_tracker.tracker.output.shift
           expect(line[1]).to eq("one #{problem.id} two")
         end
@@ -297,7 +297,7 @@ describe ProblemsController, type: 'controller' do
 
     context "when app has no issue tracker" do
       it "should redirect to problem page" do
-        post :create_issue, app_id: problem.app.id, id: problem.id
+        post :create_issue, params: { app_id: problem.app.id, id: problem.id }
         expect(response).to redirect_to(app_problem_path(problem.app, problem))
         expect(flash[:error]).to eql "This app has no issue tracker"
       end
@@ -323,7 +323,7 @@ describe ProblemsController, type: 'controller' do
       end
 
       it "should redirect to problem page" do
-        post :close_issue, app_id: problem.app.id, id: problem.id
+        post :close_issue, params: { app_id: problem.app.id, id: problem.id }
         expect(response).to redirect_to(app_problem_path(problem.app, problem))
         expect(flash[:error]).to be_blank
       end
@@ -331,7 +331,7 @@ describe ProblemsController, type: 'controller' do
 
     context "when app has no issue tracker" do
       it "should redirect to problem page" do
-        post :close_issue, app_id: problem.app.id, id: problem.id
+        post :close_issue, params: { app_id: problem.app.id, id: problem.id }
         expect(response).to redirect_to(app_problem_path(problem.app, problem))
         expect(flash[:error]).to eql "This app has no issue tracker"
       end
@@ -347,7 +347,7 @@ describe ProblemsController, type: 'controller' do
       let(:err) { Fabricate(:err, problem: Fabricate(:problem, issue_link: "http://some.host")) }
 
       before(:each) do
-        delete :unlink_issue, app_id: err.app.id, id: err.problem.id
+        delete :unlink_issue, params: { app_id: err.app.id, id: err.problem.id }
         err.problem.reload
       end
 
@@ -364,7 +364,7 @@ describe ProblemsController, type: 'controller' do
       let(:err) { Fabricate :err }
 
       before(:each) do
-        delete :unlink_issue, app_id: err.app.id, id: err.problem.id
+        delete :unlink_issue, params: { app_id: err.app.id, id: err.problem.id }
         err.problem.reload
       end
 
@@ -383,19 +383,19 @@ describe ProblemsController, type: 'controller' do
 
     context "POST /problems/merge_several" do
       it "should require at least two problems" do
-        post :merge_several, problems: [@problem1.id.to_s]
+        post :merge_several, params: { problems: [@problem1.id.to_s] }
         expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.need_two_errors_merge')
       end
 
       it "should merge the problems" do
         expect(ProblemMerge).to receive(:new).and_return(double(merge: true))
-        post :merge_several, problems: [@problem1.id.to_s, @problem2.id.to_s]
+        post :merge_several, params: { problems: [@problem1.id.to_s, @problem2.id.to_s] }
       end
     end
 
     context "POST /problems/unmerge_several" do
       it "should require at least one problem" do
-        post :unmerge_several, problems: []
+        post :unmerge_several, params: { problems: [] }
         expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.no_select_problem')
       end
 
@@ -403,7 +403,7 @@ describe ProblemsController, type: 'controller' do
         merged_problem = Problem.merge!(@problem1, @problem2)
         expect(merged_problem.errs.length).to eq 2
         expect do
-          post :unmerge_several, problems: [merged_problem.id.to_s]
+          post :unmerge_several, params: { problems: [merged_problem.id.to_s] }
           expect(merged_problem.reload.errs.length).to eq 1
         end.to change(Problem, :count).by(1)
       end
@@ -411,22 +411,22 @@ describe ProblemsController, type: 'controller' do
 
     context "POST /problems/resolve_several" do
       it "should require at least one problem" do
-        post :resolve_several, problems: []
+        post :resolve_several, params: { problems: [] }
         expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.no_select_problem')
       end
 
       it "should resolve the issue" do
-        post :resolve_several, problems: [@problem2.id.to_s]
+        post :resolve_several, params: { problems: [@problem2.id.to_s] }
         expect(@problem2.reload.resolved?).to eq true
       end
 
       it "should display a message about 1 err" do
-        post :resolve_several, problems: [@problem2.id.to_s]
+        post :resolve_several, params: { problems: [@problem2.id.to_s] }
         expect(flash[:success]).to match(/1 error has been resolved/)
       end
 
       it "should display a message about 2 errs" do
-        post :resolve_several, problems: [@problem1.id.to_s, @problem2.id.to_s]
+        post :resolve_several, params: { problems: [@problem1.id.to_s, @problem2.id.to_s] }
         expect(flash[:success]).to match(/2 errors have been resolved/)
         expect(controller.selected_problems).to eq [@problem1, @problem2]
       end
@@ -434,12 +434,12 @@ describe ProblemsController, type: 'controller' do
 
     context "POST /problems/unresolve_several" do
       it "should require at least one problem" do
-        post :unresolve_several, problems: []
+        post :unresolve_several, params: { problems: [] }
         expect(request.flash[:notice]).to eql I18n.t('controllers.problems.flash.no_select_problem')
       end
 
       it "should unresolve the issue" do
-        post :unresolve_several, problems: [@problem1.id.to_s]
+        post :unresolve_several, params: { problems: [@problem1.id.to_s] }
         expect(@problem1.reload.resolved?).to eq false
       end
     end
@@ -447,7 +447,7 @@ describe ProblemsController, type: 'controller' do
     context "POST /problems/destroy_several" do
       it "should delete the problems" do
         expect do
-          post :destroy_several, problems: [@problem1.id.to_s]
+          post :destroy_several, params: { problems: [@problem1.id.to_s] }
         end.to change(Problem, :count).by(-1)
       end
     end
@@ -462,19 +462,19 @@ describe ProblemsController, type: 'controller' do
 
       it "destroys all problems" do
         expect do
-          post :destroy_all, app_id: @app.id
+          post :destroy_all, params: { app_id: @app.id }
         end.to change(Problem, :count).by(-2)
         expect(controller.app).to eq @app
       end
 
       it "should display a message" do
-        put :destroy_all, app_id: @app.id
+        put :destroy_all, params: { app_id: @app.id }
         expect(request.flash[:success]).to match(/be deleted/)
       end
 
       it "should redirect back to the app page" do
         request.env["HTTP_REFERER"] = edit_app_path(@app)
-        put :destroy_all, app_id: @app.id
+        put :destroy_all, params: { app_id: @app.id }
         expect(response).to redirect_to(edit_app_path(@app))
       end
     end

--- a/spec/controllers/site_config_controller_spec.rb
+++ b/spec/controllers/site_config_controller_spec.rb
@@ -16,10 +16,12 @@ describe SiteConfigController, type: 'controller' do
 
   describe '#update' do
     it 'updates' do
-      put :update, site_config: {
-        notice_fingerprinter_attributes: {
-          backtrace_lines:  3,
-          environment_name: false
+      put :update, params: {
+        site_config: {
+          notice_fingerprinter_attributes: {
+            backtrace_lines:  3,
+            environment_name: false
+          }
         }
       }
 
@@ -30,26 +32,36 @@ describe SiteConfigController, type: 'controller' do
     end
 
     it 'redirects to the index' do
-      put :update, site_config: {
-        notice_fingerprinter_attributes: { error_class: true }
+      put :update, params: {
+        site_config: {
+          notice_fingerprinter_attributes: {
+            error_class: true
+          }
+        }
       }
 
       expect(response).to redirect_to(site_config_index_path)
     end
 
     it 'flashes a confirmation' do
-      put :update, site_config: {
-        notice_fingerprinter_attributes: { error_class: true }
+      put :update, params: {
+        site_config: {
+          notice_fingerprinter_attributes: {
+            error_class: true
+          }
+        }
       }
 
       expect(request.flash[:success]).to eq 'Updated site config'
     end
 
     it 'updates apps that are using site wide notice fingerprinter' do
-      put :update, site_config: {
-        notice_fingerprinter_attributes: {
-          backtrace_lines:  10,
-          environment_name: false
+      put :update, params: {
+        site_config: {
+          notice_fingerprinter_attributes: {
+            backtrace_lines:  10,
+            environment_name: false
+          }
         }
       }
       app = App.new(name: 'my_app')
@@ -57,10 +69,12 @@ describe SiteConfigController, type: 'controller' do
       expect(app.notice_fingerprinter.backtrace_lines).to be 10
       expect(app.notice_fingerprinter.environment_name).to be false
 
-      put :update, site_config: {
-        notice_fingerprinter_attributes: {
-          backtrace_lines:  11,
-          environment_name: true
+      put :update, params: {
+        site_config: {
+          notice_fingerprinter_attributes: {
+            backtrace_lines:  11,
+            environment_name: true
+          }
         }
       }
       app.reload

--- a/spec/controllers/site_config_controller_spec.rb
+++ b/spec/controllers/site_config_controller_spec.rb
@@ -27,8 +27,8 @@ describe SiteConfigController, type: 'controller' do
 
       fingerprinter = SiteConfig.document.notice_fingerprinter
 
-      expect(fingerprinter.environment_name).to be false
-      expect(fingerprinter.backtrace_lines).to be 3
+      expect(fingerprinter.environment_name).to eq(false)
+      expect(fingerprinter.backtrace_lines).to eq(3)
     end
 
     it 'redirects to the index' do
@@ -64,10 +64,12 @@ describe SiteConfigController, type: 'controller' do
           }
         }
       }
+
       app = App.new(name: 'my_app')
       app.save
-      expect(app.notice_fingerprinter.backtrace_lines).to be 10
-      expect(app.notice_fingerprinter.environment_name).to be false
+
+      expect(app.notice_fingerprinter.backtrace_lines).to eq(10)
+      expect(app.notice_fingerprinter.environment_name).to eq(false)
 
       put :update, params: {
         site_config: {
@@ -77,9 +79,11 @@ describe SiteConfigController, type: 'controller' do
           }
         }
       }
+
       app.reload
-      expect(app.notice_fingerprinter.backtrace_lines).to be 11
-      expect(app.notice_fingerprinter.environment_name).to be true
+
+      expect(app.notice_fingerprinter.backtrace_lines).to eq(11)
+      expect(app.notice_fingerprinter.environment_name).to eq(true)
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -23,14 +23,14 @@ describe UsersController, type: 'controller' do
 
     context "GET /users/:other_id/edit" do
       it "redirects to the home page" do
-        get :edit, id: other_user.id
+        get :edit, params: { id: other_user.id }
         expect(response).to redirect_to(root_path)
       end
     end
 
     context "GET /users/:my_id/edit" do
       it 'finds the user' do
-        get :edit, id: user.id
+        get :edit, params: { id: user.id }
         expect(controller.user).to eq(user)
         expect(response).to render_template 'edit'
       end
@@ -38,7 +38,7 @@ describe UsersController, type: 'controller' do
 
     context "PUT /users/:other_id" do
       it "redirects to the home page" do
-        put :update, id: other_user.id
+        put :update, params: { id: other_user.id }
         expect(response).to redirect_to(root_path)
       end
     end
@@ -46,47 +46,47 @@ describe UsersController, type: 'controller' do
     context "PUT /users/:my_id/id" do
       context "when the update is successful" do
         it "sets a message to display" do
-          put :update, id: user.to_param, user: { name: 'Kermit' }
+          put :update, params: { id: user.to_param, user: { name: 'Kermit' } }
           expect(request.flash[:success]).to include('updated')
         end
 
         it "redirects to the user's page" do
-          put :update, id: user.to_param, user: { name: 'Kermit' }
+          put :update, params: { id: user.to_param, user: { name: 'Kermit' } }
           expect(response).to redirect_to(user_path(user))
         end
 
         it "should not be able to become an admin" do
           expect do
-            put :update, id: user.to_param, user: { admin: true }
+            put :update, params: { id: user.to_param, user: { admin: true } }
           end.to_not change {
             user.reload.admin
           }.from(false)
         end
 
         it "should be able to set per_page option" do
-          put :update, id: user.to_param, user: { per_page: 555 }
+          put :update, params: { id: user.to_param, user: { per_page: 555 } }
           expect(user.reload.per_page).to eq 555
         end
 
         it "should be able to set time_zone option" do
-          put :update, id: user.to_param, user: { time_zone: "Warsaw" }
+          put :update, params: { id: user.to_param, user: { time_zone: "Warsaw" } }
           expect(user.reload.time_zone).to eq "Warsaw"
         end
 
         it "should be able to not set github_login option" do
-          put :update, id: user.to_param, user: { github_login: " " }
+          put :update, params: { id: user.to_param, user: { github_login: " " } }
           expect(user.reload.github_login).to eq nil
         end
 
         it "should be able to set github_login option" do
-          put :update, id: user.to_param, user: { github_login: "awesome_name" }
+          put :update, params: { id: user.to_param, user: { github_login: "awesome_name" } }
           expect(user.reload.github_login).to eq "awesome_name"
         end
       end
 
       context "when the update is unsuccessful" do
         it "renders the edit page" do
-          put :update, id: user.to_param, user: { name: nil }
+          put :update, params: { id: user.to_param, user: { name: nil } }
           expect(response).to render_template(:edit)
         end
       end
@@ -109,7 +109,7 @@ describe UsersController, type: 'controller' do
 
     context "GET /users/:id" do
       it 'finds the user' do
-        get :show, id: user.id
+        get :show, params: { id: user.id }
         expect(controller.user).to eq user
       end
     end
@@ -124,7 +124,7 @@ describe UsersController, type: 'controller' do
 
     context "GET /users/:id/edit" do
       it 'finds the user' do
-        get :edit, id: user.id
+        get :edit, params: { id: user.id }
         expect(controller.user).to eq user
       end
     end
@@ -134,24 +134,24 @@ describe UsersController, type: 'controller' do
         let(:attrs) { { user: Fabricate.to_params(:user) } }
 
         it "sets a message to display" do
-          post :create, attrs
+          post :create, params: { **attrs }
           expect(request.flash[:success]).to include('part of the team')
         end
 
         it "redirects to the user's page" do
-          post :create, attrs
+          post :create, params: { **attrs }
           expect(response).to redirect_to(user_path(controller.user))
         end
 
         it "should be able to create admin" do
           attrs[:user][:admin] = true
-          post :create, attrs
+          post :create, params: { **attrs }
           expect(response).to be_redirect
           expect(User.find(controller.user.to_param).admin).to be(true)
         end
 
         it "should has auth token" do
-          post :create, attrs
+          post :create, params: { **attrs }
           expect(User.last.authentication_token).to_not be_blank
         end
       end
@@ -160,13 +160,14 @@ describe UsersController, type: 'controller' do
         let(:user) do
           Struct.new(:admin, :attributes).new(true, {})
         end
+
         before do
           expect(User).to receive(:new).and_return(user)
           expect(user).to receive(:save).and_return(false)
         end
 
         it "renders the new page" do
-          post :create, user: { username: 'foo' }
+          post :create, params: { user: { username: 'foo' } }
           expect(response).to render_template(:new)
         end
       end
@@ -175,7 +176,7 @@ describe UsersController, type: 'controller' do
     context "PUT /users/:id" do
       context "when the update is successful" do
         before do
-          put :update, id: user.to_param, user: user_params
+          put :update, params: { id: user.to_param, user: user_params }
         end
 
         context "with normal params" do
@@ -188,7 +189,7 @@ describe UsersController, type: 'controller' do
       end
       context "when the update is unsuccessful" do
         it "renders the edit page" do
-          put :update, id: user.to_param, user: { name: nil }
+          put :update, params: { id: user.to_param, user: { name: nil } }
           expect(response).to render_template(:edit)
         end
       end
@@ -200,7 +201,7 @@ describe UsersController, type: 'controller' do
 
         before do
           expect(UserDestroy).to receive(:new).with(user).and_return(user_destroy)
-          delete :destroy, id: user.id
+          delete :destroy, params: { id: user.id }
         end
 
         it 'should destroy user' do
@@ -212,7 +213,7 @@ describe UsersController, type: 'controller' do
       context "with trying destroy himself" do
         before do
           expect(UserDestroy).to_not receive(:new)
-          delete :destroy, id: admin.id
+          delete :destroy, params: { id: admin.id }
         end
 
         it 'should not destroy user' do

--- a/spec/controllers/watchers_controller_spec.rb
+++ b/spec/controllers/watchers_controller_spec.rb
@@ -15,7 +15,7 @@ describe WatchersController, type: 'controller' do
       let(:watcher) { app.watchers.first }
 
       before(:each) do
-        delete :destroy, app_id: app.id, id: watcher.user.id.to_s
+        delete :destroy, params: { app_id: app.id, id: watcher.user.id.to_s }
         problem.reload
       end
 
@@ -34,7 +34,7 @@ describe WatchersController, type: 'controller' do
 
     context "successful watcher update" do
       before(:each) do
-        put :update, app_id: app.id, id: user.id.to_s
+        put :update, params: { app_id: app.id, id: user.id.to_s }
         problem.reload
       end
 

--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -229,8 +229,12 @@ describe ErrorReport do
   context "with notification service configured" do
     before do
       app.notify_on_errs = true
-      app.watchers.build(email: 'foo@example.com')
       app.save
+      watcher = app.watchers.build(email: 'foo@example.com')
+      watcher.save
+      # TODO: uncomment with new mongoid 6.2.x or later
+      # app.watchers.build(email: 'foo@example.com')
+      # app.save
     end
 
     it 'send email' do

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -129,7 +129,7 @@ describe Problem, type: 'model' do
       ## update_attributes not test #valid? but #errors.any?
       # https://github.com/mongoid/mongoid/blob/master/lib/mongoid/persistence.rb#L137
       er = ActiveModel::Errors.new(problem)
-      er.add_on_blank(:resolved)
+      er.add(:resolved, :blank)
       allow(problem).to receive(:errors).and_return(er)
       expect(problem).to_not be_valid
       expect do

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -1,4 +1,4 @@
-describe "Health", type: 'request' do
+describe HealthController, type: 'request' do
   let(:errbit_app) { Fabricate(:app, api_key: 'APIKEY') }
 
   describe "readiness" do

--- a/spec/requests/notices_controller_spec.rb
+++ b/spec/requests/notices_controller_spec.rb
@@ -6,7 +6,7 @@ describe "Notices management", type: 'request' do
       let(:xml) { Rails.root.join('spec', 'fixtures', 'hoptoad_test_notice.xml').read }
       it 'save a new notice' do
         expect do
-          post '/notifier_api/v2/notices', data: xml
+          post '/notifier_api/v2/notices', params: { data: xml }
           expect(response).to be_success
         end.to change {
           errbit_app.problems.count
@@ -18,7 +18,7 @@ describe "Notices management", type: 'request' do
       let(:xml) { Rails.root.join('spec', 'fixtures', 'hoptoad_test_notice_without_line_of_backtrace.xml').read }
       it 'save a new notice' do
         expect do
-          post '/notifier_api/v2/notices', data: xml
+          post '/notifier_api/v2/notices', params: { data: xml }
           expect(response).to be_success
         end.to change {
           errbit_app.problems.count
@@ -31,7 +31,7 @@ describe "Notices management", type: 'request' do
       let(:xml) { Rails.root.join('spec', 'fixtures', 'hoptoad_test_notice.xml').read }
       it 'not save a new notice and return 422' do
         expect do
-          post '/notifier_api/v2/notices', data: xml
+          post '/notifier_api/v2/notices', params: { data: xml }
           expect(response.status).to eq 422
           expect(response.body).to eq "Your API key is unknown"
         end.to_not change(errbit_app.problems, :count)
@@ -42,7 +42,7 @@ describe "Notices management", type: 'request' do
       let(:xml) { Rails.root.join('spec', 'fixtures', 'hoptoad_test_notice.xml').read }
       it 'save a new notice' do
         expect do
-          get '/notifier_api/v2/notices', data: xml
+          get '/notifier_api/v2/notices', params: { data: xml }
           expect(response).to be_success
         end.to change {
           errbit_app.problems.count

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,29 +29,6 @@ require 'fabrication'
 require 'sucker_punch/testing/inline'
 require 'errbit_plugin/mock_issue_tracker'
 
-# a workaround to avoid MonitorMixin double-initialize error
-# https://github.com/rails/rails/issues/34790#issuecomment-681034561
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6.0')
-  if Gem::Version.new(Rails.version) < Gem::Version.new('5.0.0')
-    module ActionController
-      class TestResponse < ActionDispatch::TestResponse
-        def recycle!
-          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
-            @mon_data = nil
-            @mon_data_owner_object_id = nil
-          else
-            @mon_mutex = nil
-            @mon_mutex_owner_object_id = nil
-          end
-          initialize
-        end
-      end
-    end
-  else
-    warn "Monkeypatch for ActionController::TestResponse is no longer needed"
-  end
-end
-
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -20,7 +20,7 @@ def it_requires_authentication(options = {})
 
     options[:for].each do |action, method|
       it "#{method.to_s.upcase} #{action} redirects to the sign in page" do
-        send(method, action, options[:params])
+        send(method, action, params: { **options[:params] })
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -50,7 +50,7 @@ def it_requires_admin_privileges(options = {})
 
     options[:for].each do |action, method|
       it "#{method.to_s.upcase} #{action} redirects to the root path" do
-        send(method, action, options[:params])
+        send(method, action, params: { **options[:params] })
         expect(response).to redirect_to(root_path)
       end
     end

--- a/spec/views/problems/show.html.haml_spec.rb
+++ b/spec/views/problems/show.html.haml_spec.rb
@@ -88,7 +88,7 @@ describe "problems/show.html.haml", type: 'view' do
     it "should not confirm the 'resolve' link if configured not to" do
       allow(Errbit::Config).to receive(:confirm_err_actions).and_return(false)
       render
-      expect(action_bar).to have_selector('a.resolve[data-confirm="null"]')
+      expect(action_bar).not_to have_selector('a.resolve[data-confirm=""]')
     end
 
     it "should link 'up' to HTTP_REFERER if is set" do


### PR DESCRIPTION
Aloha!

Main change: Upgrade Ruby on Rails to 5.0

Changes:
1. Update rubygems to 3.3.19
2. Update bundler to 2.3.19
3. Add `activemodel-serializers-xml` gem. This functionality was removed from rails 5.0. We use it `.to_xml`.
4. `mongoid` was updated to `6.0.3`. This is latest version that works with rails 5.0.
5. `yajl-ruby` gem was removed without replacement. If we need more speed, we can look at `oj` gem and `ox` gem for xml parsing.
6. Add `rails-controller-testing` gem. Required by rspec.
7. `rails_12factor` gem removed without replacement. All functionality was merged in rails itself.
8. Some gems were updated. Commit by commit. Before rails upgrade.
9. `.with(consistency: :strong)` was removed. `mongoid` gem deprecate them and remove support. We can use replacement to read from main mongo db. Did we really need this?
10. Replace `render text:` with `render body:`.
11. Remove `ActionController::RedirectBackError`. This exception deprecated.
12. Replace `update_attributes` with just `update`. `update_attributes` is just long alias to `update`.
13. `redirect_to :back` was replaced with `redirect_back fallback_location: root_path`
14. `Watcher#user` should be explicitly marked as `optional`.
15. `autotest/discover.rb` was removed without replacement. I think, this is ancient relict.
16. Rails files was synced with rails 5.0.
17. Add empty `public/apple-touch-icon-precomposed.png` to reduce error logs.
18. Add empty `public/apple-touch-icon.png` to reduce error logs.
19. Fix rails deprecations with positional arguments in tests. Like: before `get :show, id: app.id` and after `get :show, params: { id: app.id }`.
20. Rails 5.0 more strict about status code. You can't use `:error`. You should exactly code like `:internal_server_error`.
21. Rails rename `serve_static_files` to `public_file_server.enabled`. I left env name `Errbit::Config.serve_static_assets`.
22. Rails configs were synced with rails defaults. With comments and other stuff inside.
23. Sync `public/404.html`, `public/422.html` and `public/500.html` with rails 5.0.
24. Remove monkey-patch from `spec/spec_helper.rb`
25. Fix deprecation in `add_on_blank(:resolved)`
26. Fix `spec/requests/health_controller_spec.rb`

Ok, it's time to talk about broken mongoid. [Link to issue](https://jira.mongodb.org/browse/MONGOID-4499). Test suite pass, so.

I left:
```
# TODO: uncomment with new mongoid 6.2.x or later
# app.watchers.build(email: 'foo@example.com')
# app.save
```

with rails 5.1 should work properly.

P.S.: Running test suite generates a lot of warnings. This is not good, but... We can fix them later. :)

P.S.2: I update Dockerfile. And build image [here](https://hub.docker.com/r/biow0lf/errbit).