### PR TITLE
Enable Content Security Policy

### DIFF
--- a/app/assets/javascripts/errbit.js
+++ b/app/assets/javascripts/errbit.js
@@ -16,7 +16,7 @@ $(function() {
 
     // On page apps/:app_id/edit
     $('a.copy_config').on("click", function() {
-      $('select.choose_other_app').show().focus();
+      $('select.choose_other_app').removeClass('hidden').focus();
     });
 
     $('select.choose_other_app').on("change", function() {
@@ -31,10 +31,11 @@ $(function() {
       $.pjax.defaults = {timeout: 2000};
 
       $('#content').pjax('.notice-pagination a').on('pjax:start', function() {
-        $('.notice-pagination-loader').css("visibility", "visible");
+        $('.notice-pagination-loader').addClass('visible');
         currentTab = $('.tab-bar ul li a.button.active').attr('rel');
       }).on('pjax:end', function() {
         activateTabbedPanels();
+        loadSparklines();
       });
     });
   }
@@ -44,7 +45,7 @@ $(function() {
       var tab = $(this);
       var panel = $('#'+tab.attr('rel'));
       panel.addClass('panel');
-      panel.find('h3').hide();
+      panel.find('h3').addClass('hidden');
     });
 
     $('.tab-bar a').click(function(){
@@ -64,8 +65,8 @@ $(function() {
     // If clicking into 'backtrace' tab, hide external backtrace
     if (tab.attr('rel') == "backtrace") { hide_external_backtrace(); }
 
-    $('.panel').hide();
-    panel.show();
+    $('.panel').addClass('hidden');
+    panel.removeClass('hidden');
   }
 
   window.toggleProblemsCheckboxes = function() {
@@ -112,12 +113,12 @@ $(function() {
   toggleRequiredPasswordMarks();
 
   function hide_external_backtrace() {
-    $('tr.toggle_external_backtrace').hide();
-    $('td.backtrace_separator').show();
+    $('tr.toggle_external_backtrace').addClass('hidden_external_backtrace');
+    $('td.backtrace_separator').removeClass('hidden');
   }
   function show_external_backtrace() {
-    $('tr.toggle_external_backtrace').show();
-    $('td.backtrace_separator').hide();
+    $('tr.toggle_external_backtrace').removeClass('hidden_external_backtrace');
+    $('td.backtrace_separator').addClass('hidden');
   }
   // Show external backtrace lines when clicking separator
   $(document).on('click', 'td.backtrace_separator span', show_external_backtrace);
@@ -125,9 +126,26 @@ $(function() {
   hide_external_backtrace();
 
   $('.head a.show_tail').click(function(e) {
-    $(this).hide().closest('.head_and_tail').find('.tail').show();
+    $(this).addClass('hidden').closest('.head_and_tail').find('.tail').removeClass('hidden');
     e.preventDefault();
   });
+
+  function loadSparklines() {
+    $('#sparkline-placeholder[data-sparkline-url]').each(function() {
+      var placeholder = $(this);
+      $.ajax({url: placeholder.data('sparkline-url')}).then(function(response) {
+        placeholder.replaceWith(response);
+      });
+    });
+  }
+
+  $('a#forgot_password').click(function(e) {
+    // Set email field on password reset page to email that user entered on this page.
+    e.preventDefault();
+    window.location.href = $(this).attr('href') + '?email=' + encodeURIComponent($('#user_email').val());
+  });
+
+  loadSparklines();
 
   init();
 });

--- a/app/assets/javascripts/errbit.js
+++ b/app/assets/javascripts/errbit.js
@@ -40,6 +40,18 @@ $(function() {
     });
   }
 
+  $(document).on('ajax:success', 'form.search-form', function(_event, data) {
+    var form = $(this);
+    var target = $(form.data('search-target'));
+
+    target.html(data);
+    $('#flash-messages').empty();
+    if (target.attr('id') == 'problem_table') {
+      toggleProblemsCheckboxes();
+      bindProblemButtonsActions();
+    }
+  });
+
   function activateTabbedPanels() {
     $('.tab-bar a').each(function(){
       var tab = $(this);

--- a/app/assets/javascripts/form.js
+++ b/app/assets/javascripts/form.js
@@ -36,14 +36,14 @@ function makeNestedItemsDestroyable(wrapper) {
   wrapper.find('.nested').each(function(){
     var nestedItem = $(this);
     var destroyLink = $('<a/>').text('remove').addClass('remove-nested');
-    destroyLink.css('float','right');
+    destroyLink.addClass('float-right');
     nestedItem.find('label').first().before(destroyLink);
   })
 }
 
 function appendNestedItem() {
   var addLink = $(this);
-  var nestedItem = addLink.parent().find('.nested').first().clone().show();
+  var nestedItem = addLink.parent().find('.nested').first().clone().removeClass('hidden');
   var timestamp = new Date();
   timestamp = timestamp.valueOf();
 
@@ -71,7 +71,7 @@ function removeNestedItem() {
     var destroyFlag = $('<input/>').attr('name',destroyFlagName).attr('type','hidden').val('true');
     $("input[name='"+idFieldName+"']").after(destroyFlag);
   }
-  nestedItem.hide();
+  nestedItem.addClass('hidden');
 }
 
 
@@ -102,13 +102,13 @@ function activateCheckboxHooks() {
   $('input[type="checkbox"][data-hide-when-checked]').each(function(){
     $(this).change(function(){
       var el = $($(this).data('hide-when-checked'));
-      el.toggle(!$(this).is(':checked'));
+      el.toggleClass('hidden', $(this).is(':checked'));
     });
   });
   $('input[type="checkbox"][data-show-when-checked]').each(function(){
     $(this).change(function(){
       var el = $($(this).data('show-when-checked'));
-      el.toggle($(this).is(':checked'));
+      el.toggleClass('hidden', !$(this).is(':checked'));
     });
   });
 }
@@ -124,4 +124,3 @@ function activateLabelIcons() {
     });
   };
 };
-

--- a/app/assets/stylesheets/errbit.css.erb
+++ b/app/assets/stylesheets/errbit.css.erb
@@ -171,6 +171,9 @@ a.action  { float: right; font-size: 0.9em;}
   border-bottom: 1px solid #FFF;
   background-color: #f2f2f2;
 }
+#content-title {
+  display: flow-root;
+}
 
 /* Make err title bar bigger to fit more buttons */
 #content-title.err_show {
@@ -770,6 +773,10 @@ table.tally th.value {
   padding: 0;
   vertical-align: bottom;
 }
+/* Use classes for dynamic heights so sparkline rendering remains CSP-compatible. */
+<% (0..100).each do |percent| %>
+.spark > i.height-<%= percent %> { height: <%= percent %>%; }
+<% end %>
 
 /* Resolve Errs */
 #action-bar .resolve:before {
@@ -797,6 +804,12 @@ table.tally th.value {
   width: 16px;
   height: 16px;
   margin-right: 1em;
+}
+.title-avatar {
+  float: left;
+  width: 86px;
+  height: 86px;
+  margin-right: 20px;
 }
 .notice-pagination-loader img {
   vertical-align: middle

--- a/app/assets/stylesheets/tailwind.css
+++ b/app/assets/stylesheets/tailwind.css
@@ -1,3 +1,7 @@
 .hidden {
   display: none;
 }
+
+.visible {
+  visibility: visible;
+}

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -106,8 +106,13 @@ class AppsController < ApplicationController
 
   def search
     respond_to do |format|
-      format.html { render :index }
-      format.js
+      format.html do
+        if request.xhr?
+          render partial: "apps/table", locals: {apps: apps}, layout: false
+        else
+          render :index
+        end
+      end
     end
   end
 

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -157,8 +157,13 @@ class ProblemsController < ApplicationController
 
   def search
     respond_to do |format|
-      format.html { render :index }
-      format.js
+      format.html do
+        if request.xhr?
+          render partial: "problems/table", locals: {problems: problems}, layout: false
+        else
+          render :index
+        end
+      end
     end
   end
 

--- a/app/decorators/app_decorator.rb
+++ b/app/decorators/app_decorator.rb
@@ -16,16 +16,16 @@ class AppDecorator < Draper::Decorator
     object.notice_fingerprinter.attributes["source"] == SiteConfig::CONFIG_SOURCE_SITE
   end
 
-  def custom_notice_fingerprinter_style
-    use_site_fingerprinter ? "display: none" : "display: inline"
+  def custom_notice_fingerprinter_class
+    use_site_fingerprinter ? "hidden" : ""
   end
 
   def notify_user_display
     object.notify_all_users ? "display: none;" : ""
   end
 
-  def notify_err_display
-    object.notify_on_errs ? "" : "display: none;"
+  def notify_err_class
+    object.notify_on_errs ? "" : "hidden"
   end
 
   def custom_backtrace_url(file, line)

--- a/app/helpers/apps_helper.rb
+++ b/app/helpers/apps_helper.rb
@@ -9,7 +9,7 @@ module AppsHelper
     html << select("duplicate", "app",
       App.all.asc(:name).reject { |a| a == @app }
       .collect { |p| [p.name, p.id] }, {include_blank: "[choose app]"},
-      class: "choose_other_app", style: "display: none;")
+      class: "choose_other_app hidden")
     html
   end
 

--- a/app/lib/sparklines.rb
+++ b/app/lib/sparklines.rb
@@ -4,7 +4,8 @@ module Sparklines
   class << self
     def for_relative_percentages(array_of_relative_percentages)
       bars = array_of_relative_percentages.map do |percent|
-        "<i style='height:#{percent}%'></i>"
+        height = percent.round.clamp(0, 100)
+        "<i class='height-#{height}'></i>"
       end.join
       "<div class='spark'>#{bars}</div>".html_safe
     end

--- a/app/views/apps/_fields.html.erb
+++ b/app/views/apps/_fields.html.erb
@@ -68,7 +68,7 @@
   </div>
 
   <% if Errbit::Config.per_app_email_at_notices %>
-    <div class="email_at_notices_nested" style="<%= app_decorate.notify_err_display %>">
+    <div class="email_at_notices_nested <%= app_decorate.notify_err_class %>">
       <div class="field-helpertext">Send a notification every</div>
 
       <%= f.text_field :email_at_notices, value: app_decorate.email_at_notices %>
@@ -88,7 +88,7 @@
 
     <%= f.label :use_site_fingerprinter, t(".use_site_fingerprinter") %>
 
-    <div class="custom_notice_fingerprinter" style="<%= app_decorate.custom_notice_fingerprinter_style %>">
+    <div class="custom_notice_fingerprinter <%= app_decorate.custom_notice_fingerprinter_class %>">
       <%= render "shared/notice_fingerprinter", f: f %>
     </div>
   </div>

--- a/app/views/apps/_search.html.erb
+++ b/app/views/apps/_search.html.erb
@@ -1,3 +1,4 @@
-<%= form_tag search_apps_path, method: :get, remote: true do %>
+<%= form_tag search_apps_path, method: :get, remote: true,
+             class: "search-form", data: {type: "html", search_target: "#app_table"} do %>
   <%= text_field_tag :search, params[:search], placeholder: t(".search_placeholder") %>
 <% end %>

--- a/app/views/apps/search.js.erb
+++ b/app/views/apps/search.js.erb
@@ -1,2 +1,0 @@
-$("#app_table").empty().append("<%= j render("apps/table", apps: apps) %>");
-$("#flash-messages").empty();

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -49,12 +49,3 @@
     </button>
   </div>
 <% end %>
-
-<script>
-  $("a#forgot_password").click(function(){
-    // Set email field on password reset page to email that user entered on this page
-    location.href = $(this).attr("href") + "?email=" + encodeURIComponent($("#user_email").val());
-
-    return false;
-  });
-</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,8 @@
     </div>
 
     <div id="content-wrapper">
-      <div id="content-title" class="<%= yield :title_css_class %>" style="<%= yield :title_style %>">
+      <div id="content-title" class="<%= yield :title_css_class %>">
+        <%= yield :title_avatar %>
         <h1><%= yield :title %></h1>
 
         <span class="meta"><%= yield :meta %></span>

--- a/app/views/notices/_backtrace.html.erb
+++ b/app/views/notices/_backtrace.html.erb
@@ -10,7 +10,7 @@
     <% backtrace.grouped_lines.each do |in_app, line_group| %>
       <% if !in_app && line_group.size > (em * 3) %>
         <%= render partial: "notices/backtrace_line", collection: line_group[0, em], as: :line %>
-        <%= render partial: "notices/backtrace_line", collection: line_group[em, line_group.size - (em * 2)], as: :line, locals: {row_class: "toggle_external_backtrace"} %>
+        <%= render partial: "notices/backtrace_line", collection: line_group[em, line_group.size - (em * 2)], as: :line, locals: {row_class: "toggle_external_backtrace hidden_external_backtrace"} %>
         <tr>
           <td class="line backtrace_separator">
             <span>...</span>

--- a/app/views/notices/_backtrace_line.html.erb
+++ b/app/views/notices/_backtrace_line.html.erb
@@ -1,7 +1,7 @@
 <tr class="<%= defined?(row_class) && row_class %>">
   <td class="line <%= line.in_app? && "in-app" %>">
     <%= line.link_to_source_file(app) do %>
-      <span class="path"><%= raw line.decorated_path %></span>
+      <span class="path"><%= sanitize(line.decorated_path, tags: ["strong"], attributes: []) %></span>
 
       <span class="file"><%= line.file_name %></span>
 

--- a/app/views/notices/_summary.html.erb
+++ b/app/views/notices/_summary.html.erb
@@ -34,7 +34,7 @@
       <td><%= problem.notices_count - 1 %></td>
     </tr>
 
-    <tr id="sparkline-placeholder"></tr>
+    <tr id="sparkline-placeholder" data-sparkline-url="<%= xhr_sparkline_app_problem_path(app_id: notice.app.id, id: problem.id) %>"></tr>
 
     <tr>
       <th><%= t(".browser") %></th>
@@ -73,9 +73,3 @@
     </tr>
   </table>
 </div>
-
-<script>
-  $.ajax({url: "<%= xhr_sparkline_app_problem_path(app_id: notice.app.id, id: problem.id) %>"}).then(function(response) {
-    $("#sparkline-placeholder").replaceWith(response);
-  });
-</script>

--- a/app/views/problems/_search.html.erb
+++ b/app/views/problems/_search.html.erb
@@ -1,4 +1,6 @@
 <%# locals: (all_errs:, app_id:, params_sort:, params_order:) %>
-<%= form_tag search_problems_path(all_errs: all_errs, app_id: app_id, sort: params_sort, order: params_order), method: :get, remote: true do %>
+<%= form_tag search_problems_path(all_errs: all_errs, app_id: app_id, sort: params_sort, order: params_order),
+             method: :get, remote: true, class: "search-form",
+             data: {type: "html", search_target: "#problem_table"} do %>
   <%= text_field_tag :search, params[:search], placeholder: t(".search_placeholder") %>
 <% end %>

--- a/app/views/problems/_tally_table.html.erb
+++ b/app/views/problems/_tally_table.html.erb
@@ -22,7 +22,7 @@
     <% end %>
   </table>
 
-  <table class="tally tail" style="display: none">
+  <table class="tally tail hidden">
     <tbody>
       <% tail(rows).each do |row| %>
         <tr>

--- a/app/views/problems/search.js.erb
+++ b/app/views/problems/search.js.erb
@@ -1,4 +1,0 @@
-$("#problem_table").empty().append("<%= j render("problems/table", problems: problems) %>");
-$("#flash-messages").empty();
-toggleProblemsCheckboxes();
-bindProblemButtonsActions();

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,9 +1,8 @@
 <% content_for :title, @user.name %>
 
 <% if Errbit::Config.use_gravatar && (gravatar = gravatar_url(@user.email, s: 86)) %>
-  <% content_for :title_style do %>
-    background: url('<%= gravatar %>') no-repeat;
-    padding-left: 106px;
+  <% content_for :title_avatar do %>
+    <%= image_tag gravatar, class: "title-avatar", alt: "" %>
   <% end %>
 <% end %>
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -2,30 +2,23 @@
 
 # Be sure to restart your server when you modify this file.
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+require "securerandom"
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.base_uri :self
+    policy.connect_src :self
+    policy.font_src :self, :https, :data
+    policy.form_action :self
+    policy.frame_ancestors :self
+    policy.img_src :self, :https, :data
+    policy.object_src :none
+    policy.script_src :self
+    policy.style_src :self
+  end
+
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = ["script-src", "style-src"]
+  config.content_security_policy_nonce_auto = true
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,13 +9,15 @@ Rails.application.configure do
     policy.default_src :self
     policy.base_uri :self
     policy.connect_src :self
-    policy.font_src :self, :https, :data
+    policy.font_src :self
     policy.form_action :self
+    policy.frame_src :self
     policy.frame_ancestors :self
-    policy.img_src :self, :https, :data
+    policy.img_src :self, "https://secure.gravatar.com", :data
     policy.object_src :none
     policy.script_src :self
     policy.style_src :self
+    policy.upgrade_insecure_requests if Rails.env.production?
   end
 
   config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }

--- a/docs/relnotes/v0.11.5.md
+++ b/docs/relnotes/v0.11.5.md
@@ -13,4 +13,4 @@
 
 ## Security
 
-None.
+1. Enable a strict application-wide [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) with per-request nonces and CSP-compatible UI behavior by @mikelolasagasti in [errbit/errbit#3109](https://github.com/errbit/errbit/pull/3109)

--- a/spec/decorators/app_decorator_spec.rb
+++ b/spec/decorators/app_decorator_spec.rb
@@ -19,13 +19,29 @@ RSpec.describe AppDecorator, type: :decorator do
     end
   end
 
-  describe "#notify_err_display" do
-    it "return display:none if no notify" do
-      expect(described_class.new(double(notify_on_errs: false)).notify_err_display).to eq("display: none;")
+  describe "#notify_err_class" do
+    it "returns hidden if no notify" do
+      expect(described_class.new(double(notify_on_errs: false)).notify_err_class).to eq("hidden")
     end
 
-    it "return blank if no notify" do
-      expect(described_class.new(double(notify_on_errs: true)).notify_err_display).to eq("")
+    it "returns blank if notify" do
+      expect(described_class.new(double(notify_on_errs: true)).notify_err_class).to eq("")
+    end
+  end
+
+  describe "#custom_notice_fingerprinter_class" do
+    it "returns hidden when using the site fingerprinter" do
+      fingerprinter = double(attributes: {"source" => SiteConfig::CONFIG_SOURCE_SITE})
+      app = double(notice_fingerprinter: fingerprinter)
+
+      expect(described_class.new(app).custom_notice_fingerprinter_class).to eq("hidden")
+    end
+
+    it "returns blank when using a custom fingerprinter" do
+      fingerprinter = double(attributes: {"source" => "custom"})
+      app = double(notice_fingerprinter: fingerprinter)
+
+      expect(described_class.new(app).custom_notice_fingerprinter_class).to eq("")
     end
   end
 

--- a/spec/lib/sparklines_spec.rb
+++ b/spec/lib/sparklines_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe Sparklines do
-  it "includes each percentage and adds a percent sign" do
+  it "includes a height class for each percentage" do
     percentages = [33, 75, 100]
     html = described_class.for_relative_percentages(percentages)
     percentages.each do |percentage|
-      expect(html).to include("#{percentage}%")
+      expect(html).to include("height-#{percentage}")
     end
   end
 

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Content Security Policy", type: :request do
+  it "includes the nonce on executable script tags" do
+    get new_user_session_path
+
+    nonce = response.headers.fetch("Content-Security-Policy").match(/nonce-([^' ]+)/)[1]
+
+    expect(response.body).to match(/<script[^>]+nonce="#{Regexp.escape(nonce)}"/)
+  end
+
+  it "generates a different nonce for each response" do
+    get new_user_session_path
+    first_nonce = response.headers.fetch("Content-Security-Policy").match(/nonce-([^' ]+)/)[1]
+
+    get new_user_session_path
+    second_nonce = response.headers.fetch("Content-Security-Policy").match(/nonce-([^' ]+)/)[1]
+
+    expect(second_nonce).not_to eq(first_nonce)
+  end
+end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -20,4 +20,24 @@ RSpec.describe "Content Security Policy", type: :request do
 
     expect(second_nonce).not_to eq(first_nonce)
   end
+
+  it "restricts fonts and frames to the application origin" do
+    get new_user_session_path
+
+    policy = response.headers.fetch("Content-Security-Policy")
+
+    expect(policy).to include("font-src 'self'")
+    expect(policy).to include("frame-src 'self'")
+    expect(policy).not_to include("font-src 'self' https:")
+    expect(policy).not_to include("font-src 'self' data:")
+  end
+
+  it "allows Gravatar images without allowing arbitrary HTTPS images" do
+    get new_user_session_path
+
+    policy = response.headers.fetch("Content-Security-Policy")
+
+    expect(policy).to include("img-src 'self' https://secure.gravatar.com data:")
+    expect(policy).not_to include("img-src 'self' https:;")
+  end
 end

--- a/spec/system/csp_compatibility_spec.rb
+++ b/spec/system/csp_compatibility_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CSP-compatible browser behavior", type: :system, retry: 3 do
+  let!(:user) { create(:user, admin: true) }
+
+  it "loads the notice sparkline" do
+    app = create(:app)
+    problem = create(:problem, app: app)
+    err = create(:err, problem: problem)
+    notice = create(:notice, app: app, err: err)
+    create(:notice, app: app, err: err)
+    sign_in user
+
+    visit app_problem_path(notice.app, notice.problem)
+
+    expect(page).to have_css(".spark")
+    expect(page).to have_css(".spark > i[class*='height-']")
+
+    click_link "Older"
+
+    expect(page).to have_css(".spark > i[class*='height-']")
+  end
+
+  it "toggles conditional application fields without inline styles" do
+    allow(Errbit::Config).to receive(:per_app_email_at_notices).and_return(true)
+    app = create(:app, notify_on_errs: false, notice_fingerprinter: nil)
+    sign_in user
+
+    visit edit_app_path(app)
+
+    expect(page).to have_css(".email_at_notices_nested", visible: :hidden)
+    check "Notify on errors"
+    expect(page).to have_css(".email_at_notices_nested", visible: :visible)
+    uncheck "Notify on errors"
+    expect(page).to have_css(".email_at_notices_nested", visible: :hidden)
+  end
+end

--- a/spec/system/csp_compatibility_spec.rb
+++ b/spec/system/csp_compatibility_spec.rb
@@ -36,4 +36,32 @@ RSpec.describe "CSP-compatible browser behavior", type: :system, retry: 3 do
     uncheck "Notify on errors"
     expect(page).to have_css(".email_at_notices_nested", visible: :hidden)
   end
+
+  it "updates the app search without evaluating a JavaScript response" do
+    create(:app, name: "Searchable Demo App")
+    sign_in user
+
+    visit apps_path
+    fill_in "search", with: "Searchable"
+    find("#search").send_keys(:enter)
+
+    expect(page).to have_css("#app_table", text: "Searchable Demo App")
+  end
+
+  it "updates the problem search without evaluating a JavaScript response" do
+    app = create(:app)
+    create(:problem, app: app, message: "Searchable problem")
+    create(:problem, app: app, message: "Other problem")
+    sign_in user
+
+    visit problems_path
+    fill_in "search", with: "Searchable"
+    find("#search").send_keys(:enter)
+
+    expect(page).to have_css("#problem_table", text: "Searchable problem")
+    expect(page).not_to have_css("#problem_table", text: "Other problem")
+
+    check "toggle_problems_checkboxes"
+    expect(page).to have_checked_field("problems[]")
+  end
 end

--- a/spec/system/sign_in_and_sign_out_spec.rb
+++ b/spec/system/sign_in_and_sign_out_spec.rb
@@ -44,4 +44,14 @@ RSpec.describe "Sign in and sign out with email and password", type: :system, re
       expect(page).to have_content(I18n.t("devise.failure.invalid", authentication_keys: "email"))
     end
   end
+
+  it "carries the entered email to the password reset form" do
+    visit new_user_session_path
+
+    fill_in "Email", with: user.email
+    click_link "forgot it?"
+
+    expect(page).to have_current_path(new_user_password_path, ignore_query: true)
+    expect(page).to have_field("Email", with: user.email)
+  end
 end

--- a/spec/views/notices/_backtrace_line.html.erb_spec.rb
+++ b/spec/views/notices/_backtrace_line.html.erb_spec.rb
@@ -3,4 +3,30 @@
 require "rails_helper"
 
 RSpec.describe "notices/_backtrace_line.html.erb", type: :view do
+  let(:line) do
+    instance_double(
+      BacktraceLineDecorator,
+      decorated_path: "gems/foo/<strong>bar</strong><script>alert(1)</script><img src=x onerror=alert(1)>",
+      file_name: "example.rb",
+      in_app?: false,
+      method: "call",
+      number: nil,
+      column: nil
+    )
+  end
+
+  before do
+    allow(line).to receive(:link_to_source_file) { |&block| view.capture(&block) }
+    render partial: "notices/backtrace_line", locals: {line: line, app: double}
+  end
+
+  it "preserves gem highlighting" do
+    expect(rendered).to include("gems/foo/<strong>bar</strong>")
+  end
+
+  it "removes unsafe markup and attributes" do
+    expect(rendered).not_to include("<script>")
+    expect(rendered).not_to include("onerror=")
+    expect(rendered).not_to include("<img")
+  end
 end


### PR DESCRIPTION
Enable a strict Content Security Policy for Errbit and make the existing UI compatible with it.

- Add an application-wide CSP with per-request nonces for scripts and styles.
- Move inline JavaScript into the existing asset bundles.
- Replace inline styles and runtime style mutations with CSS classes.
- Preserve sparklines, dynamic forms, tabs, pagination, and backtrace interactions.
- Sanitize highlighted backtrace paths.
- Add CSP request, system, view, and helper coverage.
- Manual testing completed with Firefox and Chrome.

Closes #3102