### PR TITLE
CI: add Docker tag for Git commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: build-and-publish
+name: Build and Publish
 
 on:
   push:
@@ -11,29 +11,29 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ github.event.repository.owner.name }}/${{ github.event.repository.name }}
           tags: |
             type=raw,value=latest
-            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+            type=sha
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -5,26 +5,28 @@ make Docker deployment easy. You can pass all of [Errbit's
 configuration](/docs/configuration.md) to the Docker container using
 `docker run -e`.
 
-When running Errbit using `docker run` you must specify a MONGO_URL. If you're
+When running Errbit using `docker run` you must specify a `MONGO_URL`. If you're
 running in a production environment, you should also specify
-RACK_ENV=production and SECRET_KEY_BASE=some-secret-key.
+`RACK_ENV=production` and `SECRET_KEY_BASE=some-secret-key`.
 
 If you don't already have one, you can generate a suitable SECRET_KEY_BASE
 with:
+
 ```bash
 docker run --rm errbit/errbit bundle exec rake secret
 ```
 
 ## Which image version should I use?
 
-As of 2023, we are not releasing non-latest tags to docker hub (last release was v0.9.0 in 2020).
-Please use [errbit/errbit:latest](https://hub.docker.com/r/errbit/errbit/tags), which is updated on main builds.
-If you are interested in using official release tags of errbit, contributions to the CI process and shipping stable releases would be welcome.
+As of 2023, we are again releasing non-latest tags to Docker Hub (last release
+was v0.9.0 in 2020). Please use [errbit/errbit:latest](https://hub.docker.com/r/errbit/errbit/tags),
+which is updated on main builds.
 
 ## Standalone Errbit App
 
-Assuming you have a mongo host available, you can run errbit using `docker
+Assuming you have a Mongo host available, you can run Errbit using `docker
 run`, exposing its HTTP interface on port 8080:
+
 ```bash
 docker run \
   -e "RACK_ENV=production" \
@@ -48,7 +50,7 @@ docker run \
 
 ## Errbit + Dependencies via Docker Compose
 
-Docker compose can take care of starting up a mongo container along with the
+Docker compose can take care of starting up a Mongo container along with the
 Errbit application container and linking the two containers together:
 
 ```bash


### PR DESCRIPTION
Also update `{{version}}` to `{{major}}.{{minor}}.{{patch}}` (M.m.p) which is the same, but easier to identify as we also have M.m and M.

- Doc:   
  https://github.com/docker/metadata-action#typesha  
  https://github.com/docker/metadata-action#typesemver