### PR TITLE
Fix typo in locale key

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,7 @@ en:
       parameters: Parameters
       session: Session
       ago_by: ago by
-      ago_by_unkown_user: ago by [Unkown User]
+      ago_by_unknown_user: ago by [Unkown User]
       first_notice: First Notice
       last_notice: Last Notice
       environment: Environment


### PR DESCRIPTION
I've noticed a missing locale, when trying to fix it, it was just a typo

<img width="957" alt="image" src="https://github.com/errbit/errbit/assets/39838608/5e578622-0880-4c52-820d-1e5328ec741c">
