### PR TITLE
Rails 7.1.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "7.0.8.7"
+gem "rails", "7.1.5.1"
 
 gem "sprockets-rails"
 gem "activemodel-serializers-xml"

--- a/Gemfile
+++ b/Gemfile
@@ -121,9 +121,6 @@ gem "underscore-rails"
 
 gem "sucker_punch"
 
-# https://stackoverflow.com/questions/79360526/uninitialized-constant-activesupportloggerthreadsafelevellogger-nameerror
-gem "concurrent-ruby", "1.3.4"
-
 # Lock zeitwerk gem for support JRuby 9.4
 gem "zeitwerk", "2.6.18"
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,14 +29,6 @@ gem "rails_autolink"
 gem "useragent"
 gem "uri"
 
-# ~/.rbenv/versions/3.3.7/lib/ruby/gems/3.3.0/gems/activesupport-6.1.7.10/lib/active_support/dependencies.rb:299: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
-# You can add mutex_m to your Gemfile or gemspec to silence this warning.
-# Also please contact the author of activesupport-6.1.7.10 to request adding mutex_m into its gemspec.
-# ~/.rbenv/versions/3.3.7/lib/ruby/gems/3.3.0/gems/activesupport-6.1.7.10/lib/active_support/testing/parallelization.rb:3: warning: drb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
-# You can add drb to your Gemfile or gemspec to silence this warning.
-gem "mutex_m"
-gem "drb"
-
 # ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-6.1.7.10/lib/active_support/dependencies.rb:299: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
 # You can add benchmark to your Gemfile or gemspec to silence this warning.
 # Also please contact the author of activesupport-6.1.7.10 to request adding benchmark into its gemspec.

--- a/Gemfile
+++ b/Gemfile
@@ -29,18 +29,9 @@ gem "rails_autolink"
 gem "useragent"
 gem "uri"
 
-# ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-6.1.7.10/lib/active_support/dependencies.rb:299: warning: benchmark was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
-# You can add benchmark to your Gemfile or gemspec to silence this warning.
-# Also please contact the author of activesupport-6.1.7.10 to request adding benchmark into its gemspec.
-# ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/activesupport-6.1.7.10/lib/active_support/dependencies.rb:299: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
+# ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/mongoid-9.0.6/lib/mongoid/indexable.rb:6: warning: ~/.rbenv/versions/3.4.2/lib/ruby/3.4.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
 # You can add ostruct to your Gemfile or gemspec to silence this warning.
-# Also please contact the author of mongoid-9.0.6 to request adding ostruct into its gemspec.
-gem "benchmark"
 gem "ostruct"
-
-# ~/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/railties-7.0.8.7/lib/rails/commands/console/console_command.rb:3: warning: /Users/biow0lf/.rbenv/versions/3.4.2/lib/ruby/3.4.0/irb.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
-# You can add irb to your Gemfile or gemspec to silence this warning.
-gem "irb"
 
 # Please don't update hoptoad_notifier to airbrake.
 # It's for internal use only, and we monkeypatch certain methods

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -666,7 +666,6 @@ DEPENDENCIES
   devise
   dotenv-rails
   draper
-  drb
   email_spec
   errbit_github_plugin
   errbit_plugin
@@ -688,7 +687,6 @@ DEPENDENCIES
   listen (~> 3.5)
   mongoid
   mongoid-rspec
-  mutex_m
   octokit
   omniauth
   omniauth-github

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -654,7 +654,6 @@ DEPENDENCIES
   actionmailer_inline_css
   activemodel-serializers-xml
   airbrake (~> 4.3.5)
-  benchmark
   bigdecimal (= 3.1.9)
   bootsnap (>= 1.4.4)
   brakeman
@@ -677,7 +676,6 @@ DEPENDENCIES
   hoptoad_notifier!
   htmlentities
   httparty
-  irb
   jquery-rails
   json
   kaminari

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -661,7 +661,6 @@ DEPENDENCIES
   bundler-audit
   campy
   capybara
-  concurrent-ruby (= 1.3.4)
   decent_exposure
   devise
   dotenv-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,78 +10,90 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    actioncable (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activestorage (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activestorage (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       mail (>= 2.7.1)
       net-imap
       net-pop
       net-smtp
-    actionmailer (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      actionview (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    actionmailer (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      actionview (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       mail (~> 2.5, >= 2.5.4)
       net-imap
       net-pop
       net-smtp
-      rails-dom-testing (~> 2.0)
+      rails-dom-testing (~> 2.2)
     actionmailer_inline_css (1.6.0)
       actionmailer (>= 3.0.0)
       nokogiri (>= 1.7.0)
       premailer (>= 1.11.0)
-    actionpack (7.0.8.7)
-      actionview (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
-      rack (~> 2.0, >= 2.2.4)
+    actionpack (7.1.5.1)
+      actionview (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      nokogiri (>= 1.8.5)
+      racc
+      rack (>= 2.2.4)
+      rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actiontext (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activestorage (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    actiontext (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activestorage (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       globalid (>= 0.6.0)
       nokogiri (>= 1.8.5)
-    actionview (7.0.8.7)
-      activesupport (= 7.0.8.7)
+    actionview (7.1.5.1)
+      activesupport (= 7.1.5.1)
       builder (~> 3.1)
-      erubi (~> 1.4)
-      rails-dom-testing (~> 2.0)
-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (7.0.8.7)
-      activesupport (= 7.0.8.7)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activejob (7.1.5.1)
+      activesupport (= 7.1.5.1)
       globalid (>= 0.3.6)
-    activemodel (7.0.8.7)
-      activesupport (= 7.0.8.7)
+    activemodel (7.1.5.1)
+      activesupport (= 7.1.5.1)
     activemodel-serializers-xml (1.0.3)
       activemodel (>= 5.0.0.a)
       activesupport (>= 5.0.0.a)
       builder (~> 3.1)
-    activerecord (7.0.8.7)
-      activemodel (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
-    activestorage (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    activerecord (7.1.5.1)
+      activemodel (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      timeout (>= 0.4.0)
+    activestorage (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       marcel (~> 1.0)
-      mini_mime (>= 1.1.0)
-    activesupport (7.0.8.7)
+    activesupport (7.1.5.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
       minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
       tzinfo (~> 2.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
@@ -120,6 +132,7 @@ GEM
       logger (~> 1.5)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
+    connection_pool (2.5.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -388,26 +401,32 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     racc (1.8.1-java)
-    rack (2.2.13)
-    rack-protection (3.2.0)
+    rack (3.1.12)
+    rack-protection (4.1.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rails (7.0.8.7)
-      actioncable (= 7.0.8.7)
-      actionmailbox (= 7.0.8.7)
-      actionmailer (= 7.0.8.7)
-      actionpack (= 7.0.8.7)
-      actiontext (= 7.0.8.7)
-      actionview (= 7.0.8.7)
-      activejob (= 7.0.8.7)
-      activemodel (= 7.0.8.7)
-      activerecord (= 7.0.8.7)
-      activestorage (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
+    rackup (2.2.1)
+      rack (>= 3)
+    rails (7.1.5.1)
+      actioncable (= 7.1.5.1)
+      actionmailbox (= 7.1.5.1)
+      actionmailer (= 7.1.5.1)
+      actionpack (= 7.1.5.1)
+      actiontext (= 7.1.5.1)
+      actionview (= 7.1.5.1)
+      activejob (= 7.1.5.1)
+      activemodel (= 7.1.5.1)
+      activerecord (= 7.1.5.1)
+      activestorage (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
       bundler (>= 1.15.0)
-      railties (= 7.0.8.7)
+      railties (= 7.1.5.1)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
@@ -423,13 +442,14 @@ GEM
       actionview (> 3.1)
       activesupport (> 3.1)
       railties (> 3.1)
-    railties (7.0.8.7)
-      actionpack (= 7.0.8.7)
-      activesupport (= 7.0.8.7)
-      method_source
+    railties (7.1.5.1)
+      actionpack (= 7.1.5.1)
+      activesupport (= 7.1.5.1)
+      irb
+      rackup (>= 1.0.0)
       rake (>= 12.2)
-      thor (~> 1.0)
-      zeitwerk (~> 2.5)
+      thor (~> 1.0, >= 1.2.2)
+      zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
@@ -535,6 +555,7 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    securerandom (0.4.1)
     selenium-webdriver (4.31.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -677,7 +698,7 @@ DEPENDENCIES
   pjax_rails
   pry-rails
   puma
-  rails (= 7.0.8.7)
+  rails (= 7.1.5.1)
   rails-controller-testing
   rails_autolink
   rake
@@ -713,19 +734,19 @@ DEPENDENCIES
   zeitwerk (= 2.6.18)
 
 CHECKSUMS
-  actioncable (7.0.8.7) sha256=4034513841df2fd09dbbf38f37c1a00fc6c841122a8714e5d6916b8d6ce2f162
-  actionmailbox (7.0.8.7) sha256=940eeaa3d8e85dcd9fc6069e39571e13c5a4bdb0db52c7ab96d14da81d6ac1c2
-  actionmailer (7.0.8.7) sha256=8be8f9a2f8774af89822bc92e1ab6df10b3a2be59c75486a34e86a1f10d88d14
+  actioncable (7.1.5.1) sha256=764637b5b2d97b94e412d562c177bfd16b0fd769d55c98846362f5263e8aaa0d
+  actionmailbox (7.1.5.1) sha256=c3c20589fe43e6fa88bba2d76a6f9805ffdd02531f4a9a4af8197d59f5a5360a
+  actionmailer (7.1.5.1) sha256=b213d6d880b23b093ccfef3b4f87a3d27e4666442f71b5b634b2d19e19a49759
   actionmailer_inline_css (1.6.0) sha256=b763306c37bf79f9e46b67b5e3cca261b42a0457f0fb05ca1b850f9aef0f5450
-  actionpack (7.0.8.7) sha256=40e6b1d687904a4fd2285d1fa3aad3d9a9d9ba8fd8858dd0faa9f4673c3f5e2c
-  actiontext (7.0.8.7) sha256=cb75d2db97d5b2c8caccdc0f643541df36c2c53f076a2d49b226f971d8d528a0
-  actionview (7.0.8.7) sha256=be975bc9c61903fe5da80a97c345271159033bcbba63988c7f27b6b8b98f7fed
-  activejob (7.0.8.7) sha256=eff4db3aeaee34863a47570089d11d5577ed0ea42b1475dc9be6a413be182a20
-  activemodel (7.0.8.7) sha256=f13b04bb055c1e85b965ce40b0a2e671b8d97835083597bc7fbc04cde0f40a83
+  actionpack (7.1.5.1) sha256=2bc263d9f43f16cc3b3360f59659ab11f140577602f371f1a968e2672b38d718
+  actiontext (7.1.5.1) sha256=b8e261cfad5bc6a78b3f15be5e7c7f32190041b3dc6f027a3a353b4392d2f7ec
+  actionview (7.1.5.1) sha256=8c559a213501798e29b50b5341a643a70bbf6fa0aa2abaf571d0efc59dc4f6aa
+  activejob (7.1.5.1) sha256=7633376c857f4c491d06b5a7f5d86d9f07afc595398354a3f1abe80eb7e35767
+  activemodel (7.1.5.1) sha256=74727466854a7fbdfe8f2702ca3112b23877500d4926bf7e02e921ad542191f1
   activemodel-serializers-xml (1.0.3) sha256=fa1b16305e7254cc58a59c68833e3c0a593a59c8ab95d3be5aaea7cd9416c397
-  activerecord (7.0.8.7) sha256=f94fc8510e58a18e462c5ee8862c9be75e2bfad0688e8d022b86a6e05df2a45a
-  activestorage (7.0.8.7) sha256=ca411e73733a50983f44b0945bfd0612313beb3a8f914cd3a88e4fcd99399ef5
-  activesupport (7.0.8.7) sha256=df4702375de924aae81709c831605317c5417f0bd9e502a0373ff84a067204ff
+  activerecord (7.1.5.1) sha256=f40ad1609bf33b9ba5bdc4e16d80a77b1517153234ceb413d31d635d7b91f1e3
+  activestorage (7.1.5.1) sha256=ae6b8b076858c666eaad6f896d786b67654235e861e24a83f61f1cc97b43ff63
+  activesupport (7.1.5.1) sha256=9f0c482e473b9868cb3dfe3e9db549a3bd2302c02e4f595a5caac144a8c7cfb8
   addressable (2.8.7) sha256=462986537cf3735ab5f3c0f557f14155d778f4b43ea4f485a9deb9c8f7c58232
   airbrake (4.3.8) sha256=d06947194f5dcd7e192c28067f2c47728511d75326c17045094c3a0b84f68c2d
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
@@ -747,6 +768,7 @@ CHECKSUMS
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.4) sha256=d4aa926339b0a86b5b5054a0a8c580163e6f5dcbdfd0f4bb916b1a2570731c32
+  connection_pool (2.5.0) sha256=233b92f8d38e038c1349ccea65dd3772727d669d6d2e71f9897c8bf5cd53ebfc
   crack (1.0.0) sha256=c83aefdb428cdc7b66c7f287e488c796f055c0839e6e545fec2c7047743c4a49
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   css_parser (1.21.1) sha256=6cfd3ffc0a97333b39d2b1b49c95397b05e0e3b684d68f77ec471ba4ec2ef7c7
@@ -878,15 +900,17 @@ CHECKSUMS
   puma (6.6.0-java) sha256=707623ea7a5e4cfb8badb60f192fed6ae66d8c25d28737ebc684437d6fda08ce
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   racc (1.8.1-java) sha256=54f2e6d1e1b91c154013277d986f52a90e5ececbe91465d29172e49342732b98
-  rack (2.2.13) sha256=ccee101719696a5da12ee9da6fb3b1d20cb329939e089e0e458be6e93667f0fb
-  rack-protection (3.2.0) sha256=3c74ba7fc59066453d61af9bcba5b6fe7a9b3dab6f445418d3b391d5ea8efbff
+  rack (3.1.12) sha256=00d83055c89273eb13679ab562767b8826955aa6c4371d7d161deb975c50c540
+  rack-protection (4.1.1) sha256=51a254a5d574a7f0ca4f0672025ce2a5ef7c8c3bd09c431349d683e825d7d16a
+  rack-session (2.1.0) sha256=437c3916535b58ef71c816ce4a2dee0a01c8a52ae6077dc2b6cd19085760a290
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
-  rails (7.0.8.7) sha256=5e67ed4dd915746349bfb8c7ae2f531d3a36eb68fbe2f60ede02a0500715cded
+  rackup (2.2.1) sha256=f737191fd5c5b348b7f0a4412a3b86383f88c43e13b8217b63d4c8d90b9e798d
+  rails (7.1.5.1) sha256=05aea2ed7b6392b41ce0fc11455de118455025a431b6ea334a7ac2b101608804
   rails-controller-testing (1.0.5) sha256=741448db59366073e86fc965ba403f881c636b79a2c39a48d0486f2607182e94
   rails-dom-testing (2.2.0) sha256=e515712e48df1f687a1d7c380fd7b07b8558faa26464474da64183a7426fa93b
   rails-html-sanitizer (1.6.2) sha256=35fce2ca8242da8775c83b6ba9c1bcaad6751d9eb73c1abaa8403475ab89a560
   rails_autolink (1.1.8) sha256=fbcb9d2e5f2cea9435a32e5f12556c7a9b7ed6867889fb9cf5eac405049bfc3a
-  railties (7.0.8.7) sha256=1ab985280b02bc4b176d36e1011148db600b763c646e3de88c02a665d864505f
+  railties (7.1.5.1) sha256=0be15562e2ded4efdc1b6c30f884b6d838c9ba49573dde042334b752b043e2fb
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
@@ -924,6 +948,7 @@ CHECKSUMS
   rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   rushover (0.3.0) sha256=8490d0f8fc0421d774122ac0f299bb4c1dc3bf482cd759df5ed635965b30dd48
   sawyer (0.9.2) sha256=fa3a72d62a4525517b18857ddb78926aab3424de0129be6772a8e2ba240e7aca
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.31.0) sha256=ddb2d88eee23cddb5d6a9dadd909427a9e5163718338e11a91eef2fbead100e9
   simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
   simplecov-html (0.13.1) sha256=5dab0b7ee612e60e9887ad57693832fdf4695b4c0c859eaea5f95c18791ef10b

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,10 +2,19 @@
 
 require_relative "boot"
 
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_job/railtie"
+# require "active_record/railtie"
+# require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-# require 'mongoid/railtie'
-require "sprockets/railtie"
+# require "action_mailbox/engine"
+# require "action_text/engine"
+require "action_view/railtie"
+# require "action_cable/engine"
+# require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -16,9 +25,18 @@ module Errbit
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    # Please, add to the `ignore` list any other `lib` subdirectories that do
+    # not contain `.rb` files, or that should not be reloaded or eager loaded.
+    # Common ones are `templates`, `generators`, or `middleware`, for example.
+    config.autoload_lib(ignore: ["assets", "tasks"])
+
+    # Configuration for the application, engines, and railties goes here.
+    #
+    # These settings can be overridden in specific environments using the files
+    # in config/environments, which are processed later.
+    #
+    # config.time_zone = "Central Time (US & Canada)"
+    # config.eager_load_paths << Rails.root.join("extras")
 
     # Custom directories with classes and modules you want to eager load.
     config.eager_load_paths << Rails.root.join("lib").to_s
@@ -30,14 +48,6 @@ module Errbit
     initializer "errbit.mongoid", before: "mongoid.load-config" do
       require Rails.root.join("config/mongo")
     end
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
 
     # > rails generate - config
     config.generators do |g|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -49,6 +49,9 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
+
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
@@ -62,6 +65,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # Uncomment if you wish to allow Action Cable access from any origin.
-  # config.action_cable.disable_request_forgery_protection = true
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,18 +45,24 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  # Log to STDOUT by default
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
+
+  # "info" includes generic and useful information about system operation, but avoids logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
+  # want to log everything, set the level to "debug".
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "errbit_production"
 
   config.action_mailer.perform_caching = false
@@ -72,16 +78,11 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  # config.hosts = [
+  #   "example.com",     # Allow requests from example.com
+  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
+  # ]
+  # Skip DNS rebinding protection for the default health check endpoint.
+  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,18 +18,17 @@ Rails.application.configure do
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
+  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
+  # config.public_file_server.enabled = false
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  # Do not fall back to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
@@ -38,6 +37,10 @@ Rails.application.configure do
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
+
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,4 +56,7 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,12 +10,13 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = true
+  # While tests run files are not watched, reloading is not necessary.
+  config.enable_reloading = false
 
-  # Eager loading loads your whole application. When running a single test locally,
-  # this probably isn't necessary. It's a good idea to do in a continuous integration
-  # system, or in some way before deploying your code.
+  # Eager loading loads your entire application. When running a single test locally,
+  # this is usually not necessary, and can slow down your test suite. However, it's
+  # recommended that you enable it in continuous integration systems to ensure eager
+  # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
@@ -29,8 +30,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  # Render exception templates for rescuable exceptions and raise for other exceptions.
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -18,9 +18,9 @@
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end
 #
-#   # Generate session nonces for permitted importmap and inline scripts
+#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
+#   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #
 #   # Report violations without enforcing the policy.
 #   # config.content_security_policy_report_only = true

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,9 +2,9 @@
 
 # Be sure to restart your server when you modify this file.
 
-# Configure parameters to be filtered from the log file. Use this to limit dissemination of
-# sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
-# notations and behaviors.
+# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
+# Use this to limit dissemination of sensitive information.
+# See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
 ]

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -1,0 +1,280 @@
+# Be sure to restart your server when you modify this file.
+#
+# This file eases your Rails 7.1 framework defaults upgrade.
+#
+# Uncomment each configuration one by one to switch to the new default.
+# Once your application is ready to run with all new defaults, you can remove
+# this file and set the `config.load_defaults` to `7.1`.
+#
+# Read the Guide for Upgrading Ruby on Rails for more info on each option.
+# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
+
+###
+# No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
+# to manually require files that are managed by the autoloader, which you shouldn't do anyway.
+#
+# This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
+# of the bootsnap cache if you use it.
+#
+# To set this configuration, add the following line to `config/application.rb` (NOT this file):
+#   config.add_autoload_paths_to_load_path = false
+
+###
+# Remove the default X-Download-Options headers since it is used only by Internet Explorer.
+# If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
+#++
+# Rails.application.config.action_dispatch.default_headers = {
+#   "X-Frame-Options" => "SAMEORIGIN",
+#   "X-XSS-Protection" => "0",
+#   "X-Content-Type-Options" => "nosniff",
+#   "X-Permitted-Cross-Domain-Policies" => "none",
+#   "Referrer-Policy" => "strict-origin-when-cross-origin"
+# }
+
+###
+# Do not treat an `ActionController::Parameters` instance
+# as equal to an equivalent `Hash` by default.
+#++
+# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+
+###
+# Active Record Encryption now uses SHA-256 as its hash digest algorithm.
+#
+# There are 3 scenarios to consider.
+#
+# 1. If you have data encrypted with previous Rails versions, and you have
+# +config.active_support.key_generator_hash_digest_class+ configured as SHA1 (the default
+# before Rails 7.0), you need to configure SHA-1 for Active Record Encryption too:
+#++
+# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
+#
+# 2. If you have +config.active_support.key_generator_hash_digest_class+ configured as SHA256 (the new default
+# in 7.0), then you need to configure SHA-256 for Active Record Encryption:
+#++
+# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
+#
+# 3. If you don't currently have data encrypted with Active Record encryption, you can disable this setting to
+# configure the default behavior starting 7.1+:
+#++
+# Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false
+
+###
+# No longer run after_commit callbacks on the first of multiple Active Record
+# instances to save changes to the same database row within a transaction.
+# Instead, run these callbacks on the instance most likely to have internal
+# state which matches what was committed to the database, typically the last
+# instance to save.
+#++
+# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+
+###
+# Configures SQLite with a strict strings mode, which disables double-quoted string literals.
+#
+# SQLite has some quirks around double-quoted string literals.
+# It first tries to consider double-quoted strings as identifier names, but if they don't exist
+# it then considers them as string literals. Because of this, typos can silently go unnoticed.
+# For example, it is possible to create an index for a non existing column.
+# See https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted for more details.
+#++
+# Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
+
+###
+# Disable deprecated singular associations names.
+#++
+# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
+
+###
+# Enable the Active Job `BigDecimal` argument serializer, which guarantees
+# roundtripping. Without this serializer, some queue adapters may serialize
+# `BigDecimal` arguments as simple (non-roundtrippable) strings.
+#
+# When deploying an application with multiple replicas, old (pre-Rails 7.1)
+# replicas will not be able to deserialize `BigDecimal` arguments from this
+# serializer. Therefore, this setting should only be enabled after all replicas
+# have been successfully upgraded to Rails 7.1.
+#++
+# Rails.application.config.active_job.use_big_decimal_serializer = true
+
+###
+# Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
+# `write` are given an invalid `expires_at` or `expires_in` time.
+# Options are `true`, and `false`. If `false`, the exception will be reported
+# as `handled` and logged instead.
+#++
+# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+
+###
+# Specify whether Query Logs will format tags using the SQLCommenter format
+# (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
+# Options are `:legacy` and `:sqlcommenter`.
+#++
+# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+
+###
+# Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
+# instances.
+#
+# The legacy default is `:marshal`, which is a potential vector for
+# deserialization attacks in cases where a message signing secret has been
+# leaked.
+#
+# In Rails 7.1, the new default is `:json_allow_marshal` which serializes and
+# deserializes with `ActiveSupport::JSON`, but can fall back to deserializing
+# with `Marshal` so that legacy messages can still be read.
+#
+# In Rails 7.2, the default will become `:json` which serializes and
+# deserializes with `ActiveSupport::JSON` only.
+#
+# Alternatively, you can choose `:message_pack` or `:message_pack_allow_marshal`,
+# which serialize with `ActiveSupport::MessagePack`. `ActiveSupport::MessagePack`
+# can roundtrip some Ruby types that are not supported by JSON, and may provide
+# improved performance, but it requires the `msgpack` gem.
+#
+# For more information, see
+# https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer
+#
+# If you are performing a rolling deploy of a Rails 7.1 upgrade, wherein servers
+# that have not yet been upgraded must be able to read messages from upgraded
+# servers, first deploy without changing the serializer, then set the serializer
+# in a subsequent deploy.
+#++
+# Rails.application.config.active_support.message_serializer = :json_allow_marshal
+
+###
+# Enable a performance optimization that serializes message data and metadata
+# together. This changes the message format, so messages serialized this way
+# cannot be read by older versions of Rails. However, messages that use the old
+# format can still be read, regardless of whether this optimization is enabled.
+#
+# To perform a rolling deploy of a Rails 7.1 upgrade, wherein servers that have
+# not yet been upgraded must be able to read messages from upgraded servers,
+# leave this optimization off on the first deploy, then enable it on a
+# subsequent deploy.
+#++
+# Rails.application.config.active_support.use_message_serializer_for_metadata = true
+
+###
+# Set the maximum size for Rails log files.
+#
+# `config.load_defaults 7.1` does not set this value for environments other than
+# development and test.
+#++
+# if Rails.env.local?
+#   Rails.application.config.log_file_size = 100 * 1024 * 1024
+# end
+
+###
+# Enable raising on assignment to attr_readonly attributes. The previous
+# behavior would allow assignment but silently not persist changes to the
+# database.
+#++
+# Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
+
+###
+# Enable validating only parent-related columns for presence when the parent is mandatory.
+# The previous behavior was to validate the presence of the parent record, which performed an extra query
+# to get the parent every time the child record was updated, even when parent has not changed.
+#++
+# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+
+###
+# Enable precompilation of `config.filter_parameters`. Precompilation can
+# improve filtering performance, depending on the quantity and types of filters.
+#++
+# Rails.application.config.precompile_filter_parameters = true
+
+###
+# Enable before_committed! callbacks on all enrolled records in a transaction.
+# The previous behavior was to only run the callbacks on the first copy of a record
+# if there were multiple copies of the same record enrolled in the transaction.
+#++
+# Rails.application.config.active_record.before_committed_on_all_records = true
+
+###
+# Disable automatic column serialization into YAML.
+# To keep the historic behavior, you can set it to `YAML`, however it is
+# recommended to explicitly define the serialization method for each column
+# rather than to rely on a global default.
+#++
+# Rails.application.config.active_record.default_column_serializer = nil
+
+###
+# Enable a performance optimization that serializes Active Record models
+# in a faster and more compact way.
+#
+# To perform a rolling deploy of a Rails 7.1 upgrade, wherein servers that have
+# not yet been upgraded must be able to read caches from upgraded servers,
+# leave this optimization off on the first deploy, then enable it on a
+# subsequent deploy.
+#++
+# Rails.application.config.active_record.marshalling_format_version = 7.1
+
+###
+# Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.
+# This matches the behaviour of all other callbacks.
+# In previous versions of Rails, they ran in the inverse order.
+#++
+# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+
+###
+# Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
+#++
+# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
+
+###
+# Controls when to generate a value for <tt>has_secure_token</tt> declarations.
+#++
+# Rails.application.config.active_record.generate_secure_token_on = :initialize
+
+###
+# ** Please read carefully, this must be configured in config/application.rb **
+#
+# Change the format of the cache entry.
+#
+# Changing this default means that all new cache entries added to the cache
+# will have a different format that is not supported by Rails 7.0
+# applications.
+#
+# Only change this value after your application is fully deployed to Rails 7.1
+# and you have no plans to rollback.
+# When you're ready to change format, add this to `config/application.rb` (NOT
+# this file):
+#   config.active_support.cache_format_version = 7.1
+
+###
+# Configure Action View to use HTML5 standards-compliant sanitizers when they are supported on your
+# platform.
+#
+# `Rails::HTML::Sanitizer.best_supported_vendor` will cause Action View to use HTML5-compliant
+# sanitizers if they are supported, else fall back to HTML4 sanitizers.
+#
+# In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
+#++
+# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+
+###
+# Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your
+# platform.
+#
+# `Rails::HTML::Sanitizer.best_supported_vendor` will cause Action Text to use HTML5-compliant
+# sanitizers if they are supported, else fall back to HTML4 sanitizers.
+#
+# In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
+#++
+# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+
+###
+# Configure the log level used by the DebugExceptions middleware when logging
+# uncaught exceptions during requests.
+#++
+# Rails.application.config.action_dispatch.debug_exception_log_level = :error
+
+###
+# Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5
+# parsers.
+#
+# Nokogiri::HTML5 isn't supported on JRuby, so JRuby applications must set this to :html4.
+#
+# In previous versions of Rails, these test helpers always used an HTML4 parser.
+#++
+# Rails.application.config.dom_testing_default_html_version = :html5

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -3,27 +3,6 @@
 # this file and set the `config.load_defaults` to `7.1`.
 
 ###
-# Active Record Encryption now uses SHA-256 as its hash digest algorithm.
-#
-# There are 3 scenarios to consider.
-#
-# 1. If you have data encrypted with previous Rails versions, and you have
-# +config.active_support.key_generator_hash_digest_class+ configured as SHA1 (the default
-# before Rails 7.0), you need to configure SHA-1 for Active Record Encryption too:
-#++
-# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA1
-#
-# 2. If you have +config.active_support.key_generator_hash_digest_class+ configured as SHA256 (the new default
-# in 7.0), then you need to configure SHA-256 for Active Record Encryption:
-#++
-# Rails.application.config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
-#
-# 3. If you don't currently have data encrypted with Active Record encryption, you can disable this setting to
-# configure the default behavior starting 7.1+:
-#++
-# Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false
-
-###
 # No longer run after_commit callbacks on the first of multiple Active Record
 # instances to save changes to the same database row within a transaction.
 # Instead, run these callbacks on the instance most likely to have internal

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -1,41 +1,6 @@
-# Be sure to restart your server when you modify this file.
-#
-# This file eases your Rails 7.1 framework defaults upgrade.
-#
 # Uncomment each configuration one by one to switch to the new default.
 # Once your application is ready to run with all new defaults, you can remove
 # this file and set the `config.load_defaults` to `7.1`.
-#
-# Read the Guide for Upgrading Ruby on Rails for more info on each option.
-# https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
-
-###
-# No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
-# to manually require files that are managed by the autoloader, which you shouldn't do anyway.
-#
-# This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
-# of the bootsnap cache if you use it.
-#
-# To set this configuration, add the following line to `config/application.rb` (NOT this file):
-#   config.add_autoload_paths_to_load_path = false
-
-###
-# Remove the default X-Download-Options headers since it is used only by Internet Explorer.
-# If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
-#++
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
-
-###
-# Do not treat an `ActionController::Parameters` instance
-# as equal to an equivalent `Hash` by default.
-#++
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 ###
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -3,31 +3,6 @@
 # this file and set the `config.load_defaults` to `7.1`.
 
 ###
-# No longer run after_commit callbacks on the first of multiple Active Record
-# instances to save changes to the same database row within a transaction.
-# Instead, run these callbacks on the instance most likely to have internal
-# state which matches what was committed to the database, typically the last
-# instance to save.
-#++
-# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
-
-###
-# Configures SQLite with a strict strings mode, which disables double-quoted string literals.
-#
-# SQLite has some quirks around double-quoted string literals.
-# It first tries to consider double-quoted strings as identifier names, but if they don't exist
-# it then considers them as string literals. Because of this, typos can silently go unnoticed.
-# For example, it is possible to create an index for a non existing column.
-# See https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted for more details.
-#++
-# Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default = true
-
-###
-# Disable deprecated singular associations names.
-#++
-# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
-
-###
 # Enable the Active Job `BigDecimal` argument serializer, which guarantees
 # roundtripping. Without this serializer, some queue adapters may serialize
 # `BigDecimal` arguments as simple (non-roundtrippable) strings.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -83,12 +83,6 @@
 # Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 ###
-# Configure the log level used by the DebugExceptions middleware when logging
-# uncaught exceptions during requests.
-#++
-Rails.application.config.action_dispatch.debug_exception_log_level = :error
-
-###
 # Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5
 # parsers.
 #

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -46,34 +46,6 @@
 # Rails.application.config.active_support.use_message_serializer_for_metadata = true
 
 ###
-# Enable a performance optimization that serializes Active Record models
-# in a faster and more compact way.
-#
-# To perform a rolling deploy of a Rails 7.1 upgrade, wherein servers that have
-# not yet been upgraded must be able to read caches from upgraded servers,
-# leave this optimization off on the first deploy, then enable it on a
-# subsequent deploy.
-#++
-# Rails.application.config.active_record.marshalling_format_version = 7.1
-
-###
-# Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.
-# This matches the behaviour of all other callbacks.
-# In previous versions of Rails, they ran in the inverse order.
-#++
-# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
-
-###
-# Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
-#++
-# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
-
-###
-# Controls when to generate a value for <tt>has_secure_token</tt> declarations.
-#++
-# Rails.application.config.active_record.generate_secure_token_on = :initialize
-
-###
 # ** Please read carefully, this must be configured in config/application.rb **
 #
 # Change the format of the cache entry.
@@ -114,7 +86,7 @@
 # Configure the log level used by the DebugExceptions middleware when logging
 # uncaught exceptions during requests.
 #++
-# Rails.application.config.action_dispatch.debug_exception_log_level = :error
+Rails.application.config.action_dispatch.debug_exception_log_level = :error
 
 ###
 # Configure the test helpers in Action View, Action Dispatch, and rails-dom-testing to use HTML5

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -3,33 +3,6 @@
 # this file and set the `config.load_defaults` to `7.1`.
 
 ###
-# Enable the Active Job `BigDecimal` argument serializer, which guarantees
-# roundtripping. Without this serializer, some queue adapters may serialize
-# `BigDecimal` arguments as simple (non-roundtrippable) strings.
-#
-# When deploying an application with multiple replicas, old (pre-Rails 7.1)
-# replicas will not be able to deserialize `BigDecimal` arguments from this
-# serializer. Therefore, this setting should only be enabled after all replicas
-# have been successfully upgraded to Rails 7.1.
-#++
-# Rails.application.config.active_job.use_big_decimal_serializer = true
-
-###
-# Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or
-# `write` are given an invalid `expires_at` or `expires_in` time.
-# Options are `true`, and `false`. If `false`, the exception will be reported
-# as `handled` and logged instead.
-#++
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
-
-###
-# Specify whether Query Logs will format tags using the SQLCommenter format
-# (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
-# Options are `:legacy` and `:sqlcommenter`.
-#++
-# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
-
-###
 # Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
 # instances.
 #

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -46,51 +46,6 @@
 # Rails.application.config.active_support.use_message_serializer_for_metadata = true
 
 ###
-# Set the maximum size for Rails log files.
-#
-# `config.load_defaults 7.1` does not set this value for environments other than
-# development and test.
-#++
-# if Rails.env.local?
-#   Rails.application.config.log_file_size = 100 * 1024 * 1024
-# end
-
-###
-# Enable raising on assignment to attr_readonly attributes. The previous
-# behavior would allow assignment but silently not persist changes to the
-# database.
-#++
-# Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
-
-###
-# Enable validating only parent-related columns for presence when the parent is mandatory.
-# The previous behavior was to validate the presence of the parent record, which performed an extra query
-# to get the parent every time the child record was updated, even when parent has not changed.
-#++
-# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
-
-###
-# Enable precompilation of `config.filter_parameters`. Precompilation can
-# improve filtering performance, depending on the quantity and types of filters.
-#++
-# Rails.application.config.precompile_filter_parameters = true
-
-###
-# Enable before_committed! callbacks on all enrolled records in a transaction.
-# The previous behavior was to only run the callbacks on the first copy of a record
-# if there were multiple copies of the same record enrolled in the transaction.
-#++
-# Rails.application.config.active_record.before_committed_on_all_records = true
-
-###
-# Disable automatic column serialization into YAML.
-# To keep the historic behavior, you can set it to `YAML`, however it is
-# recommended to explicitly define the serialization method for each column
-# rather than to rely on a global default.
-#++
-# Rails.application.config.active_record.default_column_serializer = nil
-
-###
 # Enable a performance optimization that serializes Active Record models
 # in a faster and more compact way.
 #

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
+# Be sure to restart your server when you modify this file.
+
 # Define an application-wide HTTP permissions policy. For further
-# information see https://developers.google.com/web/updates/2018/06/feature-policy
-#
-# Rails.application.config.permissions_policy do |f|
-#   f.camera      :none
-#   f.gyroscope   :none
-#   f.microphone  :none
-#   f.usb         :none
-#   f.fullscreen  :self
-#   f.payment     :self, "https://secure.example.com"
+# information see: https://developers.google.com/web/updates/2018/06/feature-policy
+
+# Rails.application.config.permissions_policy do |policy|
+#   policy.camera      :none
+#   policy.gyroscope   :none
+#   policy.microphone  :none
+#   policy.usb         :none
+#   policy.fullscreen  :self
+#   policy.payment     :self, "https://secure.example.com"
 # end


### PR DESCRIPTION
Changes:

1. Ruby on Rails 7.1.5.1

NOTE: This deprecation will go away only after migration to Rails 7.2.

```
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <main> at /home/runner/work/errbit/errbit/config/environment.rb:21)
```