### PR TITLE
Normalize notice threshold configuration

### DIFF
--- a/config/load.rb
+++ b/config/load.rb
@@ -5,6 +5,22 @@ Dotenv.load(".env.default")
 
 require_relative "../app/lib/configurator"
 
+notice_thresholds = lambda do |values, key|
+  value = values[key]
+  threshold_values = if value.is_a?(Array)
+    value
+  else
+    value = value.to_s.strip
+    value = value[1...-1] if value.match?(/\A(['"]).*\1\z/)
+    value.delete_prefix("[").delete_suffix("]").split(",")
+  end
+
+  threshold_values
+    .map { |v| v.to_s.strip }
+    .reject(&:empty?)
+    .map { |v| Integer(v, 10) }
+end
+
 # map config keys to environment variables
 #
 # We use the first non-nil environment variable in the list. If the last array
@@ -16,9 +32,13 @@ Errbit::Config = Configurator.run(
   use_gravatar: ["ERRBIT_USE_GRAVATAR"],
   gravatar_default: ["ERRBIT_GRAVATAR_DEFAULT"],
   email_from: ["ERRBIT_EMAIL_FROM"],
-  email_at_notices: ["ERRBIT_EMAIL_AT_NOTICES"],
+  email_at_notices: ["ERRBIT_EMAIL_AT_NOTICES", lambda do |values|
+    notice_thresholds.call(values, :email_at_notices)
+  end],
   per_app_email_at_notices: ["ERRBIT_PER_APP_EMAIL_AT_NOTICES"],
-  notify_at_notices: ["ERRBIT_NOTIFY_AT_NOTICES"],
+  notify_at_notices: ["ERRBIT_NOTIFY_AT_NOTICES", lambda do |values|
+    notice_thresholds.call(values, :notify_at_notices)
+  end],
   per_app_notify_at_notices: ["ERRBIT_PER_APP_NOTIFY_AT_NOTICES"],
   log_location: ["ERRBIT_LOG_LOCATION"],
   notice_deprecation_days: ["ERRBIT_PROBLEM_DESTROY_AFTER_DAYS"],

--- a/spec/config/load_spec.rb
+++ b/spec/config/load_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "config/load" do
+  before do
+    @original_config = Errbit::Config if Errbit.const_defined?(:Config, false)
+  end
+
+  def load_config_with(env)
+    allow(ENV).to receive(:[]).and_return(nil)
+    {"GITHUB_URL" => "https://github.com"}.merge(env).each do |key, value|
+      allow(ENV).to receive(:[]).with(key).and_return(value)
+    end
+
+    Errbit.send(:remove_const, :Config) if Errbit.const_defined?(:Config, false)
+    load Rails.root.join("config/load.rb")
+  rescue
+    Errbit.const_set(:Config, @original_config) unless Errbit.const_defined?(:Config, false)
+    raise
+  end
+
+  after do
+    Errbit.send(:remove_const, :Config) if Errbit.const_defined?(:Config, false)
+    Errbit.const_set(:Config, @original_config) if @original_config
+  end
+
+  it "normalizes bracketed notice threshold strings" do
+    load_config_with(
+      "ERRBIT_EMAIL_AT_NOTICES" => "[1,10,100]",
+      "ERRBIT_NOTIFY_AT_NOTICES" => "[0]"
+    )
+
+    expect(Errbit::Config.email_at_notices).to eq([1, 10, 100])
+    expect(Errbit::Config.notify_at_notices).to eq([0])
+  end
+
+  it "normalizes quoted notice threshold strings" do
+    load_config_with(
+      "ERRBIT_EMAIL_AT_NOTICES" => '"[1,10,100]"',
+      "ERRBIT_NOTIFY_AT_NOTICES" => '"[0]"'
+    )
+
+    expect(Errbit::Config.email_at_notices).to eq([1, 10, 100])
+    expect(Errbit::Config.notify_at_notices).to eq([0])
+  end
+
+  it "normalizes comma-separated notice threshold strings" do
+    load_config_with(
+      "ERRBIT_EMAIL_AT_NOTICES" => '"1, 10, 100"',
+      "ERRBIT_NOTIFY_AT_NOTICES" => '"0"'
+    )
+
+    expect(Errbit::Config.email_at_notices).to eq([1, 10, 100])
+    expect(Errbit::Config.notify_at_notices).to eq([0])
+  end
+
+  it "normalizes a single unquoted threshold" do
+    load_config_with(
+      "ERRBIT_EMAIL_AT_NOTICES" => "1",
+      "ERRBIT_NOTIFY_AT_NOTICES" => "0"
+    )
+
+    expect(Errbit::Config.email_at_notices).to eq([1])
+    expect(Errbit::Config.notify_at_notices).to eq([0])
+  end
+
+  it "ignores empty threshold elements" do
+    load_config_with(
+      "ERRBIT_EMAIL_AT_NOTICES" => '"1,, 10,"',
+      "ERRBIT_NOTIFY_AT_NOTICES" => '", 0, "'
+    )
+
+    expect(Errbit::Config.email_at_notices).to eq([1, 10])
+    expect(Errbit::Config.notify_at_notices).to eq([0])
+  end
+
+  it "normalizes empty threshold strings to empty arrays" do
+    load_config_with(
+      "ERRBIT_EMAIL_AT_NOTICES" => '""',
+      "ERRBIT_NOTIFY_AT_NOTICES" => '" "'
+    )
+
+    expect(Errbit::Config.email_at_notices).to eq([])
+    expect(Errbit::Config.notify_at_notices).to eq([])
+  end
+
+  it "rejects invalid threshold values" do
+    expect do
+      load_config_with("ERRBIT_EMAIL_AT_NOTICES" => '"1,wat,100"')
+    end.to raise_error(ArgumentError)
+  end
+end


### PR DESCRIPTION
Normalize `ERRBIT_EMAIL_AT_NOTICES` and `ERRBIT_NOTIFY_AT_NOTICES` to integer arrays when loading configuration.

Support bracketed, quoted, comma-separated, and single-value formats while rejecting invalid threshold tokens instead of silently coercing them to zero.

Closes #2010