### PR TITLE
Start 0.11.0 dev

### DIFF
--- a/.github/workflows/jruby.yml
+++ b/.github/workflows/jruby.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["jruby-9.4"]
-        mongodb-version: ["4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "8.0"]
+        mongodb-version: ["6.0", "7.0", "8.0"]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.4"]
-        mongodb-version: ["4.0", "4.2", "4.4", "5.0", "6.0", "7.0", "8.0"]
+        mongodb-version: ["6.0", "7.0", "8.0"]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ updates and notifications.
 The list of requirements to install Errbit are:
 
 * Ruby 3.4 or JRuby 9.4
-* MongoDB >= 4.0
+* MongoDB >= 6.0
 
 Installation
 ------------

--- a/app/lib/errbit/version.rb
+++ b/app/lib/errbit/version.rb
@@ -23,7 +23,7 @@ module Errbit
 
     class << self
       def to_s
-        new("0.10.0", true).full_version
+        new("0.11.0", true).full_version
       end
     end
   end

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,5 +1,9 @@
 # Upgrading Errbit
 
+## Upgrading Errbit from v0.10.0 to v0.11.0
+
+* Support for MongoDB 4.0, 4.2, 4.4 and 5.0 has been removed.
+
 ## Upgrading Errbit from v0.9.0 to v0.10.0
 
 * Remove `USER_GEMFILE` env support. From now, only `UserGemfile` is


### PR DESCRIPTION
Changes:

1. Drop support for MongoDB 4.0, 4.2, 4.4 and 5.0
2. Bump version to 0.11.0-dev
