### PR TITLE
Remove USER_GEMFILE env support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "gem: --no-document" >> /etc/gemrc \
     nodejs \
     tzdata
 
-COPY ["Gemfile", "Gemfile.lock", "/app/"]
+COPY ["Gemfile", "Gemfile.lock", "UserGemfile", "/app/"]
 
 RUN apk add --no-cache --virtual build-dependencies build-base \
   && bundle config build.nokogiri --use-system-libraries \
@@ -47,4 +47,3 @@ EXPOSE 8080
 HEALTHCHECK CMD curl --fail "http://$(/bin/hostname -i | /usr/bin/awk '{ print $1 }'):${PORT:-8080}/users/sign_in" || exit 1
 
 CMD ["bundle", "exec", "puma", "-C", "config/puma.default.rb"]
-

--- a/Gemfile
+++ b/Gemfile
@@ -97,5 +97,4 @@ gem 'underscore-rails'
 
 gem 'sucker_punch'
 
-ENV['USER_GEMFILE'] ||= './UserGemfile'
-eval_gemfile ENV['USER_GEMFILE'] if File.exist?(ENV['USER_GEMFILE'])
+eval_gemfile "./UserGemfile"

--- a/README.md
+++ b/README.md
@@ -264,9 +264,8 @@ You can extend Errbit by adding Ruby gems and plugins which are typically gems.
 It's nice to keep track of which gems are core Errbit dependencies and which
 gems are your own dependencies. If you want to add gems to your own Errbit,
 place them in a new file called `UserGemfile` and Errbit will treat that file
-as an additional Gemfile. If you want to use a file with a different name, you
-can pass the name of that file in an environment variable named `USER_GEMFILE`.
-If you want to use errbit_jira_plugin, just add it to UserGemfile:
+as an additional Gemfile. If you want to use `errbit_jira_plugin`, just add it
+to `UserGemfile`:
 
 ```bash
 echo "gem 'errbit_jira_plugin'" > UserGemfile

--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -1,0 +1,8 @@
+if ENV["USER_GEMFILE"].present?
+  # Make it error in v0.11.0 release and remove in v0.12.0
+  ActiveSupport::Deprecation.warn(
+    "ENV['USER_GEMFILE'] support is deprecated and removed in Errbit v0.10.0. " \
+    "Remove it from configuration. " \
+    "In Errbit v0.10.0+ it's always 'UserGemfile'."
+  )
+end

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,3 +1,8 @@
+### Upgrading errbit from v0.9.0 to v0.10.0
+
+* Remove `USER_GEMFILE` env support. From now, only `UserGemfile` is
+  supported.
+
 ### Upgrading errbit beyond v0.8.0
 
 * Note: There are no migrations to run and the rake task for running migrations


### PR DESCRIPTION
This PR removes support of custom `UserGemfile`'s support.

From now, only `UserGemfile` is supported.

Add `ActiveSupport::Deprecation` warning for it.

Why? Dependabot can't parse Gemfile with custom ruby code. So, I simplify this code. Users still can use UserGemfile and Dependabot can parse our Gemfile and update dependencies.
