### PR TITLE
docs: Add comment for OmniAuth test mode setup

### DIFF
--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+# Set OmniAuth to test mode for mock authentication in test environment.
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
### 问题背景
The file `spec/support/omniauth.rb` lacked documentation comments, which reduced code readability and maintainability. Clear documentation helps developers understand the purpose of the code without needing to inspect the entire context.

### 修改内容
- **修改了什么**: Added a comment line `# Set OmniAuth to test mode for mock authentication in test environment.` at the beginning of the file.
- **为什么这样改**: This comment explains the intent of setting `OmniAuth.config.test_mode = true`, which is to enable mock authentication in the test environment. It improves code clarity and aligns with best practices for documenting configuration code.
- **对代码质量/性能/安全性的提升**: Enhances code readability and maintainability by providing immediate context, reducing the need for developers to infer the purpose. No impact on performance or security.

### 验证方式
- **是否通过了现有测试**: Yes, since this change only adds a comment without altering code logic, all existing tests should pass. Verification can be done by running the test suite (e.g., `bundle exec rspec`).
- **是否添加了新的测试**: No new tests were added, as this is a documentation-only change.
- **是否进行了手动验证**: Manually confirmed that the comment accurately describes the code behavior and integrates seamlessly with the existing file structure.

### 其他信息
- **是否有 breaking changes**: No breaking changes introduced.
- **是否需要更新文档**: No external documentation updates required, as this is a minor internal comment addition.
- **是否有已知的限制**: None identified.