### PR TITLE
Speed up tests

### DIFF
--- a/app/jobs/destroy_problems_by_id_job.rb
+++ b/app/jobs/destroy_problems_by_id_job.rb
@@ -3,6 +3,7 @@
 class DestroyProblemsByIdJob < ActiveJob::Base
   queue_as :default
 
+  # @param problem_ids [Array<String>]
   def perform(problem_ids)
     bson_problem_ids = []
 

--- a/spec/jobs/destroy_problems_by_id_job_spec.rb
+++ b/spec/jobs/destroy_problems_by_id_job_spec.rb
@@ -3,39 +3,24 @@
 require "rails_helper"
 
 RSpec.describe DestroyProblemsByIdJob, type: :job do
-  before do
-    @app = Fabricate(:app)
-    @problem1 = Fabricate(:problem, app: @app)
-    @problem2 = Fabricate(:problem, app: @app)
-    @problem3 = Fabricate(:problem, app: @app)
-    @problem4 = Fabricate(:problem, app: @app)
-    @problem5 = Fabricate(:problem, app: @app)
-    @problem6 = Fabricate(:problem, app: @app)
-  end
-
   it "destroys all selected problems" do
-    expect do
-      DestroyProblemsByIdJob.perform_later([@problem2.id.to_s, @problem5.id.to_s, @problem1.id.to_s])
-    end.to change(Problem, :count).by(-3)
-    expect(@app.problems.count).to eq 3
-  end
+    app = Fabricate(:app)
+    problem1 = Fabricate(:problem, app: app)
 
-  it "destroys all selected problems, even with a large amount of them" do
-    app2 = Fabricate(:app)
-    500.times do
-      Fabricate(:problem, app: app2)
-    end
     expect do
-      DestroyProblemsByIdJob.perform_later(app2.problems.to_a.sample(100).map(&:id).map(&:to_s))
-    end.to change(Problem, :count).by(-100)
-    expect(app2.problems.count).to eq 400
+      DestroyProblemsByIdJob.perform_later([problem1.id])
+    end.to change(Problem, :count).by(-1)
+
+    expect(app.problems.count).to eq(0)
   end
 
   it "should work with a fresh new application" do
-    app2 = Fabricate(:app)
+    app = Fabricate(:app)
+
     expect do
       DestroyProblemsByIdJob.perform_later([])
-    end.to change(Problem, :count).by(0)
-    expect(app2.problems.count).to eq 0
+    end.not_to change(Problem, :count)
+
+    expect(app.problems.count).to eq(0)
   end
 end


### PR DESCRIPTION
Before:

```
rspec spec/jobs/destroy_problems_by_id_job_spec.rb --profile

Randomized with seed 62023

DestroyProblemsByIdJob
  destroys all selected problems, even with a large amount of them
  should work with a fresh new application
  destroys all selected problems

Top 3 slowest examples (15.75 seconds, 100.0% of total time):
  DestroyProblemsByIdJob destroys all selected problems, even with a large amount of them
    15.57 seconds ./spec/jobs/destroy_problems_by_id_job_spec.rb:24
  DestroyProblemsByIdJob should work with a fresh new application
    0.10749 seconds ./spec/jobs/destroy_problems_by_id_job_spec.rb:38
  DestroyProblemsByIdJob destroys all selected problems
    0.07038 seconds ./spec/jobs/destroy_problems_by_id_job_spec.rb:16

Finished in 15.75 seconds (files took 1.93 seconds to load)
3 examples, 0 failures
```

After:

```
rspec spec/jobs/destroy_problems_by_id_job_spec.rb --profile

Randomized with seed 12988

DestroyProblemsByIdJob
  destroys all selected problems
  should work with a fresh new application

Top 2 slowest examples (0.28319 seconds, 99.1% of total time):
  DestroyProblemsByIdJob destroys all selected problems
    0.25373 seconds ./spec/jobs/destroy_problems_by_id_job_spec.rb:6
  DestroyProblemsByIdJob should work with a fresh new application
    0.02946 seconds ./spec/jobs/destroy_problems_by_id_job_spec.rb:17

Finished in 0.28575 seconds (files took 2.34 seconds to load)
2 examples, 0 failures
```

Total: minus 15 seconds
