### PR TITLE
Fix airbrake deprecation

### DIFF
--- a/app/views/apps/_configuration_instructions.html.erb
+++ b/app/views/apps/_configuration_instructions.html.erb
@@ -11,8 +11,7 @@
 # config/initializers/errbit.rb with the following flags:
 
 Airbrake.configure do |config|
-  # FIXME: `.host` deprecated.
-  config.host = "<%= errbit_url %>"
+  config.error_host = "<%= errbit_url %>"
   config.project_id = 1 # required, but any positive integer works
   config.project_key = "<%= api_key %>"
 


### PR DESCRIPTION
Airbrake:

`.host` deprecated since 5.0.0.

Replace with `.error_host`.
