### PR TITLE
Replace actionmailer, actionpack and railties with rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,7 @@ source 'https://rubygems.org'
 RAILS_VERSION = '5.0.7.2'
 # RAILS_VERSION = '5.1.7'
 
-gem 'actionmailer', RAILS_VERSION
-gem 'actionpack', RAILS_VERSION
-gem 'railties', RAILS_VERSION
+gem 'rails', RAILS_VERSION
 
 gem 'activemodel-serializers-xml'
 gem 'actionmailer_inline_css'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (5.0.7.2)
+      actionpack (= 5.0.7.2)
+      nio4r (>= 1.2, < 3.0)
+      websocket-driver (~> 0.6.1)
     actionmailer (5.0.7.2)
       actionpack (= 5.0.7.2)
       actionview (= 5.0.7.2)
@@ -323,6 +327,18 @@ GEM
     rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
+    rails (5.0.7.2)
+      actioncable (= 5.0.7.2)
+      actionmailer (= 5.0.7.2)
+      actionpack (= 5.0.7.2)
+      actionview (= 5.0.7.2)
+      activejob (= 5.0.7.2)
+      activemodel (= 5.0.7.2)
+      activerecord (= 5.0.7.2)
+      activesupport (= 5.0.7.2)
+      bundler (>= 1.3.0)
+      railties (= 5.0.7.2)
+      sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -457,6 +473,9 @@ GEM
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket (1.2.11)
+    websocket-driver (0.6.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     xmpp4r (0.5.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -472,9 +491,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionmailer (= 5.0.7.2)
   actionmailer_inline_css
-  actionpack (= 5.0.7.2)
   activemodel-serializers-xml
   airbrake (~> 4.3.5)
   bigdecimal (~> 1.4.4)
@@ -513,8 +530,8 @@ DEPENDENCIES
   puma
   rack-ssl
   rack-ssl-enforcer
+  rails (= 5.0.7.2)
   rails-controller-testing
-  railties (= 5.0.7.2)
   rake
   ri_cal
   rinku


### PR DESCRIPTION
Soon or later, this will happen.

This PR replace: `actionmailer`, `actionpack` and `railties` with simple `rails` gem.