### PR TITLE
Format comments

### DIFF
--- a/app/helpers/problems_helper.rb
+++ b/app/helpers/problems_helper.rb
@@ -3,6 +3,10 @@ module ProblemsHelper
     t(format('problems.confirm.%s', action)) unless Errbit::Config.confirm_err_actions.eql? false
   end
 
+  def auto_link_format(body)
+    Rinku.auto_link(simple_format(body), :all, 'target="_blank"')
+  end
+
   def gravatar_tag(email, options = {})
     return nil unless email.present?
 

--- a/app/helpers/problems_helper.rb
+++ b/app/helpers/problems_helper.rb
@@ -4,7 +4,7 @@ module ProblemsHelper
   end
 
   def auto_link_format(body)
-    Rinku.auto_link(simple_format(body), :all, 'target="_blank"')
+    Rinku.auto_link(simple_format(body), :all, 'target="_blank"').html_safe
   end
 
   def gravatar_tag(email, options = {})

--- a/app/helpers/problems_helper.rb
+++ b/app/helpers/problems_helper.rb
@@ -4,7 +4,7 @@ module ProblemsHelper
   end
 
   def auto_link_format(body)
-    Rinku.auto_link(simple_format(body), :all, 'target="_blank"').html_safe
+    Rinku.auto_link(simple_format(body), :all, 'target="_blank"')
   end
 
   def gravatar_tag(email, options = {})

--- a/app/helpers/problems_helper.rb
+++ b/app/helpers/problems_helper.rb
@@ -4,7 +4,11 @@ module ProblemsHelper
   end
 
   def auto_link_format(body)
-    Rinku.auto_link(simple_format(body), :all, 'target="_blank"')
+    sanitize(
+      Rinku.auto_link(simple_format(body), :all, 'target="_blank"').html_safe, # rubocop:disable Rails/OutputSafety
+      tags:       %w[a p],
+      attributes: %w[href target]
+    )
   end
 
   def gravatar_tag(email, options = {})

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -45,7 +45,7 @@
             %span.delete= link_to '&#10008;'.html_safe, [app, problem, comment], :method => :delete,
               :data => { :confirm => t("comments.confirm_delete") }, :class => "destroy-comment"
         %tr
-          %td= simple_format comment.body
+          %td= auto_link_format(comment.body)
   = form_for [app, problem, @comment] do |comment_form|
     %p= t('.add_a_comment')
     = comment_form.text_area :body

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -45,7 +45,7 @@
             %span.delete= link_to '&#10008;'.html_safe, [app, problem, comment], :method => :delete,
               :data => { :confirm => t("comments.confirm_delete") }, :class => "destroy-comment"
         %tr
-          %td= auto_link_format(comment.body).html_safe
+          %td= auto_link_format(comment.body)
   = form_for [app, problem, @comment] do |comment_form|
     %p= t('.add_a_comment')
     = comment_form.text_area :body

--- a/app/views/problems/show.html.haml
+++ b/app/views/problems/show.html.haml
@@ -45,7 +45,7 @@
             %span.delete= link_to '&#10008;'.html_safe, [app, problem, comment], :method => :delete,
               :data => { :confirm => t("comments.confirm_delete") }, :class => "destroy-comment"
         %tr
-          %td= auto_link_format(comment.body)
+          %td= auto_link_format(comment.body).html_safe
   = form_for [app, problem, @comment] do |comment_form|
     %p= t('.add_a_comment')
     = comment_form.text_area :body

--- a/spec/helpers/problems_helper_spec.rb
+++ b/spec/helpers/problems_helper_spec.rb
@@ -5,6 +5,10 @@ describe ProblemsHelper do
         helper.auto_link_format("Goto https://errbit.com/ and say hello to team@errbit.invalid")
       ).to eq "<p>Goto <a href=\"https://errbit.com/\" target=\"_blank\">https://errbit.com/</a> and say hello to <a href=\"mailto:team@errbit.invalid\" target=\"_blank\">team@errbit.invalid</a></p>"
     end
+
+    it 'sanitizes body of html tags' do
+      expect(helper.auto_link_format('Hello, <b>World!</b>')).to eq '<p>Hello, World!</p>'
+    end
   end
 
   describe "#gravatar_tag" do

--- a/spec/helpers/problems_helper_spec.rb
+++ b/spec/helpers/problems_helper_spec.rb
@@ -1,4 +1,12 @@
 describe ProblemsHelper do
+  describe "#auto_link_format" do
+    it 'handles links with target and wraps paragraph' do
+      expect(
+        helper.auto_link_format("Goto https://errbit.com/ and say hello to team@errbit.invalid")
+      ).to eq "<p>Goto <a href=\"https://errbit.com/\" target=\"_blank\">https://errbit.com/</a> and say hello to <a href=\"mailto:team@errbit.invalid\" target=\"_blank\">team@errbit.invalid</a></p>"
+    end
+  end
+
   describe "#gravatar_tag" do
     let(:email) { "gravatar@example.com" }
     let(:email_hash) { Digest::MD5.hexdigest email }


### PR DESCRIPTION
It always bothered me that pasting a URL into a comment wouldn't allow you to simply click it, instead you'd have to copy and paste it into your Search bar.