### PR TITLE
Add semantic autocomplete attributes to authentication forms

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -8,13 +8,13 @@
   <div class="required">
     <%= f.label :password, "New password" %>
 
-    <%= f.password_field :password %>
+    <%= f.password_field :password, autocomplete: "new-password" %>
   </div>
 
   <div class="required">
     <%= f.label :password_confirmation, "Type your new password again" %>
 
-    <%= f.password_field :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="buttons">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -6,7 +6,7 @@
   <div class="required">
     <%= f.label :email %>
 
-    <%= f.text_field :email, value: params[:email] %>
+    <%= f.text_field :email, value: params[:email], autocomplete: "email" %>
   </div>
 
   <div class="buttons">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "Sign in" %>
 
 <% auth_key = Devise.authentication_keys.first %>
+<% auth_key_autocomplete = Errbit::Config.user_has_username ? "username" : "email" %>
 
 <% if Errbit::Config.github_authentication || Errbit::Config.google_authentication %>
   <% content_for :action_bar do %>
@@ -24,7 +25,7 @@
   <div class="required">
     <%= f.label auth_key %>
 
-    <%= f.text_field auth_key, type: (Errbit::Config.user_has_username ? "text" : "email"), tabindex: 1, autofocus: true %>
+    <%= f.text_field auth_key, type: (Errbit::Config.user_has_username ? "text" : "email"), autocomplete: auth_key_autocomplete, tabindex: 1, autofocus: true %>
   </div>
 
   <div class="required">
@@ -32,7 +33,7 @@
 
     <%= f.label :password %>
 
-    <%= f.password_field :password, tabindex: 2 %>
+    <%= f.password_field :password, autocomplete: "current-password", tabindex: 2 %>
   </div>
 
   <% if devise_mapping.rememberable? %>

--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -38,12 +38,12 @@
 
 <div class="required">
   <%= f.label :password, t(".password") %>
-  <%= f.password_field :password, autocomplete: "off" %>
+  <%= f.password_field :password, autocomplete: "new-password" %>
 </div>
 
 <div class="required">
   <%= f.label :password_confirmation, t(".password_confirmation") %>
-  <%= f.password_field :password_confirmation %>
+  <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
 </div>
 
 <% if current_user.admin? %>

--- a/app/views/users/_fields.html.erb
+++ b/app/views/users/_fields.html.erb
@@ -10,13 +10,13 @@
 <% if Errbit::Config.user_has_username %>
   <div class="required">
     <%= f.label :username, t(".username") %>
-    <%= f.text_field :username %>
+    <%= f.text_field :username, autocomplete: "username" %>
   </div>
 <% end %>
 
 <div class="required">
   <%= f.label :email, t(".email") %>
-  <%= f.text_field :email %>
+  <%= f.text_field :email, autocomplete: "email" %>
 </div>
 
 <% if Errbit::Config.github_authentication %>

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -178,6 +178,10 @@ RSpec.describe UsersController, type: :request do
           expect(response).to have_http_status(:ok)
 
           expect(assigns(:user)).to eq(user)
+          form = response.parsed_body
+          expect(form.at_css('input[name="user[email]"][autocomplete="email"]')).not_to be_nil
+          expect(form.at_css('input[name="user[password]"][autocomplete="new-password"]')).not_to be_nil
+          expect(form.at_css('input[name="user[password_confirmation]"][autocomplete="new-password"]')).not_to be_nil
         end
       end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -124,9 +124,10 @@ RSpec.describe UsersController, type: :request do
           expect(response).to have_http_status(:ok)
 
           expect(assigns(:user).new_record?).to eq(true)
-          expect(response.body).to include('name="user[password]"')
-          expect(response.body).to include('name="user[password_confirmation]"')
-          expect(response.body.scan('autocomplete="new-password"').size).to eq(2)
+          form = response.parsed_body
+          expect(form.at_css('input[name="user[email]"][autocomplete="email"]')).not_to be_nil
+          expect(form.at_css('input[name="user[password]"][autocomplete="new-password"]')).not_to be_nil
+          expect(form.at_css('input[name="user[password_confirmation]"][autocomplete="new-password"]')).not_to be_nil
         end
       end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -124,6 +124,9 @@ RSpec.describe UsersController, type: :request do
           expect(response).to have_http_status(:ok)
 
           expect(assigns(:user).new_record?).to eq(true)
+          expect(response.body).to include('name="user[password]"')
+          expect(response.body).to include('name="user[password_confirmation]"')
+          expect(response.body.scan('autocomplete="new-password"').size).to eq(2)
         end
       end
 

--- a/spec/system/sign_in_and_sign_out_spec.rb
+++ b/spec/system/sign_in_and_sign_out_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe "Sign in and sign out with email and password", type: :system, re
       visit root_path
 
       expect(page).to have_content(I18n.t("devise.failure.unauthenticated"))
+      expect(page).to have_css('input[name="user[email]"][autocomplete="email"]')
+      expect(page).to have_css('input[name="user[password]"][autocomplete="current-password"]')
 
       fill_in "Email", with: user.email
       fill_in "Password", with: "password"
@@ -53,5 +55,11 @@ RSpec.describe "Sign in and sign out with email and password", type: :system, re
 
     expect(page).to have_current_path(new_user_password_path, ignore_query: true)
     expect(page).to have_field("Email", with: user.email)
+  end
+
+  it "renders the password reset email autocomplete attribute" do
+    visit new_user_password_path
+
+    expect(page).to have_css('input[name="user[email]"][autocomplete="email"]')
   end
 end

--- a/spec/system/sign_in_and_sign_out_spec.rb
+++ b/spec/system/sign_in_and_sign_out_spec.rb
@@ -62,4 +62,26 @@ RSpec.describe "Sign in and sign out with email and password", type: :system, re
 
     expect(page).to have_css('input[name="user[email]"][autocomplete="email"]')
   end
+
+  it "renders the password reset new-password autocomplete attributes" do
+    token = user.send_reset_password_instructions
+    visit edit_user_password_path(reset_password_token: token)
+
+    expect(page).to have_css('input[name="user[password]"][autocomplete="new-password"]')
+    expect(page).to have_css('input[name="user[password_confirmation]"][autocomplete="new-password"]')
+  end
+
+  it "renders the username autocomplete attribute when username authentication is enabled" do
+    allow(Errbit::Config).to receive(:user_has_username).and_return(true)
+    allow(Devise).to receive(:authentication_keys).and_return([:username])
+    allow(User).to receive(:new).and_wrap_original do |original, *args|
+      original.call(*args).tap do |resource|
+        allow(resource).to receive(:username).and_return(nil)
+      end
+    end
+
+    visit new_user_session_path
+
+    expect(page).to have_css('input[name="user[username]"][autocomplete="username"]')
+  end
 end


### PR DESCRIPTION
Use `current-password` for sign-in and `new-password` for account creation and password reset forms. Add `email` and `username` autocomplete hints for authentication identifiers.

Add regression coverage for sign-in, password reset, and user creation form attributes.

Closes #3111