### PR TITLE
Add git to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN echo "gem: --no-document" >> /etc/gemrc \
   && gem update --system "$RUBYGEMS_VERSION" \
   && gem install bundler --version "$BUNDLER_VERSION" \
   && apk add --no-cache \
+    git \
     curl \
     less \
     libxml2-dev \


### PR DESCRIPTION
We install hoptoad_notifier from git. Add `git` to Dcokerfile to fix build.