### PR TITLE
Handle strings in pretty_hash to prevent exceptions (NoMethodError: undefined method 'keys' for #<String>)

### DIFF
--- a/app/helpers/hash_helper.rb
+++ b/app/helpers/hash_helper.rb
@@ -1,6 +1,6 @@
 module HashHelper
   def pretty_hash(hash, nesting = 0)
-    return '{}' if hash.empty?
+    return '{}' if hash.empty? || hash.is_a?(String)
 
     tab_size = 2
     nesting += 1

--- a/spec/helpers/hash_helper_spec.rb
+++ b/spec/helpers/hash_helper_spec.rb
@@ -1,0 +1,30 @@
+describe HashHelper do
+  describe '.pretty_hash' do
+    let(:expected_pretty_hash) do
+      <<~HASH.chomp
+        {
+          "action" => "some_action",
+          "controller" => "some_controller"
+        }
+      HASH
+    end
+
+    it 'is expected to prettify hashes' do
+      expect(pretty_hash('controller' => 'some_controller', 'action' => 'some_action')).to eq expected_pretty_hash
+    end
+
+    it 'is expected to handle empty hashes' do
+      expect(pretty_hash({})).to eq '{}'
+    end
+
+    context 'with string, instead of hash' do
+      it 'is expected not to raise exception' do
+        expect { pretty_hash('This is a string.') }.not_to raise_exception
+      end
+
+      it 'is expected to handle strings' do
+        expect(pretty_hash('{ a_string: "But it looks like a hash"}')).to eq '{}'
+      end
+    end
+  end
+end


### PR DESCRIPTION
We are experiencing errors in `Self.Errbit` when trying to open some Problems.
After some digging, I found out that `notice.params` returned a String, instead of a hash.

![Problem](https://github.com/errbit/errbit/assets/39838608/bf7762a6-f485-4e44-9c1e-992a245a9a2f)
![Backtrace](https://github.com/errbit/errbit/assets/39838608/d602a00f-0c25-4f08-b10e-8fa646d99b9c)
