### PR TITLE
Speed up tests

### DIFF
--- a/app/jobs/destroy_problems_by_app_job.rb
+++ b/app/jobs/destroy_problems_by_app_job.rb
@@ -3,6 +3,7 @@
 class DestroyProblemsByAppJob < ActiveJob::Base
   queue_as :default
 
+  # @param app_id [String]
   def perform(app_id)
     app = App.find_by(id: app_id)
 

--- a/spec/jobs/destroy_problems_by_app_job_spec.rb
+++ b/spec/jobs/destroy_problems_by_app_job_spec.rb
@@ -3,35 +3,24 @@
 require "rails_helper"
 
 RSpec.describe DestroyProblemsByAppJob, type: :job do
-  before do
-    @app = Fabricate(:app)
-    @problem1 = Fabricate(:problem, app: @app)
-    @problem2 = Fabricate(:problem, app: @app)
-  end
-
   it "destroys all problems" do
-    expect do
-      DestroyProblemsByAppJob.perform_later(@app.id)
-    end.to change(Problem, :count).by(-2)
-    expect(@app.problems.count).to eq 0
-  end
+    app = Fabricate(:app)
+    problem = Fabricate(:problem, app: app)
 
-  it "destroys all problems, even with a large amount of them" do
-    app2 = Fabricate(:app)
-    500.times do
-      Fabricate(:problem, app: app2)
-    end
     expect do
-      DestroyProblemsByAppJob.perform_later(app2.id)
-    end.to change(Problem, :count).by(-500)
-    expect(app2.problems.count).to eq 0
+      DestroyProblemsByAppJob.perform_later(app.id)
+    end.to change(Problem, :count).by(-1)
+
+    expect(app.problems.count).to eq(0)
   end
 
   it "should work with a fresh new application" do
-    app2 = Fabricate(:app)
+    app = Fabricate(:app)
+
     expect do
-      DestroyProblemsByAppJob.perform_later(app2.id)
-    end.to change(Problem, :count).by(0)
-    expect(app2.problems.count).to eq 0
+      DestroyProblemsByAppJob.perform_later(app.id)
+    end.not_to change(Problem, :count)
+
+    expect(app.problems.count).to eq(0)
   end
 end


### PR DESCRIPTION
Before:

```
rspec spec/jobs/destroy_problems_by_app_job_spec.rb --profile

Randomized with seed 45881

DestroyProblemsByAppJob
  destroys all problems, even with a large amount of them
  should work with a fresh new application
  destroys all problems

Top 3 slowest examples (23.47 seconds, 100.0% of total time):
  DestroyProblemsByAppJob destroys all problems, even with a large amount of them
    23.34 seconds ./spec/jobs/destroy_problems_by_app_job_spec.rb:19
  DestroyProblemsByAppJob should work with a fresh new application
    0.06987 seconds ./spec/jobs/destroy_problems_by_app_job_spec.rb:30
  DestroyProblemsByAppJob destroys all problems
    0.05931 seconds ./spec/jobs/destroy_problems_by_app_job_spec.rb:12

Finished in 23.47 seconds (files took 1.98 seconds to load)
3 examples, 0 failures
```

After:

```
rspec spec/jobs/destroy_problems_by_app_job_spec.rb --profile

Randomized with seed 57248

DestroyProblemsByAppJob
  should work with a fresh new application
  destroys all problems

Top 2 slowest examples (0.26001 seconds, 99.0% of total time):
  DestroyProblemsByAppJob should work with a fresh new application
    0.19385 seconds ./spec/jobs/destroy_problems_by_app_job_spec.rb:17
  DestroyProblemsByAppJob destroys all problems
    0.06616 seconds ./spec/jobs/destroy_problems_by_app_job_spec.rb:6

Finished in 0.26272 seconds (files took 4.23 seconds to load)
2 examples, 0 failures
```

Total: minus 23 seconds