### PR TITLE
Feature/copy as markdown button

### DIFF
--- a/app/helpers/problems_helper.rb
+++ b/app/helpers/problems_helper.rb
@@ -35,4 +35,48 @@ module ProblemsHelper
     url = "https://secure.gravatar.com"
     "#{url}/avatar/#{email_hash}?#{params.to_query}"
   end
+
+  # Generates a structured Markdown snippet from a given notice
+  def notice_as_markdown(notice)
+    return "" unless notice
+
+    problem = notice.problem
+    
+    md = []
+    # Title & Header
+    md << "# #{notice.error_class}: #{notice.message}\n"
+    
+    # Metadata List
+    md << "- **App**: #{problem.app.name}" if problem.app
+    md << "- **Environment**: #{problem.environment}"
+    md << "- **Where**: #{notice.where}" if notice.where.present?
+    md << "- **Occurred at**: #{notice.created_at.to_formatted_s(:db)}"
+    md << "- **First notice**: #{problem.first_notice_at&.to_formatted_s(:db)}"
+    md << "- **Last notice**: #{problem.last_notice_at&.to_formatted_s(:db)}"
+    md << "- **Occurrences**: #{problem.notices_count}\n"
+    
+    # Backtrace Section
+    if notice.backtrace&.lines.present?
+      md << "## Backtrace\n"
+      md << "```text"
+      notice.backtrace.lines.each do |line|
+        # Highlight in-app frames if Errbit's model provides helper methods for it
+        # Otherwise, output a clean, standard line format
+        md << "  #{line.file}:#{line.number} → #{line.method}"
+      end
+      md << "```\n"
+    end
+
+    # Contextual Request/Environment hashes (Omitting empty sections)
+    %w(params session user_attributes env_vars).each do |section|
+      if notice.respond_to?(section) && (data = notice.send(section)).present?
+        md << "## #{section.humanize}\n"
+        md << "```ruby"
+        md << data.to_yaml.strip.gsub(/^---\s*\n/, '') # Clean YAML-like or Hash output
+        md << "```\n"
+      end
+    end
+
+    md.join("\n")
+  end
 end

--- a/app/views/problems/show.html.erb
+++ b/app/views/problems/show.html.erb
@@ -31,9 +31,41 @@
   <% end %>
 
   <span><%= link_to t(".up"), (request.env["HTTP_REFERER"] ? :back : app_problems_path(app)), class: "up" %></span>
+
+  <span>
+    <%= link_to '#', id: 'copy-as-markdown-btn', class: 'button items-center' do %>
+      <i class="fa fa-copy"></i>
+      <span>Copy as Markdown</span>
+    <% end %>
+  </span>
+
   <br>
   <%= render "issue_tracker_links", app: app, problem: problem %>
 <% end %>
+
+<textarea id="markdown-payload" style="display: none;" aria-hidden="true"><%= notice_as_markdown(@notice || @problem.current_notice) %></textarea>
+
+<script>
+  document.getElementById('copy-as-markdown-btn').addEventListener('click', function(e) {
+    e.preventDefault();
+    const payload = document.getElementById('markdown-payload').value;
+    const btn = this;
+    
+    navigator.clipboard.writeText(payload).then(() => {
+      const originalText = btn.innerHTML;
+      btn.innerHTML = '<i class="fa fa-check"></i> <span>Copied! ✓</span>';
+      btn.classList.add('success'); // adjust class to match Errbit styling framework
+      
+      setTimeout(() => {
+        btn.innerHTML = originalText;
+        btn.classList.remove('success');
+      }, 2000);
+    }).catch(err => {
+      console.error('Could not copy markdown text: ', err);
+      alert('Failed to copy to clipboard.');
+    });
+  });
+</script>
 
 <% content_for :comments do %>
   <h3><%= t(".comments") %></h3>


### PR DESCRIPTION
Perfect! ✅ I've successfully implemented the "Copy as Markdown" feature for issue #2790. Here's what was done:

## Changes Made

### 1. **ProblemsHelper** (`app/helpers/problems_helper.rb`)
Added the `notice_as_markdown` method that:
- Generates a structured markdown document from a notice
- Includes error class, message, and metadata (app, environment, where, timestamps, occurrence count)
- Formats the backtrace section with file:line → method format
- Includes optional sections for params, session, user_attributes, and env_vars (omits empty sections)
- Returns clean, LLM-ready markdown

### 2. **Problems Show View** (`app/views/problems/show.html.erb`)
Added to the action bar:
- **"Copy as Markdown" button** with a copy icon next to resolve/iCal/up buttons
- **Hidden textarea** storing the generated markdown payload
- **JavaScript handler** that:
  - Copies the markdown to clipboard when clicked
  - Shows "Copied! ✓" feedback for 2 seconds
  - Has error handling with user alerts

## Branch Details
- **Branch**: `feature/copy-as-markdown-button`
- **Repository**: `aniruthramidi/errbit`
- **Commits**: 2 commits implementing the feature

The implementation matches the spec from issue #2790 with minimal footprint and no new routes/models. Ready for PR! 🚀