### PR TITLE
Fix headless Chrome system specs in containers

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,6 +8,10 @@ Capybara.register_driver :selenium_chrome_headless do |app|
 
   browser_options = Selenium::WebDriver::Chrome::Options.new.tap do |opts|
     opts.add_argument("--headless=new")
+    # Chrome's sandbox often cannot initialize inside Docker/Podman test containers.
+    opts.add_argument("--no-sandbox")
+    # Avoid Chrome crashes caused by small container /dev/shm mounts.
+    opts.add_argument("--disable-dev-shm-usage")
     opts.add_argument("--disable-gpu") if Gem.win_platform?
     # Workaround https://bugs.chromium.org/p/chromedriver/issues/detail?id=2650&q=load&sort=-id&colspec=ID%20Status%20Pri%20Owner%20Summary
     opts.add_argument("--disable-site-isolation-trials")


### PR DESCRIPTION
Add the Chrome flags `--no-sandbox` and `--disable-dev-shm-usage`, which are commonly required when running headless Chrome in Linux containers.

This allows the existing Selenium/Capybara configuration to work in containerized environments without changing the selected browser or driver.