### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -29,15 +29,11 @@ jobs:
           bundler: "latest"
           bundler-cache: true
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.12.0
         with:
+          # Here we are using an image from Amazon's ECR rather than the default image from Docker Hub
+          mongodb-image: "public.ecr.aws/docker/library/mongo"
           mongodb-version: ${{ matrix.mongodb-version }}
 
       - run: bundle exec rails zeitwerk:check


### PR DESCRIPTION
DockerHub rate limiting pulls to 10 for unauthorised users and we hit this limit while running tests on GitHub Actions.

I try solve this puzzle with docker login in tests, but this is not working. PR's from e.g. dependabot can't access secrets and docker login not works.

This is second try to fix this issue. I remove docker login and change registry from docker hub to public amazon. They are don't rate limiting pulls.

Let's see if it works.