### PR TITLE
Remove errbit from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,4 @@
 services:
-  errbit:
-    image: "errbit/errbit:latest"
-    ports:
-      - "3000:3000"
-    environment:
-      RAILS_ENV: "production"
-      MONGO_URL: "mongodb://mongo:27017/errbit"
-
   mongo:
     image: "mongo:6.0.23"
     ports:


### PR DESCRIPTION
File `docker-compose.yml` is for development. We don't need Errbit itself in it.
