### PR TITLE
Updates

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --require spec_helper
 --order random
+--format documentation

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -290,8 +290,17 @@ Security/JSONLoad:
 
 # Our rubocop rules
 
+# Bundler rules.
+
 Bundler/OrderedGems:
   Enabled: false
+
+# Gemspec rules
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+# Style rules
 
 # Don't allow %i[foo bar baz]
 Style/SymbolArray:
@@ -307,9 +316,11 @@ Style/WordArray:
 Style/Documentation:
   Enabled: false
 
-# This is new RSpec default. Disable.
-RSpecRails/InferredSpecType:
+# Disable as in standard.
+Style/ArgumentsForwarding:
   Enabled: false
+
+# RSpec rules
 
 # Prefer eq over be.
 RSpec/BeEq:
@@ -335,17 +346,11 @@ RSpec/ExpectInHook:
 RSpec/IndexedLet:
   Enabled: false
 
-# We don't use ActiveRecord.
-Rails/ActiveRecordAliases:
+# We don't use named subject's
+RSpec/NamedSubject:
   Enabled: false
 
-# We don't use ActiveRecord.
-Rails/SkipsModelValidations:
-  Enabled: false
-
-# Disable as in standard.
-Style/ArgumentsForwarding:
-  Enabled: false
+# Naming rules:
 
 # Disable anonymous block forwarding.
 Naming/BlockForwarding:
@@ -358,9 +363,27 @@ Naming/FileName:
   Exclude:
     - "spec/support/mongoid-rspec.rb"
 
+# Disabled syntax:
+
 # Disable shorthand hash syntax like: ({ x:, y: })
 # Disable % style literals
 Style/DisableSyntax:
   DisableSyntax:
     - shorthand_hash_syntax
     - percent_literals
+
+# RSpec Rails rules:
+
+# This is new RSpec default. Disable.
+RSpecRails/InferredSpecType:
+  Enabled: false
+
+# Rails rules:
+
+# We don't use ActiveRecord.
+Rails/ActiveRecordAliases:
+  Enabled: false
+
+# We don't use ActiveRecord.
+Rails/SkipsModelValidations:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,9 @@ gem "draper"
 gem "errbit_plugin",
   git: "https://github.com/errbit/errbit_plugin",
   branch: "master"
-gem "errbit_github_plugin"
+gem "errbit_github_plugin",
+  git: "https://github.com/errbit/errbit_github_plugin",
+  branch: "master"
 gem "font-awesome-rails"
 gem "haml"
 gem "htmlentities"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,9 @@ gem "decent_exposure"
 gem "devise"
 gem "dotenv-rails"
 gem "draper"
-gem "errbit_plugin"
+gem "errbit_plugin",
+  git: "https://github.com/errbit/errbit_plugin",
+  branch: "master"
 gem "errbit_github_plugin"
 gem "font-awesome-rails"
 gem "haml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/errbit/errbit_github_plugin
+  revision: 033b0e760f3db5355805fb9b13decebca5c993f2
+  branch: master
+  specs:
+    errbit_github_plugin (0.4.0)
+      errbit_plugin
+      octokit
+
+GIT
   remote: https://github.com/errbit/errbit_plugin
   revision: 3914b7ac8434dff11177223336ad94778d3aa70e
   branch: master
@@ -170,9 +179,6 @@ GEM
       htmlentities (~> 4.3.3)
       launchy (>= 2.1, < 4.0)
       mail (~> 2.7)
-    errbit_github_plugin (0.3.0)
-      errbit_plugin
-      octokit
     erubi (1.13.1)
     fabrication (2.31.0)
     faker (3.5.1)
@@ -669,7 +675,7 @@ DEPENDENCIES
   dotenv-rails
   draper
   email_spec
-  errbit_github_plugin
+  errbit_github_plugin!
   errbit_plugin!
   fabrication
   faker
@@ -785,7 +791,7 @@ CHECKSUMS
   draper (4.0.4) sha256=acf3d7f4d5b28fd0e3b9fad9a0692f9a990e119362b802b92852362f9535b85e
   drb (2.2.1) sha256=e9d472bf785f558b96b25358bae115646da0dbfd45107ad858b0bc0d935cb340
   email_spec (2.3.0) sha256=df23be7a131186f7a3d5be3b35eaac9196f9ac13bd26c9c3d59341e13d852d11
-  errbit_github_plugin (0.3.0) sha256=96391948fae85fe3aaed78efa598791a8f16187e39e7038ca00bc137a266cc92
+  errbit_github_plugin (0.4.0)
   errbit_plugin (0.7.0)
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   fabrication (2.31.0) sha256=2c79f10d1b88034a2ebd47ce77acba66847fc4636581c8282b3408adc68e85aa

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/errbit/errbit_plugin
+  revision: a904ef1c89c5c5cf56480e43fa8d08a891ecebc5
+  branch: master
+  specs:
+    errbit_plugin (0.7.0)
+
+GIT
   remote: https://github.com/errbit/hoptoad_notifier
   revision: 9b6a6f5017c5ca52b07b8d5c64c79b6d44c121d3
   branch: errbit
@@ -166,7 +173,6 @@ GEM
     errbit_github_plugin (0.3.0)
       errbit_plugin
       octokit
-    errbit_plugin (0.6.0)
     erubi (1.13.1)
     fabrication (2.31.0)
     faker (3.5.1)
@@ -664,7 +670,7 @@ DEPENDENCIES
   draper
   email_spec
   errbit_github_plugin
-  errbit_plugin
+  errbit_plugin!
   fabrication
   faker
   faraday-retry
@@ -780,7 +786,7 @@ CHECKSUMS
   drb (2.2.1) sha256=e9d472bf785f558b96b25358bae115646da0dbfd45107ad858b0bc0d935cb340
   email_spec (2.3.0) sha256=df23be7a131186f7a3d5be3b35eaac9196f9ac13bd26c9c3d59341e13d852d11
   errbit_github_plugin (0.3.0) sha256=96391948fae85fe3aaed78efa598791a8f16187e39e7038ca00bc137a266cc92
-  errbit_plugin (0.6.0) sha256=ec4a7567333e3771802805e6c8e901fdfdbb9d576bbcc2af91573694cea89b15
+  errbit_plugin (0.7.0)
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   fabrication (2.31.0) sha256=2c79f10d1b88034a2ebd47ce77acba66847fc4636581c8282b3408adc68e85aa
   faker (3.5.1) sha256=1ad1fbea279d882f486059c23fe3ddb816ccd1d7052c05a45014b4450d859bfc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,12 @@
 GIT
   remote: https://github.com/errbit/errbit_github_plugin
-  revision: 033b0e760f3db5355805fb9b13decebca5c993f2
+  revision: 4039a70ec79238acc88a0a87f2325d3a18d504ba
   branch: master
   specs:
     errbit_github_plugin (0.4.0)
+      activesupport
       errbit_plugin
+      faraday-retry
       octokit
 
 GIT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/errbit/errbit_plugin
-  revision: a904ef1c89c5c5cf56480e43fa8d08a891ecebc5
+  revision: 3914b7ac8434dff11177223336ad94778d3aa70e
   branch: master
   specs:
     errbit_plugin (0.7.0)


### PR DESCRIPTION
Changes:

1. Update `errbit_plugin` from master (until `errbit_plugin` new gem release)
2. Update `errbit_github_plugin` from master (until `errbit_github_plugin ` new gem release)
3. Update `rubocop` config
4. RSpec: `--format documentation`

Most funny that enabling RSpec `--format documentation` "fixes" flaky tests.