### PR TITLE
fix: Skip COMPACT via clear_outdated if not allowed

### DIFF
--- a/app/interactors/outdated_problem_clearer.rb
+++ b/app/interactors/outdated_problem_clearer.rb
@@ -30,11 +30,9 @@ private
     collections.map(&:name).map do |collection|
       Mongoid.default_client.command compact: collection
     rescue Mongo::Error::OperationFailure => e
-      if e.message =~ /CMD_NOT_ALLOWED: compact/
-        next
-      else
-        raise e
-      end
+      next if /CMD_NOT_ALLOWED: compact/.match?(e.message)
+
+      raise e
     end
   end
 end

--- a/app/interactors/outdated_problem_clearer.rb
+++ b/app/interactors/outdated_problem_clearer.rb
@@ -29,6 +29,12 @@ private
     collections = Mongoid.default_client.collections
     collections.map(&:name).map do |collection|
       Mongoid.default_client.command compact: collection
+    rescue Mongo::Error::OperationFailure => e
+      if e.message =~ /CMD_NOT_ALLOWED: compact/
+        next
+      else
+        raise e
+      end
     end
   end
 end


### PR DESCRIPTION
Atlas' M0 tier does not allow execution of COMPACT command. Running this rake exits with the following error and aborting the whole deletion process. However, it can be skipped if operation is not allowed and outdated problems are still destroyed.

### Before

```bash
~ $ ERRBIT_PROBLEM_DESTROY_AFTER_DAYS=21 rake errbit:clear_outdated Overwriting existing field _id in class App.
rake aborted!
Mongo::Error::OperationFailure: [8000:AtlasError]: CMD_NOT_ALLOWED: compact (on errbit-shard-00-01.pf7i2.mongodb.net:27017) /app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/result.rb:364:in `raise_operation_failure'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/result.rb:330:in `validate!'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/response_handling.rb:36:in `block (3 levels) in validate_result'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/response_handling.rb:108:in `add_server_diagnostics'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/response_handling.rb:35:in `block (2 levels) in validate_result'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/response_handling.rb:54:in `add_error_labels'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/response_handling.rb:34:in `block in validate_result'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/response_handling.rb:94:in `unpin_maybe'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/response_handling.rb:33:in `validate_result'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/executable.rb:81:in `block in execute'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/executable.rb:80:in `tap'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/executable.rb:80:in `execute'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/polymorphic_operation.rb:50:in `execute_with_connection'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/polymorphic_operation.rb:36:in `block in execute'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/server/connection_pool.rb:667:in `with_connection'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/server.rb:448:in `with_connection'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/operation/shared/polymorphic_operation.rb:35:in `execute'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/database.rb:235:in `block in command'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/client.rb:1132:in `with_session'
/app/vendor/bundle/ruby/2.7.0/gems/mongo-2.18.1/lib/mongo/database.rb:226:in `command'
/app/app/interactors/outdated_problem_clearer.rb:31:in `block in compact_database'
/app/app/interactors/outdated_problem_clearer.rb:30:in `map' /app/app/interactors/outdated_problem_clearer.rb:30:in `compact_database'
/app/app/interactors/outdated_problem_clearer.rb:13:in `block in execute'
/app/app/interactors/outdated_problem_clearer.rb:8:in `tap' /app/app/interactors/outdated_problem_clearer.rb:8:in `execute' /app/lib/tasks/errbit/database.rake:17:in `block (2 levels) in <top (required)>'
Tasks: TOP => errbit:clear_outdated
(See full trace by running task with --trace)
```

### After

```bash
~ $ ERRBIT_PROBLEM_DESTROY_AFTER_DAYS=20 rake errbit:clear_outdated
Overwriting existing field _id in class App.
=== Cleared 28 outdated errors from the database.
```

Closes #1551