### PR TITLE
RSpec: follow default settings

### DIFF
--- a/app/assets/stylesheets/mailers/mailer.css
+++ b/app/assets/stylesheets/mailers/mailer.css
@@ -5,22 +5,24 @@ td.header {
   text-align: left;
   border-bottom: 1px solid #ccccee;
 }
-  td.header a {
-    display: block;
-    height: 31px;
-    width: 88px;
-    margin-top: 4px;
-  }
-    /* Style 'Errbit' logo alt text if image cannot be loaded. */
-    td.header a img {
-      border: none;
-      color: #E3E3E3;
-      font-family: helvetica;
-      font-size: 30px;
-      font-weight: bold;
-      min-height: 31px;
-      text-shadow: 0 1px 0 #EEEEFF;
-    }
+
+td.header a {
+  display: block;
+  height: 31px;
+  width: 88px;
+  margin-top: 4px;
+}
+
+/* Style 'Errbit' logo alt text if image cannot be loaded. */
+td.header a img {
+  border: none;
+  color: #E3E3E3;
+  font-family: helvetica;
+  font-size: 30px;
+  font-weight: bold;
+  min-height: 31px;
+  text-shadow: 0 1px 0 #EEEEFF;
+}
 
 td.section, td.content, td.footer {
   font-family: Helvetica,Arial,sans-serif;
@@ -28,14 +30,17 @@ td.section, td.content, td.footer {
   background-color: #ffffff;
   text-align: left;
 }
+
 td.section {
   padding: 0;
   border-bottom: 1px solid #dddddd;
 }
+
 td.content {
   padding: 20px 20px 10px 20px;
   line-height: 1.3em;
 }
+
 td.footer {
   padding: 10px 20px 20px 20px;
   font-size: 11px;
@@ -46,10 +51,12 @@ td.footer {
 a.bold, span.bold { font-weight: bold; }
 
 p { margin: 0 0 15px 0; }
+
 p.heading {
   color: #6a6a6a;
   margin-bottom: 4px;
 }
-p.monospace, p.backtrace { font-family: monospace; }
-p.backtrace { margin-bottom: 2px; }
 
+p.monospace, p.backtrace { font-family: monospace; }
+
+p.backtrace { margin-bottom: 2px; }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,11 +35,6 @@ class UsersController < ApplicationController
     end
   end
 
-  ##
-  # Destroy the user pass in args
-  #
-  # @param [ String ] id the id of user we want delete
-  #
   def destroy
     if user == current_user
       flash[:error] = I18n.t("controllers.users.flash.destroy.error")

--- a/app/models/notification_services/campfire_service.rb
+++ b/app/models/notification_services/campfire_service.rb
@@ -1,34 +1,36 @@
-class NotificationServices::CampfireService < NotificationService
-  LABEL = "campfire"
-  FIELDS += [
-    [:subdomain, {
-      label: "Subdomain",
-      placeholder: "subdomain from http://{{subdomain}}.campfirenow.com"
-    }],
-    [:api_token, {
-      label: "API Token",
-      placeholder: "123456789abcdef123456789abcdef"
-    }],
-    [:room_id, {
-      label: "Room ID",
-      placeholder: "123456"
-    }]
-  ]
+module NotificationServices
+  class CampfireService < NotificationService
+    LABEL = "campfire"
+    FIELDS += [
+      [:subdomain, {
+        label: "Subdomain",
+        placeholder: "subdomain from http://{{subdomain}}.campfirenow.com"
+      }],
+      [:api_token, {
+        label: "API Token",
+        placeholder: "123456789abcdef123456789abcdef"
+      }],
+      [:room_id, {
+        label: "Room ID",
+        placeholder: "123456"
+      }]
+    ]
 
-  def check_params
-    if FIELDS.detect { |f| self[f[0]].blank? }
-      errors.add :base, "You must specify your Campfire Subdomain, API token and Room ID"
+    def check_params
+      if FIELDS.detect { |f| self[f[0]].blank? }
+        errors.add :base, "You must specify your Campfire Subdomain, API token and Room ID"
+      end
     end
-  end
 
-  def url
-    "http://#{subdomain}.campfirenow.com/"
-  end
+    def url
+      "http://#{subdomain}.campfirenow.com/"
+    end
 
-  def create_notification(problem)
-    # build the campfire client
-    campy = Campy::Room.new(account: subdomain, token: api_token, room_id: room_id)
-    # post the issue to the campfire room
-    campy.speak "[errbit] #{problem.app.name} #{notification_description problem} - #{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}/problems/#{problem.id}"
+    def create_notification(problem)
+      # build the campfire client
+      campy = Campy::Room.new(account: subdomain, token: api_token, room_id: room_id)
+      # post the issue to the campfire room
+      campy.speak "[errbit] #{problem.app.name} #{notification_description problem} - #{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}/problems/#{problem.id}"
+    end
   end
 end

--- a/app/models/notification_services/campfire_service.rb
+++ b/app/models/notification_services/campfire_service.rb
@@ -1,36 +1,34 @@
-if defined? Campy
-  class NotificationServices::CampfireService < NotificationService
-    LABEL = "campfire"
-    FIELDS += [
-      [:subdomain, {
-        label: "Subdomain",
-        placeholder: "subdomain from http://{{subdomain}}.campfirenow.com"
-      }],
-      [:api_token, {
-        label: "API Token",
-        placeholder: "123456789abcdef123456789abcdef"
-      }],
-      [:room_id, {
-        label: "Room ID",
-        placeholder: "123456"
-      }]
-    ]
+class NotificationServices::CampfireService < NotificationService
+  LABEL = "campfire"
+  FIELDS += [
+    [:subdomain, {
+      label: "Subdomain",
+      placeholder: "subdomain from http://{{subdomain}}.campfirenow.com"
+    }],
+    [:api_token, {
+      label: "API Token",
+      placeholder: "123456789abcdef123456789abcdef"
+    }],
+    [:room_id, {
+      label: "Room ID",
+      placeholder: "123456"
+    }]
+  ]
 
-    def check_params
-      if FIELDS.detect { |f| self[f[0]].blank? }
-        errors.add :base, "You must specify your Campfire Subdomain, API token and Room ID"
-      end
+  def check_params
+    if FIELDS.detect { |f| self[f[0]].blank? }
+      errors.add :base, "You must specify your Campfire Subdomain, API token and Room ID"
     end
+  end
 
-    def url
-      "http://#{subdomain}.campfirenow.com/"
-    end
+  def url
+    "http://#{subdomain}.campfirenow.com/"
+  end
 
-    def create_notification(problem)
-      # build the campfire client
-      campy = Campy::Room.new(account: subdomain, token: api_token, room_id: room_id)
-      # post the issue to the campfire room
-      campy.speak "[errbit] #{problem.app.name} #{notification_description problem} - #{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}/problems/#{problem.id}"
-    end
+  def create_notification(problem)
+    # build the campfire client
+    campy = Campy::Room.new(account: subdomain, token: api_token, room_id: room_id)
+    # post the issue to the campfire room
+    campy.speak "[errbit] #{problem.app.name} #{notification_description problem} - #{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}/problems/#{problem.id}"
   end
 end

--- a/app/models/notification_services/gtalk_service.rb
+++ b/app/models/notification_services/gtalk_service.rb
@@ -1,77 +1,79 @@
-class NotificationServices::GtalkService < NotificationService
-  LABEL = "gtalk"
-  FIELDS += [
-    [:subdomain, {
-      placeholder: "username@example.com",
-      label: "Username"
-    }],
-    [:api_token, {
-      placeholder: "password",
-      label: "Password"
-    }],
-    [:user_id, {
-      placeholder: "touser@example.com, anotheruser@example.com",
-      label: "Send To User(s)"
-    }, :room_id],
-    [:room_id, {
-      placeholder: "toroom@conference.example.com",
-      label: "Send To Room (one only)"
-    }, :user_id],
-    [:service, {
-      placeholder: "talk.google.com",
-      label: "Jabber Service"
-    }],
-    [:service_url, {
-      placeholder: "http://www.google.com/talk/",
-      label: "Link To Jabber Service"
-    }]
-  ]
+module NotificationServices
+  class GtalkService < NotificationService
+    LABEL = "gtalk"
+    FIELDS += [
+      [:subdomain, {
+        placeholder: "username@example.com",
+        label: "Username"
+      }],
+      [:api_token, {
+        placeholder: "password",
+        label: "Password"
+      }],
+      [:user_id, {
+        placeholder: "touser@example.com, anotheruser@example.com",
+        label: "Send To User(s)"
+      }, :room_id],
+      [:room_id, {
+        placeholder: "toroom@conference.example.com",
+        label: "Send To Room (one only)"
+      }, :user_id],
+      [:service, {
+        placeholder: "talk.google.com",
+        label: "Jabber Service"
+      }],
+      [:service_url, {
+        placeholder: "http://www.google.com/talk/",
+        label: "Link To Jabber Service"
+      }]
+    ]
 
-  def check_params
-    if FIELDS.detect { |f| self[f[0]].blank? && self[f[2]].blank? }
-      errors.add :base,
-        "You must specify your Username, Password, service, service_url
-           and either rooms or users to send to or both"
+    def check_params
+      if FIELDS.detect { |f| self[f[0]].blank? && self[f[2]].blank? }
+        errors.add :base,
+          "You must specify your Username, Password, service, service_url
+             and either rooms or users to send to or both"
+      end
     end
-  end
 
-  def url
-    service_url || "http://www.google.com/talk/"
-  end
-
-  def create_notification(problem)
-    # build the xmpp client
-    client = nil
-    Timeout.timeout(5) do
-      client = Jabber::Client.new(Jabber::JID.new(subdomain))
-      client.connect(service)
-      client.auth(api_token)
-
-      # has to look like this to be formatted properly in the client
-      message = "#{problem.app.name}\n" \
-        "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}\n" \
-        "#{notification_description problem}"
-
-      # post the issue to the xmpp room(s)
-      send_to_users(client, message) unless user_id.blank?
-      send_to_muc(client, message) unless room_id.blank?
+    def url
+      service_url || "http://www.google.com/talk/"
     end
-  ensure
-    client.close unless client.nil?
-  end
 
-  private
+    def create_notification(problem)
+      # build the xmpp client
+      client = nil
+      Timeout.timeout(5) do
+        client = Jabber::Client.new(Jabber::JID.new(subdomain))
+        client.connect(service)
+        client.auth(api_token)
 
-  def send_to_users(client, message)
-    user_id.tr(" ", ",").tr(";", ",").split(",").map(&:strip).reject(&:empty?).each do |user|
-      client.send(Jabber::Message.new(user, message))
+        # has to look like this to be formatted properly in the client
+        message = "#{problem.app.name}\n" \
+          "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}\n" \
+          "#{notification_description problem}"
+
+        # post the issue to the xmpp room(s)
+        send_to_users(client, message) unless user_id.blank?
+        send_to_muc(client, message) unless room_id.blank?
+      end
+    ensure
+      client.close unless client.nil?
     end
-  end
 
-  def send_to_muc(client, message)
-    # TODO: set this so that it can send to multiple rooms like users, nb multiple room joins in one send fail randomly so leave as one room for the moment
-    muc = Jabber::MUC::SimpleMUCClient.new(client)
-    muc.join(room_id + "/errbit")
-    muc.send(Jabber::Message.new(room_id, message))
+    private
+
+    def send_to_users(client, message)
+      user_id.tr(" ", ",").tr(";", ",").split(",").map(&:strip).reject(&:empty?).each do |user|
+        client.send(Jabber::Message.new(user, message))
+      end
+    end
+
+    def send_to_muc(client, message)
+      # TODO: set this so that it can send to multiple rooms like users, nb multiple room joins in one send fail randomly so leave as one room for the moment
+      muc = Jabber::MUC::SimpleMUCClient.new(client)
+      muc.join(room_id + "/errbit")
+      muc.send(Jabber::Message.new(room_id, message))
+    end
   end
 end

--- a/app/models/notification_services/hoiio_service.rb
+++ b/app/models/notification_services/hoiio_service.rb
@@ -1,41 +1,43 @@
-class NotificationServices::HoiioService < NotificationService
-  LABEL = "hoiio"
-  FIELDS += [
-    [:api_token, {
-      placeholder: "App ID",
-      label: "App ID"
-    }],
-    [:subdomain, {
-      placeholder: "Access Token",
-      label: "Access Token"
-    }],
-    [:room_id, {
-      placeholder: "+6511111111, +6511111111",
-      label: "Recipient's phone numbers seperated by comma. Phone numbers should start with a \"+\" and country code."
-    }]
-  ]
+module NotificationServices
+  class HoiioService < NotificationService
+    LABEL = "hoiio"
+    FIELDS += [
+      [:api_token, {
+        placeholder: "App ID",
+        label: "App ID"
+      }],
+      [:subdomain, {
+        placeholder: "Access Token",
+        label: "Access Token"
+      }],
+      [:room_id, {
+        placeholder: "+6511111111, +6511111111",
+        label: "Recipient's phone numbers seperated by comma. Phone numbers should start with a \"+\" and country code."
+      }]
+    ]
 
-  def check_params
-    if FIELDS.detect { |f| self[f[0]].blank? }
-      errors.add :base, "You must specify your App ID, Access Token and Recipient's phone numbers"
+    def check_params
+      if FIELDS.detect { |f| self[f[0]].blank? }
+        errors.add :base, "You must specify your App ID, Access Token and Recipient's phone numbers"
+      end
     end
-  end
 
-  def url
-    "https://secure.hoiio.com/user/"
-  end
+    def url
+      "https://secure.hoiio.com/user/"
+    end
 
-  def notification_description(problem)
-    "[#{problem.environment}]#{problem.message.to_s.truncate(50)}"
-  end
+    def notification_description(problem)
+      "[#{problem.environment}]#{problem.message.to_s.truncate(50)}"
+    end
 
-  def create_notification(problem)
-    # build the hoi client
-    sms = Hoi::SMS.new(api_token, subdomain)
+    def create_notification(problem)
+      # build the hoi client
+      sms = Hoi::SMS.new(api_token, subdomain)
 
-    # send sms
-    room_id.split(",").each do |number|
-      sms.send dest: number, msg: "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id} #{notification_description problem}"
+      # send sms
+      room_id.split(",").each do |number|
+        sms.send dest: number, msg: "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id} #{notification_description problem}"
+      end
     end
   end
 end

--- a/app/models/notification_services/hubot_service.rb
+++ b/app/models/notification_services/hubot_service.rb
@@ -1,31 +1,33 @@
-class NotificationServices::HubotService < NotificationService
-  LABEL = "hubot"
-  FIELDS += [
-    [:api_token, {
-      placeholder: "http://hubot.example.org:8080/hubot/say",
-      label: "Hubot URL"
-    }],
-    [:room_id, {
-      placeholder: "#dev",
-      label: "Room where Hubot should notify"
-    }]
-  ]
+module NotificationServices
+  class HubotService < NotificationService
+    LABEL = "hubot"
+    FIELDS += [
+      [:api_token, {
+        placeholder: "http://hubot.example.org:8080/hubot/say",
+        label: "Hubot URL"
+      }],
+      [:room_id, {
+        placeholder: "#dev",
+        label: "Room where Hubot should notify"
+      }]
+    ]
 
-  def check_params
-    if FIELDS.detect { |f| self[f[0]].blank? }
-      errors.add :base, "You must specify the URL of your hubot"
+    def check_params
+      if FIELDS.detect { |f| self[f[0]].blank? }
+        errors.add :base, "You must specify the URL of your hubot"
+      end
     end
-  end
 
-  def url
-    api_token
-  end
+    def url
+      api_token
+    end
 
-  def message_for_hubot(problem)
-    "[#{problem.app.name}][#{problem.environment}][#{problem.where}]: #{problem.error_class} #{problem.url}"
-  end
+    def message_for_hubot(problem)
+      "[#{problem.app.name}][#{problem.environment}][#{problem.where}]: #{problem.error_class} #{problem.url}"
+    end
 
-  def create_notification(problem)
-    HTTParty.post(url, body: {message: message_for_hubot(problem), room: room_id})
+    def create_notification(problem)
+      HTTParty.post(url, body: {message: message_for_hubot(problem), room: room_id})
+    end
   end
 end

--- a/app/models/notification_services/pushover_service.rb
+++ b/app/models/notification_services/pushover_service.rb
@@ -1,31 +1,33 @@
-class NotificationServices::PushoverService < NotificationService
-  LABEL = "pushover"
-  FIELDS += [
-    [:api_token, {
-      placeholder: "User Key",
-      label: "User Key"
-    }],
-    [:subdomain, {
-      placeholder: "Application API Token",
-      label: "Application API Token"
-    }]
-  ]
+module NotificationServices
+  class PushoverService < NotificationService
+    LABEL = "pushover"
+    FIELDS += [
+      [:api_token, {
+        placeholder: "User Key",
+        label: "User Key"
+      }],
+      [:subdomain, {
+        placeholder: "Application API Token",
+        label: "Application API Token"
+      }]
+    ]
 
-  def check_params
-    if FIELDS.detect { |f| self[f[0]].blank? }
-      errors.add :base, "You must specify your User Key and Application API Token."
+    def check_params
+      if FIELDS.detect { |f| self[f[0]].blank? }
+        errors.add :base, "You must specify your User Key and Application API Token."
+      end
     end
-  end
 
-  def url
-    "https://pushover.net/login"
-  end
+    def url
+      "https://pushover.net/login"
+    end
 
-  def create_notification(problem)
-    # build the hoi client
-    notification = Rushover::Client.new(subdomain)
+    def create_notification(problem)
+      # build the hoi client
+      notification = Rushover::Client.new(subdomain)
 
-    # send push notification to pushover
-    notification.notify(api_token, "#{notification_description problem}", priority: 1, title: "Errbit Notification", url: "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}", url_title: "Link to error")
+      # send push notification to pushover
+      notification.notify(api_token, "#{notification_description problem}", priority: 1, title: "Errbit Notification", url: "#{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{problem.app.id}", url_title: "Link to error")
+    end
   end
 end

--- a/app/models/notification_services/slack_service.rb
+++ b/app/models/notification_services/slack_service.rb
@@ -1,95 +1,97 @@
-class NotificationServices::SlackService < NotificationService
-  CHANNEL_NAME_REGEXP = /^#[a-z\d_-]+$/
-  LABEL = "slack"
-  FIELDS += [
-    [:service_url, {
-      placeholder: "Slack Hook URL (https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX)",
-      label: "Hook URL"
-    }],
-    [:room_id, {
-      placeholder: "#general",
-      label: "Notification channel",
-      hint: "If empty Errbit will use the default channel for the webook"
-    }]
-  ]
-
-  # Make room_id optional in case users want to use the default channel
-  # setup on Slack when creating the webhook
-  def check_params
-    if service_url.blank?
-      errors.add :service_url, "You must specify your Slack Hook url"
-    end
-
-    if room_id.present? && !CHANNEL_NAME_REGEXP.match(room_id)
-      errors.add :room_id, "Slack channel name must be lowercase, with no space, special character, or periods."
-    end
-  end
-
-  def message_for_slack(problem)
-    "[#{problem.app.name}][#{problem.environment}][#{problem.where}]: #{problem.error_class} #{problem.url}"
-  end
-
-  def post_payload(problem)
-    {
-      username: "Errbit",
-      icon_url: "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
-      channel: room_id,
-      attachments: [
-        {
-          fallback: message_for_slack(problem),
-          title: problem.message.to_s.truncate(100),
-          title_link: problem.url,
-          text: problem.where,
-          color: "#D00000",
-          mrkdwn_in: ["fields"],
-          fields: post_payload_fields(problem)
-        }
-      ]
-    }.compact.to_json # compact to remove empty channel in case it wasn't selected by user
-  end
-
-  def create_notification(problem)
-    HTTParty.post(
-      service_url,
-      body: post_payload(problem),
-      headers: {
-        "Content-Type" => "application/json"
-      }
-    )
-  end
-
-  def configured?
-    service_url.present?
-  end
-
-  private
-
-  def post_payload_fields(problem)
-    [
-      {title: "Application", value: problem.app.name, short: true},
-      {title: "Environment", value: problem.environment, short: true},
-      {title: "Times Occurred", value: problem.notices_count.try(:to_s),
-       short: true},
-      {title: "First Noticed",
-       value: problem.first_notice_at.try(:localtime).try(:to_s, :db),
-       short: true},
-      {title: "Backtrace", value: backtrace_lines(problem), short: false}
+module NotificationServices
+  class SlackService < NotificationService
+    CHANNEL_NAME_REGEXP = /^#[a-z\d_-]+$/
+    LABEL = "slack"
+    FIELDS += [
+      [:service_url, {
+        placeholder: "Slack Hook URL (https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXX)",
+        label: "Hook URL"
+      }],
+      [:room_id, {
+        placeholder: "#general",
+        label: "Notification channel",
+        hint: "If empty Errbit will use the default channel for the webook"
+      }]
     ]
-  end
 
-  def backtrace_line(line)
-    path = line.decorated_path.gsub(%r{</?strong>}, "")
-    "#{path}#{line.file_name}:#{line.number} → #{line.method}\n"
-  end
+    # Make room_id optional in case users want to use the default channel
+    # setup on Slack when creating the webhook
+    def check_params
+      if service_url.blank?
+        errors.add :service_url, "You must specify your Slack Hook url"
+      end
 
-  def backtrace_lines(problem)
-    notice = NoticeDecorator.new problem.notices.last
-    return unless notice
-    backtrace = notice.backtrace
-    return unless backtrace
+      if room_id.present? && !CHANNEL_NAME_REGEXP.match(room_id)
+        errors.add :room_id, "Slack channel name must be lowercase, with no space, special character, or periods."
+      end
+    end
 
-    output = ""
-    backtrace.lines[0..4].each { |line| output << backtrace_line(line) }
-    "```#{output}```"
+    def message_for_slack(problem)
+      "[#{problem.app.name}][#{problem.environment}][#{problem.where}]: #{problem.error_class} #{problem.url}"
+    end
+
+    def post_payload(problem)
+      {
+        username: "Errbit",
+        icon_url: "https://raw.githubusercontent.com/errbit/errbit/master/docs/notifications/slack/errbit.png",
+        channel: room_id,
+        attachments: [
+          {
+            fallback: message_for_slack(problem),
+            title: problem.message.to_s.truncate(100),
+            title_link: problem.url,
+            text: problem.where,
+            color: "#D00000",
+            mrkdwn_in: ["fields"],
+            fields: post_payload_fields(problem)
+          }
+        ]
+      }.compact.to_json # compact to remove empty channel in case it wasn't selected by user
+    end
+
+    def create_notification(problem)
+      HTTParty.post(
+        service_url,
+        body: post_payload(problem),
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+    end
+
+    def configured?
+      service_url.present?
+    end
+
+    private
+
+    def post_payload_fields(problem)
+      [
+        {title: "Application", value: problem.app.name, short: true},
+        {title: "Environment", value: problem.environment, short: true},
+        {title: "Times Occurred", value: problem.notices_count.try(:to_s),
+         short: true},
+        {title: "First Noticed",
+         value: problem.first_notice_at.try(:localtime).try(:to_s, :db),
+         short: true},
+        {title: "Backtrace", value: backtrace_lines(problem), short: false}
+      ]
+    end
+
+    def backtrace_line(line)
+      path = line.decorated_path.gsub(%r{</?strong>}, "")
+      "#{path}#{line.file_name}:#{line.number} → #{line.method}\n"
+    end
+
+    def backtrace_lines(problem)
+      notice = NoticeDecorator.new problem.notices.last
+      return unless notice
+      backtrace = notice.backtrace
+      return unless backtrace
+
+      output = ""
+      backtrace.lines[0..4].each { |line| output << backtrace_line(line) }
+      "```#{output}```"
+    end
   end
 end

--- a/app/models/notification_services/webhook_service.rb
+++ b/app/models/notification_services/webhook_service.rb
@@ -1,25 +1,27 @@
-class NotificationServices::WebhookService < NotificationService
-  LABEL = "webhook"
-  FIELDS = [
-    [:api_token, {
-      placeholder: "URL to receive a POST request when an error occurs",
-      label: "URL"
-    }]
-  ]
+module NotificationServices
+  class WebhookService < NotificationService
+    LABEL = "webhook"
+    FIELDS = [
+      [:api_token, {
+        placeholder: "URL to receive a POST request when an error occurs",
+        label: "URL"
+      }]
+    ]
 
-  def check_params
-    if FIELDS.detect { |f| self[f[0]].blank? }
-      errors.add :base, "You must specify the URL"
+    def check_params
+      if FIELDS.detect { |f| self[f[0]].blank? }
+        errors.add :base, "You must specify the URL"
+      end
     end
-  end
 
-  def message_for_webhook(problem)
-    {
-      problem: {url: problem.url}.merge!(problem.as_json)
-    }
-  end
+    def message_for_webhook(problem)
+      {
+        problem: {url: problem.url}.merge!(problem.as_json)
+      }
+    end
 
-  def create_notification(problem)
-    HTTParty.post(api_token, headers: {"Content-Type" => "application/json", "User-Agent" => "Errbit"}, body: message_for_webhook(problem).to_json)
+    def create_notification(problem)
+      HTTParty.post(api_token, headers: {"Content-Type" => "application/json", "User-Agent" => "Errbit"}, body: message_for_webhook(problem).to_json)
+    end
   end
 end

--- a/docs/api/stats.md
+++ b/docs/api/stats.md
@@ -1,36 +1,28 @@
 # Statistics API Documentation
 
-
 ## Get Stats
 
 Represent error statistics. Render JSON if no extension specified on path.
-
 
 ### Request
 
 Example:
 
-```sh
-
+```console
 curl 'http://myerrbit.com/api/v1/stats/app?api_key=6423d563e5285b34cb117f757b2bc7b1'
-
 ```
 
 Parameters:
 
 - **api_key** - required, this endpoints require authentication with an API Key.
 
-
 ### Response
 
-
-```javascript
-
+```json
 {
-  name: "sample app",
-  id: "552941336a756e4e71012345",
-  last_error_time: "2015-04-12T08:43:47.480+00:00",
-  unresolved_errors: 4
+  "name": "sample app",
+  "id": "552941336a756e4e71012345",
+  "last_error_time": "2015-04-12T08:43:47.480+00:00",
+  "unresolved_errors": 4
 }
-
 ```

--- a/docs/deployment/dokku.md
+++ b/docs/deployment/dokku.md
@@ -5,7 +5,7 @@ For more details see [Heroku](heroku.md) guide.
 
 ## Create an app on dokku and push the source code
 
-```bash
+```console
 dokku apps:create errbit
 dokku plugin:install https://github.com/dokku/dokku-mongo.git mongo
 dokku mongo:create errbit errbit
@@ -22,8 +22,8 @@ git remote add dokku dokku@<host>:errbit
 git push dokku main
 ```
 
-### Prepare the DB
+## Prepare the DB
 
-```bash
+```console
 dokku run errbit rake errbit:bootstrap
 ```

--- a/spec/acceptance/app_regenerate_api_key_spec.rb
+++ b/spec/acceptance/app_regenerate_api_key_spec.rb
@@ -1,6 +1,6 @@
 require "acceptance/acceptance_helper"
 
-feature "Regeneration api_Key" do
+RSpec.feature "Regeneration api_Key" do
   let(:app) { Fabricate(:app) }
   let(:admin) { Fabricate(:admin) }
   let(:user) do
@@ -34,7 +34,7 @@ feature "Regeneration api_Key" do
   end
 end
 
-feature "Create an application" do
+RSpec.feature "Create an application" do
   let(:admin) { Fabricate(:admin) }
   let(:user) do
     Fabricate(:user_watcher, app: app).user

--- a/spec/acceptance/reset_password_token.rb
+++ b/spec/acceptance/reset_password_token.rb
@@ -1,6 +1,6 @@
 require "acceptance/acceptance_helper"
 
-feature "password reset token" do
+RSpec.feature "password reset token" do
   let(:user) { Fabricate :user }
 
   scenario "receives correct password reset token" do

--- a/spec/acceptance/sign_in_with_github_spec.rb
+++ b/spec/acceptance/sign_in_with_github_spec.rb
@@ -1,6 +1,6 @@
 require "acceptance/acceptance_helper"
 
-feature "Sign in with GitHub" do
+RSpec.feature "Sign in with GitHub" do
   background do
     allow(Errbit::Config).to receive(:github_authentication).and_return(true)
     Fabricate(:user, github_login: "nashby")

--- a/spec/acceptance/sign_in_with_google_spec.rb
+++ b/spec/acceptance/sign_in_with_google_spec.rb
@@ -1,6 +1,6 @@
 require "acceptance/acceptance_helper"
 
-feature "Sign in with Google" do
+RSpec.feature "Sign in with Google" do
   background do
     allow(Errbit::Config).to receive(:google_authentication).and_return(true)
     Fabricate(:user, google_uid: "nashby")
@@ -22,7 +22,7 @@ feature "Sign in with Google" do
   end
 end
 
-feature "Sign in with Google with auto provision" do
+RSpec.feature "Sign in with Google with auto provision" do
   background do
     allow(Errbit::Config).to receive(:google_authentication).and_return(true)
     allow(Errbit::Config).to receive(:google_auto_provision).and_return(true)
@@ -38,7 +38,7 @@ feature "Sign in with Google with auto provision" do
   end
 end
 
-feature "Sign in with Google with domain validation" do
+RSpec.feature "Sign in with Google with domain validation" do
   background do
     allow(Errbit::Config).to receive(:google_authentication).and_return(true)
     allow(Errbit::Config).to receive(:google_auto_provision).and_return(true)

--- a/spec/acceptance/watch_unwatch_app_spec.rb
+++ b/spec/acceptance/watch_unwatch_app_spec.rb
@@ -1,6 +1,6 @@
 require "acceptance/acceptance_helper"
 
-feature "A user can watch and unwatch an application" do
+RSpec.feature "A user can watch and unwatch an application" do
   let!(:app) { Fabricate(:app) }
   let!(:user) { Fabricate(:user) }
 

--- a/spec/controllers/api/v1/comments_controller_spec.rb
+++ b/spec/controllers/api/v1/comments_controller_spec.rb
@@ -1,4 +1,6 @@
-describe Api::V1::CommentsController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe Api::V1::CommentsController, type: :controller do
   context "when logged in" do
     before do
       @user = Fabricate(:user)

--- a/spec/controllers/api/v1/notices_controller_spec.rb
+++ b/spec/controllers/api/v1/notices_controller_spec.rb
@@ -1,4 +1,6 @@
-describe Api::V1::NoticesController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe Api::V1::NoticesController, type: :controller do
   context "when logged in" do
     before do
       @user = Fabricate(:user)

--- a/spec/controllers/api/v1/problems_controller_spec.rb
+++ b/spec/controllers/api/v1/problems_controller_spec.rb
@@ -1,4 +1,6 @@
-describe Api::V1::ProblemsController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe Api::V1::ProblemsController, type: :controller do
   context "when logged in" do
     before do
       @user = Fabricate(:user)

--- a/spec/controllers/api/v3/notices_controller_spec.rb
+++ b/spec/controllers/api/v3/notices_controller_spec.rb
@@ -1,4 +1,6 @@
-describe Api::V3::NoticesController, type: :controller do
+require "rails_helper"
+
+RSpec.describe Api::V3::NoticesController, type: :controller do
   let(:app) { Fabricate(:app) }
   let(:project_id) { app.api_key }
   let(:legit_params) { {project_id: project_id, key: project_id} }

--- a/spec/controllers/apps_controller_spec.rb
+++ b/spec/controllers/apps_controller_spec.rb
@@ -1,4 +1,6 @@
-describe AppsController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe AppsController, type: :controller do
   it_requires_authentication
   it_requires_admin_privileges for: {new: :get, edit: :get, create: :post, update: :put, destroy: :delete}
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,4 +1,6 @@
-describe CommentsController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe CommentsController, type: :controller do
   let(:app) { Fabricate(:app) }
   let(:err) { Fabricate(:err, problem: Fabricate(:problem, app: app, environment: "production")) }
 

--- a/spec/controllers/devise_sessions_controller_spec.rb
+++ b/spec/controllers/devise_sessions_controller_spec.rb
@@ -1,4 +1,6 @@
-describe Devise::SessionsController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe Devise::SessionsController, type: :controller do
   render_views
 
   describe "POST /users/sign_in" do

--- a/spec/controllers/notices_controller_spec.rb
+++ b/spec/controllers/notices_controller_spec.rb
@@ -1,4 +1,6 @@
-describe NoticesController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe NoticesController, type: :controller do
   it_requires_authentication for: {locate: :get}
 
   let(:notice) { Fabricate(:notice) }

--- a/spec/controllers/problems_controller_spec.rb
+++ b/spec/controllers/problems_controller_spec.rb
@@ -1,4 +1,6 @@
-describe ProblemsController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe ProblemsController, type: :controller do
   it_requires_authentication for: {
                                index: :get, show: :get, resolve: :put, search: :get
                              },

--- a/spec/controllers/site_config_controller_spec.rb
+++ b/spec/controllers/site_config_controller_spec.rb
@@ -1,4 +1,6 @@
-describe SiteConfigController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe SiteConfigController, type: :controller do
   it_requires_admin_privileges for: {
     index: :get,
     update: :put

--- a/spec/controllers/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/users/omniauth_callbacks_controller_spec.rb
@@ -1,4 +1,6 @@
-describe Users::OmniauthCallbacksController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe Users::OmniauthCallbacksController, type: :controller do
   def stub_env_for_github_omniauth(login, token = nil, email = "user@example.com")
     # This a Devise specific thing for functional tests. See https://github.com/plataformatec/devise/issues/closed#issue/608
     request.env["devise.mapping"] = Devise.mappings[:user]

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,4 +1,6 @@
-describe UsersController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe UsersController, type: :controller do
   it_requires_authentication
   it_requires_admin_privileges for: {
     index: :get,

--- a/spec/controllers/watchers_controller_spec.rb
+++ b/spec/controllers/watchers_controller_spec.rb
@@ -1,4 +1,6 @@
-describe WatchersController, type: "controller" do
+require "rails_helper"
+
+RSpec.describe WatchersController, type: :controller do
   let(:user) { Fabricate(:user) }
   let(:problem) { Fabricate(:problem) }
 

--- a/spec/decorators/app_decorator_spec.rb
+++ b/spec/decorators/app_decorator_spec.rb
@@ -1,4 +1,6 @@
-describe AppDecorator do
+require "rails_helper"
+
+RSpec.describe AppDecorator, type: :decorator do
   describe "#email_at_notices" do
     it "return the list separate by comma" do
       expect(AppDecorator.new(double(email_at_notices: [2, 3])).email_at_notices).to eql "2, 3"

--- a/spec/decorators/backtrace_decorator_spec.rb
+++ b/spec/decorators/backtrace_decorator_spec.rb
@@ -1,4 +1,6 @@
-describe BacktraceDecorator, type: :decorator do
+require "rails_helper"
+
+RSpec.describe BacktraceDecorator, type: :decorator do
   let(:backtrace) do
     described_class.new(
       Backtrace.new(

--- a/spec/decorators/backtrace_line_decorator_spec.rb
+++ b/spec/decorators/backtrace_line_decorator_spec.rb
@@ -1,4 +1,6 @@
-describe BacktraceLineDecorator, type: :decorator do
+require "rails_helper"
+
+RSpec.describe BacktraceLineDecorator, type: :decorator do
   let(:backtrace_line) do
     described_class.new(
       number: 884,

--- a/spec/decorators/issue_tracker_decorator_spec.rb
+++ b/spec/decorators/issue_tracker_decorator_spec.rb
@@ -1,4 +1,6 @@
-describe IssueTrackerDecorator do
+require "rails_helper"
+
+RSpec.describe IssueTrackerDecorator, type: :decorator do
   let(:fake_tracker) do
     klass = Class.new(ErrbitPlugin::IssueTracker) do
       def self.label

--- a/spec/decorators/issue_tracker_field_decorator.rb
+++ b/spec/decorators/issue_tracker_field_decorator.rb
@@ -1,4 +1,6 @@
-describe IssueTrackerFieldDecorator do
+require "rails_helper"
+
+RSpec.describe IssueTrackerFieldDecorator, type: :decorator do
   describe "#label" do
     it "return the label of field_info by default" do
       expect(IssueTrackerFieldDecorator.new(:foo, label: "hello").label).to eq "hello"

--- a/spec/decorators/issue_tracker_type_decorator_spec.rb
+++ b/spec/decorators/issue_tracker_type_decorator_spec.rb
@@ -1,4 +1,6 @@
-describe IssueTrackerDecorator do
+require "rails_helper"
+
+RSpec.describe IssueTrackerDecorator, type: :decorator do
   let(:fake_tracker_class) do
     klass = Class.new(ErrbitPlugin::IssueTracker) do
       def self.label

--- a/spec/decorators/watcher_decorator_spec.rb
+++ b/spec/decorators/watcher_decorator_spec.rb
@@ -1,4 +1,6 @@
-describe WatcherDecorator do
+require "rails_helper"
+
+RSpec.describe WatcherDecorator, type: :decorator do
   describe "#email_choosen" do
     context "with email define" do
       it "return blank" do

--- a/spec/fabricators/app_fabricator.rb
+++ b/spec/fabricators/app_fabricator.rb
@@ -1,21 +1,25 @@
 Fabricator(:app) do
   name { sequence(:app_name) { |n| "App ##{n}" } }
+
   repository_branch "main"
 end
 
 Fabricator(:app_with_watcher, from: :app) do
-  watchers(count: 1) do |parent, _i|
+  watchers(count: 1) do |parent, _|
     Fabricate.build(:watcher, app: parent)
   end
 end
 
 Fabricator(:watcher) do
   app
+
   watcher_type "email"
+
   email { sequence(:email) { |n| "email#{n}@example.com" } }
 end
 
 Fabricator(:user_watcher, from: :watcher) do
   user
+
   watcher_type "user"
 end

--- a/spec/fabricators/comment_fabricator.rb
+++ b/spec/fabricators/comment_fabricator.rb
@@ -1,5 +1,7 @@
 Fabricator :comment do
   user
+
   body "Test comment"
+
   err(fabricator: :problem)
 end

--- a/spec/fabricators/err_fabricator.rb
+++ b/spec/fabricators/err_fabricator.rb
@@ -1,4 +1,5 @@
 Fabricator :err do
   problem
+
   fingerprint "some-finger-print"
 end

--- a/spec/fabricators/issue_tracker_fabricator.rb
+++ b/spec/fabricators/issue_tracker_fabricator.rb
@@ -1,10 +1,12 @@
 Fabricator :issue_tracker do
   type_tracker "mock"
+
   options do
     {
       foo: "one",
       bar: "two"
     }
   end
+
   app
 end

--- a/spec/fabricators/notice_fabricator.rb
+++ b/spec/fabricators/notice_fabricator.rb
@@ -1,15 +1,23 @@
 Fabricator :notice do
   app
+
   err
+
   error_class "FooError"
+
   message "FooError: Too Much Bar"
+
   backtrace
+
   server_environment { {"environment-name" => "production"} }
+
   request { {"component" => "foo", "action" => "bar"} }
+
   notifier { {"name" => "Notifier", "version" => "1", "url" => "http://toad.com"} }
 
   after_create do
     Problem.cache_notice(err.problem_id, self)
+
     problem.reload
   end
 end

--- a/spec/fabricators/notification_service_fabricator.rb
+++ b/spec/fabricators/notification_service_fabricator.rb
@@ -1,19 +1,26 @@
 Fabricator :notification_service do
   app
+
   room_id { sequence :word }
+
   api_token { sequence :word }
+
   subdomain { sequence :word }
-  notify_at_notices { sequence { |_a| [0] } }
+
+  notify_at_notices { sequence { |_| [0] } }
 end
 
 Fabricator :gtalk_notification_service, from: :notification_service, class_name: "NotificationServices::GtalkService" do
   user_id { sequence :word }
+
   service_url { sequence :word }
+
   service { sequence :word }
 end
 
 Fabricator :slack_notification_service, from: :notification_service, class_name: "NotificationServices::SlackService" do
   service_url { sequence :word }
+
   room_id { sequence(:room_id) { |i| "#room-#{i}" } }
 end
 

--- a/spec/fabricators/problem_fabricator.rb
+++ b/spec/fabricators/problem_fabricator.rb
@@ -1,7 +1,10 @@
 Fabricator(:problem) do
   app { Fabricate(:app) }
+
   comments { [] }
+
   error_class "FooError"
+
   environment "production"
 end
 
@@ -24,6 +27,7 @@ end
 Fabricator(:problem_resolved, from: :problem) do
   after_create do |pr|
     Fabricate(:notice, err: Fabricate(:err, problem: pr))
+
     pr.resolve!
   end
 end

--- a/spec/fabricators/sequences_fabricator.rb
+++ b/spec/fabricators/sequences_fabricator.rb
@@ -1,2 +1,3 @@
 Fabricate.sequence(:name) { |n| "John #{n} Doe" }
+
 Fabricate.sequence(:word) { |n| "word#{n}" }

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,7 +1,10 @@
 Fabricator :user do
   name "Clyde Frog"
+
   email { sequence(:user_email) { |n| "user.#{n}@example.com" } }
+
   password "password"
+
   password_confirmation "password"
 end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,6 @@
-describe ApplicationHelper do
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
   let(:notice) { Fabricate(:notice) }
   describe "#generate_problem_ical" do
     it "return the ical format" do

--- a/spec/helpers/hash_helper_spec.rb
+++ b/spec/helpers/hash_helper_spec.rb
@@ -1,4 +1,6 @@
-describe HashHelper do
+require "rails_helper"
+
+RSpec.describe HashHelper, type: :helper do
   describe ".pretty_hash" do
     let(:expected_pretty_hash) do
       <<~HASH.chomp

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -1,4 +1,6 @@
-describe NavigationHelper do
+require "rails_helper"
+
+RSpec.describe NavigationHelper, type: :helper do
   describe "#page_count_from_end" do
     it "returns the page number when counting from the last occurrence of a notice" do
       expect(page_count_from_end(1, 6)).to eq 6

--- a/spec/helpers/problems_helper_spec.rb
+++ b/spec/helpers/problems_helper_spec.rb
@@ -1,4 +1,6 @@
-describe ProblemsHelper do
+require "rails_helper"
+
+RSpec.describe ProblemsHelper, type: :helper do
   describe "#auto_link_format" do
     it "handles links with target and wraps paragraph" do
       expect(

--- a/spec/initializers/action_mailer_spec.rb
+++ b/spec/initializers/action_mailer_spec.rb
@@ -1,4 +1,6 @@
-describe "initializers/action_mailer" do
+require "rails_helper"
+
+RSpec.describe "initializers/action_mailer" do
   def load_initializer
     load File.join(Rails.root, "config", "initializers", "action_mailer.rb")
   end

--- a/spec/initializers/devise_spec.rb
+++ b/spec/initializers/devise_spec.rb
@@ -1,4 +1,6 @@
-describe "initializers/devise" do
+require "rails_helper"
+
+RSpec.describe "initializers/devise" do
   def load_initializer
     load File.join(Rails.root, "config", "initializers", "devise.rb")
   end

--- a/spec/interactors/notice_refingerprinter_spec.rb
+++ b/spec/interactors/notice_refingerprinter_spec.rb
@@ -1,4 +1,6 @@
-describe NoticeRefingerprinter do
+require "rails_helper"
+
+RSpec.describe NoticeRefingerprinter do
   let(:app) { Fabricate(:app) }
   let(:backtrace) do
     Fabricate(:backtrace)

--- a/spec/interactors/outdated_problem_clearer_spec.rb
+++ b/spec/interactors/outdated_problem_clearer_spec.rb
@@ -1,4 +1,6 @@
-describe OutdatedProblemClearer do
+require "rails_helper"
+
+RSpec.describe OutdatedProblemClearer do
   before do
     allow(Errbit::Config).to receive(:notice_deprecation_days).and_return(7)
   end

--- a/spec/interactors/problem_destroy_spec.rb
+++ b/spec/interactors/problem_destroy_spec.rb
@@ -1,4 +1,6 @@
-describe ProblemDestroy do
+require "rails_helper"
+
+RSpec.describe ProblemDestroy do
   let(:problem_destroy) do
     ProblemDestroy.new(problem)
   end

--- a/spec/interactors/problem_merge_spec.rb
+++ b/spec/interactors/problem_merge_spec.rb
@@ -1,4 +1,6 @@
-describe ProblemMerge do
+require "rails_helper"
+
+RSpec.describe ProblemMerge do
   let(:problem) { Fabricate(:problem_with_errs) }
   let(:problem_1) { Fabricate(:problem_with_errs) }
 

--- a/spec/interactors/problem_recacher_spec.rb
+++ b/spec/interactors/problem_recacher_spec.rb
@@ -1,4 +1,6 @@
-describe ProblemRecacher do
+require "rails_helper"
+
+RSpec.describe ProblemRecacher do
   let(:app) { Fabricate(:app) }
   let(:backtrace) do
     Fabricate(:backtrace)

--- a/spec/interactors/resolved_problem_clearer_spec.rb
+++ b/spec/interactors/resolved_problem_clearer_spec.rb
@@ -1,4 +1,6 @@
-describe ResolvedProblemClearer do
+require "rails_helper"
+
+RSpec.describe ResolvedProblemClearer do
   let(:resolved_problem_clearer) do
     ResolvedProblemClearer.new
   end

--- a/spec/interactors/user_destroy_spec.rb
+++ b/spec/interactors/user_destroy_spec.rb
@@ -1,4 +1,6 @@
-describe UserDestroy do
+require "rails_helper"
+
+RSpec.describe UserDestroy do
   let(:app) do
     Fabricate(
       :app,

--- a/spec/jobs/destroy_problems_by_app_job_spec.rb
+++ b/spec/jobs/destroy_problems_by_app_job_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe DestroyProblemsByAppJob, type: :job do
   before do
     @app = Fabricate(:app)

--- a/spec/jobs/destroy_problems_by_id_job_spec.rb
+++ b/spec/jobs/destroy_problems_by_id_job_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe DestroyProblemsByIdJob, type: :job do
   before do
     @app = Fabricate(:app)

--- a/spec/lib/airbrake_api/v3/notice_parser_spec.rb
+++ b/spec/lib/airbrake_api/v3/notice_parser_spec.rb
@@ -1,4 +1,6 @@
-describe AirbrakeApi::V3::NoticeParser do
+require "rails_helper"
+
+RSpec.describe AirbrakeApi::V3::NoticeParser do
   let(:app) { Fabricate(:app) }
   let(:notifier_params) do
     {

--- a/spec/lib/configurator_spec.rb
+++ b/spec/lib/configurator_spec.rb
@@ -1,4 +1,6 @@
-describe Configurator do
+require "rails_helper"
+
+RSpec.describe Configurator do
   before(:each) do
     allow(ENV).to receive(:[]).and_return(nil)
     allow(ENV).to receive(:[]).with("VARONE").and_return("zoom")

--- a/spec/lib/errbit/version_spec.rb
+++ b/spec/lib/errbit/version_spec.rb
@@ -1,4 +1,6 @@
-describe Errbit::Version do
+require "rails_helper"
+
+RSpec.describe Errbit::Version do
   let(:version) { "0.0.0" }
 
   context "release version" do

--- a/spec/lib/sparklines_spec.rb
+++ b/spec/lib/sparklines_spec.rb
@@ -1,4 +1,6 @@
-describe Sparklines do
+require "rails_helper"
+
+RSpec.describe Sparklines do
   it "includes each percentage and adds a percent sign" do
     percentages = [33, 75, 100]
     sparklines_html = Sparklines.for_relative_percentages(percentages)

--- a/spec/mailers/mailer_spec.rb
+++ b/spec/mailers/mailer_spec.rb
@@ -1,4 +1,6 @@
-shared_examples "a notification email" do
+require "rails_helper"
+
+RSpec.shared_examples "a notification email" do
   it "should have X-Mailer header" do
     expect(email).to have_header("X-Mailer", "Errbit")
   end
@@ -26,7 +28,7 @@ shared_examples "a notification email" do
   end
 end
 
-describe Mailer do
+RSpec.describe Mailer do
   context "Err Notification" do
     include EmailSpec::Helpers
     include EmailSpec::Matchers

--- a/spec/models/app_spec.rb
+++ b/spec/models/app_spec.rb
@@ -1,4 +1,6 @@
-describe App, type: "model" do
+require "rails_helper"
+
+RSpec.describe App, type: :model do
   context "Attributes" do
     it { is_expected.to have_field(:_id).of_type(String) }
     it { is_expected.to have_field(:name).of_type(String) }

--- a/spec/models/backtrace_spec.rb
+++ b/spec/models/backtrace_spec.rb
@@ -1,4 +1,6 @@
-describe Backtrace, type: "model" do
+require "rails_helper"
+
+RSpec.describe Backtrace, type: :model do
   describe ".find_or_create" do
     let(:lines) do
       [

--- a/spec/models/comment_observer_spec.rb
+++ b/spec/models/comment_observer_spec.rb
@@ -1,4 +1,6 @@
-describe "Callback on Comment", type: "model" do
+require "rails_helper"
+
+RSpec.describe "Callback on Comment", type: :model do
   context "when a Comment is saved" do
     let(:comment) { Fabricate.build(:comment) }
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,4 +1,6 @@
-describe Comment, type: "model" do
+require "rails_helper"
+
+RSpec.describe Comment, type: :model do
   context "validations" do
     it "should require a body" do
       comment = Fabricate.build(:comment, body: nil)

--- a/spec/models/err_spec.rb
+++ b/spec/models/err_spec.rb
@@ -1,4 +1,6 @@
-describe Err, type: "model" do
+require "rails_helper"
+
+RSpec.describe Err, type: :model do
   context "validations" do
     it "requires a fingerprint" do
       err = Fabricate.build(:err, fingerprint: nil)

--- a/spec/models/error_report_spec.rb
+++ b/spec/models/error_report_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 require "airbrake/version"
 require "airbrake/backtrace"
 require "airbrake/notice"
@@ -16,7 +18,7 @@ module Airbrake
   end
 end
 
-describe ErrorReport do
+RSpec.describe ErrorReport, type: :model do
   let(:xml) do
     Rails.root.join("spec", "fixtures", "hoptoad_test_notice.xml").read
   end

--- a/spec/models/fabricators_spec.rb
+++ b/spec/models/fabricators_spec.rb
@@ -1,10 +1,12 @@
+require "rails_helper"
+
 Fabrication::Config.fabricator_path.each do |folder|
   Dir.glob(File.join(Rails.root, folder, "**", "*.rb")).each do |file|
     require file
   end
 end
 
-describe "Fabrication" do
+RSpec.describe "Fabrication", type: :model do
   # TODO : when 1.8.7 drop support se directly Symbol#sort
   Fabrication.manager.schematics.keys.sort.each do |fabricator_name|
     context "Fabricate(:#{fabricator_name})" do

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -1,4 +1,6 @@
-describe Issue, type: "model" do
+require "rails_helper"
+
+RSpec.describe Issue, type: :model do
   subject(:issue) { Issue.new(problem: problem, user: user, body: body) }
 
   let(:problem) { notice.problem }

--- a/spec/models/issue_tracker_spec.rb
+++ b/spec/models/issue_tracker_spec.rb
@@ -1,4 +1,6 @@
-describe IssueTracker, type: "model" do
+require "rails_helper"
+
+RSpec.describe IssueTracker, type: :model do
   describe "Association" do
     it { is_expected.to be_embedded_in(:app) }
   end

--- a/spec/models/notice_fingerprinter_spec.rb
+++ b/spec/models/notice_fingerprinter_spec.rb
@@ -1,4 +1,6 @@
-describe NoticeFingerprinter, type: "model" do
+require "rails_helper"
+
+RSpec.describe NoticeFingerprinter, type: :model do
   let(:fingerprinter) { described_class.new }
   let(:notice) { Fabricate(:notice) }
   let(:backtrace) { Fabricate(:backtrace) }

--- a/spec/models/notice_observer_spec.rb
+++ b/spec/models/notice_observer_spec.rb
@@ -1,4 +1,6 @@
-describe "Callback on Notice", type: "model" do
+require "rails_helper"
+
+RSpec.describe "Callback on Notice", type: :model do
   let(:notice_attrs_for) do
     lambda do |api_key|
       {

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -1,4 +1,6 @@
-describe Notice, type: "model" do
+require "rails_helper"
+
+RSpec.describe Notice, type: :model do
   context "validations" do
     it "requires a backtrace" do
       notice = Fabricate.build(:notice, backtrace: nil)

--- a/spec/models/notification_service/campfire_service_spec.rb
+++ b/spec/models/notification_service/campfire_service_spec.rb
@@ -1,4 +1,6 @@
-describe NotificationServices::CampfireService, type: "model" do
+require "rails_helper"
+
+RSpec.describe NotificationServices::CampfireService, type: :model do
   it "it should send a notification to campfire" do
     # setup
     notice = Fabricate :notice

--- a/spec/models/notification_service/campfire_service_spec.rb
+++ b/spec/models/notification_service/campfire_service_spec.rb
@@ -2,17 +2,13 @@ require "rails_helper"
 
 RSpec.describe NotificationServices::CampfireService, type: :model do
   it "it should send a notification to campfire" do
-    # setup
     notice = Fabricate :notice
     notification_service = Fabricate :campfire_notification_service, app: notice.app
     problem = notice.problem
 
-    # campy stubbing
     campy = double("CampfireService")
     allow(Campy::Room).to receive(:new).and_return(campy)
     allow(campy).to receive(:speak).and_return(true)
-
-    # assert
     expect(campy).to receive(:speak)
 
     notification_service.create_notification(problem)

--- a/spec/models/notification_service/gtalk_service_spec.rb
+++ b/spec/models/notification_service/gtalk_service_spec.rb
@@ -1,4 +1,6 @@
-describe NotificationServices::GtalkService, type: "model" do
+require "rails_helper"
+
+RSpec.describe NotificationServices::GtalkService, type: :model do
   it "it should send a notification to gtalk" do
     # setup
     notice = Fabricate :notice

--- a/spec/models/notification_service/gtalk_service_spec.rb
+++ b/spec/models/notification_service/gtalk_service_spec.rb
@@ -2,13 +2,11 @@ require "rails_helper"
 
 RSpec.describe NotificationServices::GtalkService, type: :model do
   it "it should send a notification to gtalk" do
-    # setup
     notice = Fabricate :notice
     notice.problem
     notification_service = Fabricate :gtalk_notification_service, app: notice.app
     problem = notice.problem
 
-    # gtalk stubbing
     gtalk = double("GtalkService")
     jid = double("jid")
     message = double("message")
@@ -26,7 +24,6 @@ RSpec.describe NotificationServices::GtalkService, type: :model do
     expect(Jabber::MUC::SimpleMUCClient).to receive(:new).and_return(gtalk)
     expect(gtalk).to receive(:join).with(notification_service.room_id + "/errbit")
 
-    # assert
     expect(gtalk).to receive(:send).exactly(2).times.with(message)
     expect(gtalk).to receive(:close)
 
@@ -43,7 +40,6 @@ RSpec.describe NotificationServices::GtalkService, type: :model do
 #{Errbit::Config.protocol}://#{Errbit::Config.host}/apps/#{@problem.app.id}
 #{@notification_service.notification_description @problem}"
 
-      # gtalk stubbing
       @gtalk = double("GtalkService")
       expect(@gtalk).to receive(:connect)
       expect(@gtalk).to receive(:auth)
@@ -51,6 +47,7 @@ RSpec.describe NotificationServices::GtalkService, type: :model do
       allow(Jabber::JID).to receive(:new).with(@notification_service.subdomain).and_return(jid)
       allow(Jabber::Client).to receive(:new).with(jid).and_return(@gtalk)
     end
+
     it "should send a notification to all ',' separated users" do
       expect(Jabber::Message).to receive(:new).with("first@domain.org", @error_msg)
       expect(Jabber::Message).to receive(:new).with("second@domain.org", @error_msg)
@@ -64,6 +61,7 @@ RSpec.describe NotificationServices::GtalkService, type: :model do
       @notification_service.room_id = ""
       @notification_service.create_notification(@problem)
     end
+
     it "should send a notification to all ';' separated users" do
       expect(Jabber::Message).to receive(:new).with("first@domain.org", @error_msg)
       expect(Jabber::Message).to receive(:new).with("second@domain.org", @error_msg)
@@ -77,6 +75,7 @@ RSpec.describe NotificationServices::GtalkService, type: :model do
       @notification_service.room_id = ""
       @notification_service.create_notification(@problem)
     end
+
     it "should send a notification to all ' ' separated users" do
       expect(Jabber::Message).to receive(:new).with("first@domain.org", @error_msg)
       expect(Jabber::Message).to receive(:new).with("second@domain.org", @error_msg)
@@ -93,13 +92,11 @@ RSpec.describe NotificationServices::GtalkService, type: :model do
   end
 
   it "it should send a notification to room only" do
-    # setup
     notice = Fabricate :notice
     notice.problem
     notification_service = Fabricate :gtalk_notification_service, app: notice.app
     problem = notice.problem
 
-    # gtalk stubbing
     gtalk = double("GtalkService")
     jid = double("jid")
     message = double("message")
@@ -118,7 +115,6 @@ RSpec.describe NotificationServices::GtalkService, type: :model do
 
     notification_service.user_id = ""
 
-    # assert
     expect(gtalk).to receive(:send).with(message)
     expect(gtalk).to receive(:close)
 

--- a/spec/models/notification_service/hoiio_service_spec.rb
+++ b/spec/models/notification_service/hoiio_service_spec.rb
@@ -1,4 +1,6 @@
-describe NotificationServices::HoiioService, type: "model" do
+require "rails_helper"
+
+RSpec.describe NotificationServices::HoiioService, type: :model do
   it "it should send a notification to hoiio" do
     # setup
     notice = Fabricate :notice

--- a/spec/models/notification_service/hoiio_service_spec.rb
+++ b/spec/models/notification_service/hoiio_service_spec.rb
@@ -2,17 +2,14 @@ require "rails_helper"
 
 RSpec.describe NotificationServices::HoiioService, type: :model do
   it "it should send a notification to hoiio" do
-    # setup
     notice = Fabricate :notice
     notification_service = Fabricate :hoiio_notification_service, app: notice.app
     problem = notice.problem
 
-    # hoi stubbing
     sms = double("HoiioService")
     allow(Hoi::SMS).to receive(:new).and_return(sms)
     allow(sms).to receive(:send).and_return(true)
 
-    # assert
     expect(sms).to receive(:send)
 
     notification_service.create_notification(problem)

--- a/spec/models/notification_service/hubot_service_spec.rb
+++ b/spec/models/notification_service/hubot_service_spec.rb
@@ -1,11 +1,11 @@
-describe NotificationServices::HubotService, type: "model" do
+require "rails_helper"
+
+RSpec.describe NotificationServices::HubotService, type: :model do
   it "it should send a notification to Hubot" do
-    # setup
     notice = Fabricate :notice
     notification_service = Fabricate :hubot_notification_service, app: notice.app
     problem = notice.problem
 
-    # faraday stubbing
     expect(HTTParty).to receive(:post).with(notification_service.api_token, body: {message: an_instance_of(String), room: notification_service.room_id}).and_return(true)
 
     notification_service.create_notification(problem)

--- a/spec/models/notification_service/pushover_service_spec.rb
+++ b/spec/models/notification_service/pushover_service_spec.rb
@@ -1,16 +1,15 @@
-describe NotificationServices::PushoverService, type: "model" do
+require "rails_helper"
+
+RSpec.describe NotificationServices::PushoverService, type: :model do
   it "it should send a notification to Pushover" do
-    # setup
     notice = Fabricate :notice
     notification_service = Fabricate :pushover_notification_service, app: notice.app
     problem = notice.problem
 
-    # hoi stubbing
     notification = double("PushoverService")
     allow(Rushover::Client).to receive(:new).and_return(notification)
     allow(notification).to receive(:notify).and_return(true)
 
-    # assert
     expect(notification).to receive(:notify)
 
     notification_service.create_notification(problem)

--- a/spec/models/notification_service/slack_service_spec.rb
+++ b/spec/models/notification_service/slack_service_spec.rb
@@ -1,4 +1,6 @@
-describe NotificationServices::SlackService, type: "model" do
+require "rails_helper"
+
+RSpec.describe NotificationServices::SlackService, type: :model do
   let(:backtrace) do
     Fabricate :backtrace, lines: [
       {number: 22, file: "/path/to/file/1.rb", method: "first_method"},
@@ -31,7 +33,6 @@ describe NotificationServices::SlackService, type: "model" do
     "```#{lines}```"
   end
 
-  # faraday stubbing
   let(:payload_hash) do
     {
       username: "Errbit",

--- a/spec/models/notification_service/webhook_service_spec.rb
+++ b/spec/models/notification_service/webhook_service_spec.rb
@@ -1,4 +1,6 @@
-describe NotificationServices::WebhookService, type: "model" do
+require "rails_helper"
+
+RSpec.describe NotificationServices::WebhookService, type: :model do
   it "it should send a notification to a user-specified URL" do
     notice = Fabricate :notice
     notification_service = Fabricate :webhook_notification_service, app: notice.app

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -1,4 +1,6 @@
-describe Problem, type: "model" do
+require "rails_helper"
+
+RSpec.describe Problem, type: :model do
   context "validations" do
     it "requires an environment" do
       err = Fabricate.build(:problem, environment: nil)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,6 @@
-describe User do
+require "rails_helper"
+
+RSpec.describe User, type: :model do
   context "validations" do
     it "require that a name is present" do
       user = Fabricate.build(:user, name: nil)

--- a/spec/models/watcher_spec.rb
+++ b/spec/models/watcher_spec.rb
@@ -1,4 +1,6 @@
-describe Watcher, type: "model" do
+require "rails_helper"
+
+RSpec.describe Watcher, type: :model do
   context "validations" do
     it "requires an email address or an associated user" do
       watcher = Fabricate.build(:watcher, email: nil, user: nil)

--- a/spec/requests/health_controller_spec.rb
+++ b/spec/requests/health_controller_spec.rb
@@ -1,4 +1,6 @@
-describe HealthController, type: "request" do
+require "rails_helper"
+
+RSpec.describe HealthController, type: :request do
   let(:errbit_app) { Fabricate(:app, api_key: "APIKEY") }
 
   describe "readiness" do

--- a/spec/requests/notices_controller_spec.rb
+++ b/spec/requests/notices_controller_spec.rb
@@ -1,4 +1,6 @@
-describe "Notices management", type: "request" do
+require "rails_helper"
+
+RSpec.describe "Notices management", type: :request do
   let(:errbit_app) { Fabricate(:app, api_key: "APIKEY") }
 
   describe "create a new notice" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,8 @@ Mongoid::Tasks::Database.create_indexes
 ActionMailer::Base.delivery_method = :test
 
 RSpec.configure do |config|
+  config.disable_monkey_patching!
+
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Mongoid::Matchers, type: :model
   config.alias_example_to :fit, focused: true
@@ -48,8 +50,6 @@ RSpec.configure do |config|
   config.before(:each, type: :decorator) do |_|
     Draper::ViewContext.current.class_eval { include Haml::Helpers }
   end
-
-  config.infer_spec_type_from_file_location!
 end
 
 OmniAuth.config.test_mode = true

--- a/spec/support/macros.rb
+++ b/spec/support/macros.rb
@@ -21,6 +21,7 @@ def it_requires_authentication(options = {})
     options[:for].each do |action, method|
       it "#{method.to_s.upcase} #{action} redirects to the sign in page" do
         send(method, action, params: {**options[:params]})
+
         expect(response).to redirect_to(new_user_session_path)
       end
     end
@@ -45,12 +46,14 @@ def it_requires_admin_privileges(options = {})
   context "when signed in as a regular user" do
     before do
       sign_out :user
+
       sign_in Fabricate(:user)
     end
 
     options[:for].each do |action, method|
       it "#{method.to_s.upcase} #{action} redirects to the root path" do
         send(method, action, params: {**options[:params]})
+
         expect(response).to redirect_to(root_path)
       end
     end

--- a/spec/views/apps/edit.html.haml_spec.rb
+++ b/spec/views/apps/edit.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "apps/edit.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "apps/edit.html.haml", type: :view do
   let(:app) { stub_model(App) }
   let(:app_decorate) { AppDecorator.new(app) }
 

--- a/spec/views/apps/new.html.haml_spec.rb
+++ b/spec/views/apps/new.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "apps/new.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "apps/new.html.haml", type: :view do
   let(:app) { stub_model(App) }
   let(:app_decorate) { AppDecorator.new(app) }
 

--- a/spec/views/apps/show.atom.builder_spec.rb
+++ b/spec/views/apps/show.atom.builder_spec.rb
@@ -1,4 +1,6 @@
-describe "apps/show.atom.builder", type: "view" do
+require "rails_helper"
+
+RSpec.describe "apps/show.atom.builder", type: :view do
   let(:notice) { Fabricate(:notice) }
   let(:app) { notice.app }
   let(:problems) { [notice.problem] }

--- a/spec/views/apps/show.html.haml_spec.rb
+++ b/spec/views/apps/show.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "apps/show.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "apps/show.html.haml", type: :view do
   let(:app) { stub_model(App) }
   let(:user) { stub_model(User) }
 

--- a/spec/views/issue_trackers/issue.md.erb_spec.rb
+++ b/spec/views/issue_trackers/issue.md.erb_spec.rb
@@ -1,4 +1,6 @@
-describe "issue_trackers/issue.md.erb", type: "view" do
+require "rails_helper"
+
+RSpec.describe "issue_trackers/issue.md.erb", type: :view do
   let(:problem) do
     problem = Fabricate(:problem)
     Fabricate(:notice, err: Fabricate(:err, problem: problem))

--- a/spec/views/issue_trackers/issue.txt.erb_spec.rb
+++ b/spec/views/issue_trackers/issue.txt.erb_spec.rb
@@ -1,4 +1,6 @@
-describe "issue_trackers/issue.txt.erb", type: "view" do
+require "rails_helper"
+
+RSpec.describe "issue_trackers/issue.txt.erb", type: :view do
   let(:problem) do
     problem = Fabricate(:problem)
     Fabricate(:notice, err: Fabricate(:err, problem: problem))

--- a/spec/views/notices/_summary.html.haml_spec.rb
+++ b/spec/views/notices/_summary.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "notices/_summary.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "notices/_summary.html.haml", type: :view do
   let(:notice) { Fabricate(:notice, framework: "Rails 3.2.11") }
 
   it "renders application framework" do

--- a/spec/views/notices/_user_attributes.html.haml_spec.rb
+++ b/spec/views/notices/_user_attributes.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "notices/_user_attributes.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "notices/_user_attributes.html.haml", type: :view do
   describe "autolink" do
     let(:notice) do
       user_attributes = {"foo" => {"bar" => "http://example.com"}}

--- a/spec/views/problems/index.atom.builder_spec.rb
+++ b/spec/views/problems/index.atom.builder_spec.rb
@@ -1,4 +1,6 @@
-describe "problems/index.atom.builder", type: "view" do
+require "rails_helper"
+
+RSpec.describe "problems/index.atom.builder", type: :view do
   it "display problem message" do
     app = App.new(new_record: false)
     allow(view).to receive(:problems).and_return([Problem.new(

--- a/spec/views/problems/index.html.haml_spec.rb
+++ b/spec/views/problems/index.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "problems/index.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "problems/index.html.haml", type: :view do
   let(:problem_1) { Fabricate(:problem) }
   let(:problem_2) { Fabricate(:problem, app: problem_1.app) }
 

--- a/spec/views/problems/show.html.haml_spec.rb
+++ b/spec/views/problems/show.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "problems/show.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "problems/show.html.haml", type: :view do
   let(:problem) { Fabricate(:problem) }
   let(:comment) { Fabricate(:comment) }
   let(:pivotal_tracker) do

--- a/spec/views/problems/show.ics.haml_spec.rb
+++ b/spec/views/problems/show.ics.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "problems/show.html.ics", type: "view" do
+require "rails_helper"
+
+RSpec.describe "problems/show.html.ics", type: :view do
   let(:problem) { ProblemDecorator.new(Fabricate(:problem)) }
 
   before do

--- a/spec/views/users/edit.html.haml_spec.rb
+++ b/spec/views/users/edit.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "users/edit.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "users/edit.html.haml", type: :view do
   let(:user) { stub_model(User, name: "shingara") }
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/users/index.html.haml_spec.rb
+++ b/spec/views/users/index.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "users/index.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "users/index.html.haml", type: :view do
   let(:user) { stub_model(User) }
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/users/new.html.haml_spec.rb
+++ b/spec/views/users/new.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "users/new.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "users/new.html.haml", type: :view do
   let(:user) { stub_model(User) }
   before do
     allow(view).to receive(:current_user).and_return(user)

--- a/spec/views/users/show.html.haml_spec.rb
+++ b/spec/views/users/show.html.haml_spec.rb
@@ -1,4 +1,6 @@
-describe "users/show.html.haml", type: "view" do
+require "rails_helper"
+
+RSpec.describe "users/show.html.haml", type: :view do
   let(:user) do
     stub_model(User, created_at: Time.zone.now, email: "test@example.com")
   end


### PR DESCRIPTION
Changes:

1. Add `spec/rails_helper` to follow RSpec convention
2. Add `require "spec/rails_helper"` to all tests
3. RSpec: remove `config.infer_spec_type_from_file_location!` and properly set `:type` for all tests
4. RSpec: add `config.disable_monkey_patching!` and add `RSpec.` to all `describe` calls
5. Remove useless `if defined? Campy` from `app/models/notification_services/campfire_service.rb`
6. Properly namespace `app/models/notification_services/gtalk_service.rb`
7. Properly namespace `app/models/notification_services/hoiio_service.rb`
8. Properly namespace `app/models/notification_services/hubot_service.rb`
9. Properly namespace `app/models/notification_services/pushover_service.rb`
10. Properly namespace `app/models/notification_services/slack_service.rb`
11. Properly namespace `app/models/notification_services/webhook_service.rb`
12. Indent `app/assets/stylesheets/mailers/mailer.css`
