### PR TITLE
Rubocop: Style/Encoding

### DIFF
--- a/app/helpers/notices_helper.rb
+++ b/app/helpers/notices_helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module NoticesHelper
   def notice_atom_summary(notice)
     render "notices/atom_entry", notice: notice

--- a/app/helpers/sort_helper.rb
+++ b/app/helpers/sort_helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 module SortHelper
   def link_for_sort(name, field = nil)
     field ||= name.underscore


### PR DESCRIPTION
`UTF-8 has been the default source file encoding since Ruby 2.0.`

[Link](https://rubystyle.guide/#utf-8)