### PR TITLE
MongoDB versions

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.4"]
-        mongodb-version: ["6.0", "7.0", "8.0"]
+        mongodb-version: ["7.0", "8.0", "8.2"]
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ updates and notifications.
 The list of requirements to install Errbit are:
 
 * Ruby 3.4
-* MongoDB >= 6.0
+* MongoDB >= 7.0
 
 Installation
 ------------


### PR DESCRIPTION
Changes:

1. Bump minimal MongoDB version to >= 7.0.
2. Remove 6.0 from testing matrix.
3. Add 8.2 to testing matrix.
