### PR TITLE
Update rack gem to 2.2.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,7 +334,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     racc (1.8.1-java)
-    rack (2.2.12)
+    rack (2.2.13)
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)


### PR DESCRIPTION
[CVE-2025-27610](https://github.com/rack/rack/security/advisories/GHSA-7wqh-767x-r66v)