### PR TITLE
Add typed environment configuration

### DIFF
--- a/app/lib/configurator.rb
+++ b/app/lib/configurator.rb
@@ -34,8 +34,17 @@ class Configurator
   #   config.key_one
   #   #=> 'another'
   #
-  # @param Hash map of configuration keys with array values where the array is
-  #   a list of environment variables to scan for configuration
+  # @example Using typed values
+  #   config = Configurator.run(
+  #     port: {env: 'PORT', type: :integer}
+  #   )
+  #
+  #   config.port
+  #   #=> 3000
+  #
+  # @param [Hash] mapping configuration keys mapped to legacy environment-name
+  #   arrays or typed definitions with :env, :type, and optional :override keys
+  #   Supported types are :boolean, :integer, :string_array, and :integer_array.
   # @return OpenStruct configuration object
   def self.run(mapping)
     reader = new(mapping)
@@ -54,13 +63,104 @@ class Configurator
 
   # Process the environment variable values and store the overrides
   def scan
-    @mapping.each do |key, values|
-      @overrides[key] = values.pop if values.last.is_a? Proc
-      env_name = values.find { |v| ENV[v] }
-      @storage[key] = if env_name
-        ENV[env_name].empty? ? "" : YAML.parse(ENV[env_name]).to_ruby
-      end
+    @mapping.each do |key, definition|
+      env_names, type, override = parse_definition(definition)
+      @overrides[key] = override if override
+      env_name = env_names.find { |name| ENV[name] }
+      @storage[key] = parse_value(ENV[env_name], type, env_name) if env_name
     end
+  end
+
+  def parse_definition(definition)
+    if definition.is_a?(Hash)
+      env_names = Array(definition.fetch(:env))
+      raise ArgumentError, "configuration environment names cannot be empty" if env_names.empty?
+
+      [env_names, definition[:type], definition[:override]]
+    else
+      values = Array(definition).dup
+      override = values.pop if values.last.is_a? Proc
+      [values, nil, override]
+    end
+  end
+
+  def parse_value(value, type, env_name)
+    return value.empty? ? "" : YAML.parse(value).to_ruby unless type
+
+    case type
+    when :boolean
+      parse_boolean(value, env_name)
+    when :integer
+      parse_integer(value, env_name)
+    when :string_array
+      parse_array(value, env_name) { |item| item.to_s.strip }
+    when :integer_array
+      parse_array(value, env_name) { |item| parse_integer(item, env_name) }
+    else
+      raise ArgumentError, "Unsupported configuration type #{type.inspect}"
+    end
+  end
+
+  def parse_boolean(value, env_name)
+    value = strip_quotes(value.to_s.strip)
+    raise ArgumentError, "#{env_name} cannot be empty" if value.empty?
+
+    case value.downcase
+    when "true" then true
+    when "false" then false
+    else
+      raise ArgumentError, "#{env_name} must be true or false"
+    end
+  end
+
+  def parse_integer(value, env_name)
+    value = strip_quotes(value.to_s.strip)
+    raise ArgumentError, "#{env_name} cannot be empty" if value.empty?
+
+    begin
+      Integer(value, 10)
+    rescue ArgumentError
+      raise ArgumentError, "#{env_name} must contain an integer, got #{value.inspect}"
+    end
+  end
+
+  def parse_array(value, env_name)
+    value = value.to_s.strip
+    raise ArgumentError, "#{env_name} cannot be empty" if value.empty?
+
+    value = strip_quotes(value)
+    values = if value.start_with?("[") || value.end_with?("]")
+      unless value.start_with?("[") && value.end_with?("]")
+        raise ArgumentError, "#{env_name} must contain a valid list"
+      end
+
+      parse_yaml_array(value, env_name)
+    else
+      value.split(",")
+    end
+
+    if values.any? { |item| item.to_s.strip.empty? }
+      raise ArgumentError, "#{env_name} must not contain empty list elements"
+    end
+
+    values.map { |item| yield item }
+  end
+
+  def strip_quotes(value)
+    if value.match?(/\A(['"]).*\1\z/)
+      value[1...-1]
+    else
+      value
+    end
+  end
+
+  def parse_yaml_array(value, env_name)
+    parsed = YAML.safe_load(value, permitted_classes: [], aliases: false)
+    raise ArgumentError, "#{env_name} must contain a list" unless parsed.is_a?(Array)
+
+    parsed
+  rescue Psych::Exception
+    raise ArgumentError, "#{env_name} must contain a valid list"
   end
 
   # Apply the override functions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User
       match_data = /.+@(?<domain>.+)$/.match(email)
       return false if match_data.nil?
 
-      Errbit::Config.google_authorized_domains.split(",").include?(match_data[:domain])
+      Errbit::Config.google_authorized_domains.include?(match_data[:domain])
     end
 
     # @param access_token [String]

--- a/config/load.rb
+++ b/config/load.rb
@@ -11,15 +11,15 @@ require_relative "../app/lib/configurator"
 # element is a proc, it runs at the end, overriding the config value
 Errbit::Config = Configurator.run(
   host: ["ERRBIT_HOST"],
-  confirm_err_actions: ["ERRBIT_CONFIRM_ERR_ACTIONS"],
-  user_has_username: ["ERRBIT_USER_HAS_USERNAME"],
-  use_gravatar: ["ERRBIT_USE_GRAVATAR"],
+  confirm_err_actions: {env: ["ERRBIT_CONFIRM_ERR_ACTIONS"], type: :boolean},
+  user_has_username: {env: ["ERRBIT_USER_HAS_USERNAME"], type: :boolean},
+  use_gravatar: {env: ["ERRBIT_USE_GRAVATAR"], type: :boolean},
   gravatar_default: ["ERRBIT_GRAVATAR_DEFAULT"],
   email_from: ["ERRBIT_EMAIL_FROM"],
-  email_at_notices: ["ERRBIT_EMAIL_AT_NOTICES"],
-  per_app_email_at_notices: ["ERRBIT_PER_APP_EMAIL_AT_NOTICES"],
-  notify_at_notices: ["ERRBIT_NOTIFY_AT_NOTICES"],
-  per_app_notify_at_notices: ["ERRBIT_PER_APP_NOTIFY_AT_NOTICES"],
+  email_at_notices: {env: ["ERRBIT_EMAIL_AT_NOTICES"], type: :integer_array},
+  per_app_email_at_notices: {env: ["ERRBIT_PER_APP_EMAIL_AT_NOTICES"], type: :boolean},
+  notify_at_notices: {env: ["ERRBIT_NOTIFY_AT_NOTICES"], type: :integer_array},
+  per_app_notify_at_notices: {env: ["ERRBIT_PER_APP_NOTIFY_AT_NOTICES"], type: :boolean},
   log_location: ["ERRBIT_LOG_LOCATION"],
   notice_deprecation_days: ["ERRBIT_PROBLEM_DESTROY_AFTER_DAYS"],
 
@@ -30,21 +30,21 @@ Errbit::Config = Configurator.run(
   github_url: ["GITHUB_URL", lambda do |values|
     values[:github_url].gsub(%r{/*\z}, "")
   end],
-  github_authentication: ["GITHUB_AUTHENTICATION"],
+  github_authentication: {env: ["GITHUB_AUTHENTICATION"], type: :boolean},
   github_client_id: ["GITHUB_CLIENT_ID"],
   github_secret: ["GITHUB_SECRET"],
-  github_org_id: ["GITHUB_ORG_ID"],
-  github_access_scope: ["GITHUB_ACCESS_SCOPE"],
+  github_org_id: {env: ["GITHUB_ORG_ID"], type: :integer},
+  github_access_scope: {env: ["GITHUB_ACCESS_SCOPE"], type: :string_array},
   github_api_url: ["GITHUB_API_URL"],
   github_site_title: ["GITHUB_SITE_TITLE"],
   # google
-  google_authentication: ["GOOGLE_AUTHENTICATION"],
-  google_auto_provision: ["GOOGLE_AUTO_PROVISION"],
+  google_authentication: {env: ["GOOGLE_AUTHENTICATION"], type: :boolean},
+  google_auto_provision: {env: ["GOOGLE_AUTO_PROVISION"], type: :boolean},
   google_site_title: ["GOOGLE_SITE_TITLE"],
   google_client_id: ["GOOGLE_CLIENT_ID"],
   google_secret: ["GOOGLE_SECRET"],
   google_redirect_uri: ["GOOGLE_REDIRECT_URI"],
-  google_authorized_domains: ["GOOGLE_AUTHORIZED_DOMAINS"],
+  google_authorized_domains: {env: ["GOOGLE_AUTHORIZED_DOMAINS"], type: :string_array},
 
   email_delivery_method: ["EMAIL_DELIVERY_METHOD", lambda do |values|
     email_delivery_method = values[:email_delivery_method]
@@ -58,9 +58,9 @@ Errbit::Config = Configurator.run(
 
   # SMTP settings
   smtp_address: ["SMTP_SERVER"],
-  smtp_port: ["SMTP_PORT"],
+  smtp_port: {env: ["SMTP_PORT"], type: :integer},
   smtp_authentication: ["SMTP_AUTHENTICATION"],
-  smtp_enable_starttls_auto: ["SMTP_ENABLE_STARTTLS_AUTO"],
+  smtp_enable_starttls_auto: {env: ["SMTP_ENABLE_STARTTLS_AUTO"], type: :boolean},
   smtp_openssl_verify_mode: ["SMTP_OPENSSL_VERIFY_MODE"],
   smtp_user_name: ["SMTP_USERNAME", "SENDGRID_USERNAME"],
   smtp_password: ["SMTP_PASSWORD", "SENDGRID_PASSWORD"],
@@ -73,5 +73,5 @@ Errbit::Config = Configurator.run(
   sendmail_location: ["SENDMAIL_LOCATION"],
   sendmail_arguments: ["SENDMAIL_ARGUMENTS"],
 
-  devise_modules: ["DEVISE_MODULES"]
+  devise_modules: {env: ["DEVISE_MODULES"], type: :string_array}
 )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,6 +83,13 @@ You can learn more about thruster environment variables [here](https://github.co
 
 ### Application environment variables
 
+Errbit validates settings with a known type while loading the environment. Array
+settings use the bracketed format shown below as the canonical syntax. Typed
+arrays also accept comma-separated and single-value forms.
+Boolean settings must be `true` or `false`, and numeric settings must contain a
+valid integer. Invalid typed settings prevent Errbit from booting so a
+configuration error is reported immediately.
+
 #### `MONGO_URL`
 
 MongoDB connection string in the form
@@ -186,7 +193,7 @@ Default in container: same as default value.
 <dd>The redirect URI for your application (useful if you want to redirect using HTTPS)
 <dd>defaults to the HTTP location of ERRBIT_HOST
 <dt>GOOGLE_AUTHORIZED_DOMAINS
-<dd>A comma-delimited list of account domains that are permitted to sign-in (recommended to set when GOOGLE_AUTO_PROVISION is set to true)
+<dd>A list of account domains that are permitted to sign-in (recommended to set when GOOGLE_AUTO_PROVISION is set to true). Bracketed array syntax is canonical; comma-separated values are also accepted.
 <dt>GOOGLE_SITE_TITLE</dt>
 <dd>The title to use for Google. This value is whatever you want displayed in the Errbit UI when referring to Google.</dd>
 <dd>defaults to Google</dd>
@@ -205,7 +212,7 @@ Default in container: same as default value.
 <dt>SMTP_DOMAIN
 <dd>HELO domain to set for outgoing SMTP messages, you can also use SENDGRID_DOMAIN
 <dt>SMTP_ENABLE_STARTTLS_AUTO
-<dd>Detects if STARTTLS is enabled in your SMTP server and starts to use it
+<dd>Detects if STARTTLS is enabled in your SMTP server and starts to use it. Must be `true` or `false`.
 <dt>SMTP_OPENSSL_VERIFY_MODE
 <dd>When using TLS, you can set how OpenSSL checks the certificate. This is really useful if you need to validate a self-signed and/or a wildcard certificate. You can use the name of an OpenSSL verify constant ('none', 'peer', 'client_once', 'fail_if_no_peer_cert').
 <dt>SENDMAIL_LOCATION

--- a/spec/config/load_spec.rb
+++ b/spec/config/load_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "config/load" do
+  before do
+    @original_config = Errbit::Config if Errbit.const_defined?(:Config, false)
+  end
+
+  def load_config_with(env)
+    allow(ENV).to receive(:[]).and_return(nil)
+    allow(ENV).to receive(:[]).with("GITHUB_URL").and_return("https://github.com")
+    env.each do |key, value|
+      allow(ENV).to receive(:[]).with(key).and_return(value)
+    end
+
+    Errbit.send(:remove_const, :Config) if Errbit.const_defined?(:Config, false)
+    load Rails.root.join("config/load.rb")
+  rescue
+    restore_config
+    raise
+  end
+
+  def restore_config
+    Errbit.send(:remove_const, :Config) if Errbit.const_defined?(:Config, false)
+    Errbit.const_set(:Config, @original_config) if @original_config
+  end
+
+  after { restore_config }
+
+  it "loads typed application settings" do
+    load_config_with(
+      "ERRBIT_CONFIRM_ERR_ACTIONS" => "false",
+      "ERRBIT_EMAIL_AT_NOTICES" => "1, 10, 100",
+      "ERRBIT_NOTIFY_AT_NOTICES" => "0",
+      "ERRBIT_PER_APP_EMAIL_AT_NOTICES" => "true",
+      "ERRBIT_PER_APP_NOTIFY_AT_NOTICES" => "false",
+      "GITHUB_ACCESS_SCOPE" => "repo, user",
+      "GITHUB_AUTHENTICATION" => "true",
+      "GITHUB_ORG_ID" => "123",
+      "GOOGLE_AUTHENTICATION" => "false",
+      "GOOGLE_AUTO_PROVISION" => "true",
+      "GOOGLE_AUTHORIZED_DOMAINS" => "example.com, example.org",
+      "SMTP_PORT" => "2525",
+      "SMTP_ENABLE_STARTTLS_AUTO" => "false",
+      "DEVISE_MODULES" => "database_authenticatable, recoverable"
+    )
+
+    expect(Errbit::Config.confirm_err_actions).to be(false)
+    expect(Errbit::Config.email_at_notices).to eq([1, 10, 100])
+    expect(Errbit::Config.notify_at_notices).to eq([0])
+    expect(Errbit::Config.per_app_email_at_notices).to be(true)
+    expect(Errbit::Config.per_app_notify_at_notices).to be(false)
+    expect(Errbit::Config.github_access_scope).to eq(["repo", "user"])
+    expect(Errbit::Config.github_authentication).to be(true)
+    expect(Errbit::Config.github_org_id).to eq(123)
+    expect(Errbit::Config.google_authentication).to be(false)
+    expect(Errbit::Config.google_auto_provision).to be(true)
+    expect(Errbit::Config.google_authorized_domains).to eq(["example.com", "example.org"])
+    expect(Errbit::Config.smtp_port).to eq(2525)
+    expect(Errbit::Config.smtp_enable_starttls_auto).to be(false)
+    expect(Errbit::Config.devise_modules).to eq(["database_authenticatable", "recoverable"])
+  end
+
+  it "rejects an invalid typed setting" do
+    expect do
+      load_config_with("ERRBIT_EMAIL_AT_NOTICES" => "1, invalid, 100")
+    end.to raise_error(ArgumentError, /ERRBIT_EMAIL_AT_NOTICES must contain an integer/)
+  end
+end

--- a/spec/lib/configurator_spec.rb
+++ b/spec/lib/configurator_spec.rb
@@ -79,4 +79,159 @@ RSpec.describe Configurator do
 
     expect(result.emptyvar).to eq("")
   end
+
+  describe "typed values" do
+    it "parses booleans strictly" do
+      allow(ENV).to receive(:[]).with("TRUE_VALUE").and_return("true")
+      allow(ENV).to receive(:[]).with("FALSE_VALUE").and_return('"false"')
+
+      result = described_class.run(
+        true_value: {env: ["TRUE_VALUE"], type: :boolean},
+        false_value: {env: ["FALSE_VALUE"], type: :boolean}
+      )
+
+      expect(result.true_value).to be(true)
+      expect(result.false_value).to be(false)
+    end
+
+    it "rejects ambiguous booleans" do
+      allow(ENV).to receive(:[]).with("BOOLEAN_VALUE").and_return("maybe")
+
+      expect do
+        described_class.run(boolean_value: {env: ["BOOLEAN_VALUE"], type: :boolean})
+      end.to raise_error(ArgumentError, "BOOLEAN_VALUE must be true or false")
+    end
+
+    it "parses integers" do
+      allow(ENV).to receive(:[]).with("INTEGER_VALUE").and_return('"2525"')
+
+      result = described_class.run(integer_value: {env: "INTEGER_VALUE", type: :integer})
+
+      expect(result.integer_value).to eq(2525)
+    end
+
+    it "rejects invalid integers" do
+      allow(ENV).to receive(:[]).with("INTEGER_VALUE").and_return("25.25")
+
+      expect do
+        described_class.run(integer_value: {env: ["INTEGER_VALUE"], type: :integer})
+      end.to raise_error(ArgumentError, /INTEGER_VALUE must contain an integer/)
+    end
+
+    it "rejects empty typed scalar values" do
+      allow(ENV).to receive(:[]).with("EMPTY_BOOLEAN").and_return(" ")
+      allow(ENV).to receive(:[]).with("EMPTY_INTEGER").and_return("")
+
+      expect do
+        described_class.run(empty_boolean: {env: ["EMPTY_BOOLEAN"], type: :boolean})
+      end.to raise_error(ArgumentError, "EMPTY_BOOLEAN cannot be empty")
+
+      expect do
+        described_class.run(empty_integer: {env: ["EMPTY_INTEGER"], type: :integer})
+      end.to raise_error(ArgumentError, "EMPTY_INTEGER cannot be empty")
+    end
+
+    it "parses string arrays from YAML and comma-separated values" do
+      allow(ENV).to receive(:[]).with("YAML_ARRAY").and_return("[repo, user]")
+      allow(ENV).to receive(:[]).with("CSV_ARRAY").and_return('"example.com, example.org"')
+      allow(ENV).to receive(:[]).with("SINGLE_VALUE").and_return("repo")
+
+      result = described_class.run(
+        yaml_array: {env: ["YAML_ARRAY"], type: :string_array},
+        csv_array: {env: ["CSV_ARRAY"], type: :string_array},
+        single_value: {env: ["SINGLE_VALUE"], type: :string_array}
+      )
+
+      expect(result.yaml_array).to eq(["repo", "user"])
+      expect(result.csv_array).to eq(["example.com", "example.org"])
+      expect(result.single_value).to eq(["repo"])
+    end
+
+    it "rejects empty elements in typed arrays" do
+      allow(ENV).to receive(:[]).with("INTEGER_ARRAY").and_return('"1,, 10,"')
+
+      expect do
+        described_class.run(integer_array: {env: ["INTEGER_ARRAY"], type: :integer_array})
+      end.to raise_error(ArgumentError, "INTEGER_ARRAY must not contain empty list elements")
+    end
+
+    it "normalizes an empty typed array" do
+      allow(ENV).to receive(:[]).with("EMPTY_ARRAY").and_return("[]")
+
+      result = described_class.run(empty_array: {env: ["EMPTY_ARRAY"], type: :string_array})
+
+      expect(result.empty_array).to eq([])
+    end
+
+    it "rejects blank typed arrays" do
+      allow(ENV).to receive(:[]).with("BLANK_ARRAY").and_return(" ")
+
+      expect do
+        described_class.run(blank_array: {env: ["BLANK_ARRAY"], type: :string_array})
+      end.to raise_error(ArgumentError, "BLANK_ARRAY cannot be empty")
+    end
+
+    it "parses negative integer arrays" do
+      allow(ENV).to receive(:[]).with("INTEGER_ARRAY").and_return("[-1, 0, 10]")
+
+      result = described_class.run(integer_array: {env: ["INTEGER_ARRAY"], type: :integer_array})
+
+      expect(result.integer_array).to eq([-1, 0, 10])
+    end
+
+    it "rejects malformed array brackets" do
+      allow(ENV).to receive(:[]).with("MALFORMED_ARRAY").and_return("[repo, user")
+
+      expect do
+        described_class.run(malformed_array: {env: ["MALFORMED_ARRAY"], type: :string_array})
+      end.to raise_error(ArgumentError, "MALFORMED_ARRAY must contain a valid list")
+    end
+
+    it "rejects malformed YAML arrays" do
+      allow(ENV).to receive(:[]).with("MALFORMED_ARRAY").and_return('[repo, "unterminated]')
+
+      expect do
+        described_class.run(malformed_array: {env: ["MALFORMED_ARRAY"], type: :string_array})
+      end.to raise_error(ArgumentError, "MALFORMED_ARRAY must contain a valid list")
+    end
+
+    it "rejects typed definitions without environment names" do
+      expect do
+        described_class.run(value: {env: [], type: :integer})
+      end.to raise_error(ArgumentError, "configuration environment names cannot be empty")
+    end
+
+    it "rejects unsupported typed values" do
+      allow(ENV).to receive(:[]).with("VALUE").and_return("value")
+
+      expect do
+        described_class.run(value: {env: "VALUE", type: :float})
+      end.to raise_error(ArgumentError, "Unsupported configuration type :float")
+    end
+
+    it "uses the first configured environment and applies an override" do
+      allow(ENV).to receive(:[]).with("PRIMARY_PORT").and_return(nil)
+      allow(ENV).to receive(:[]).with("FALLBACK_PORT").and_return("2525")
+
+      result = described_class.run(port: {
+        env: ["PRIMARY_PORT", "FALLBACK_PORT"],
+        type: :integer,
+        override: ->(values) { values[:port] + 1 }
+      })
+
+      expect(result.port).to eq(2526)
+    end
+
+    it "preserves typed override callbacks" do
+      allow(ENV).to receive(:[]).with("PORT").and_return("2525")
+
+      result = described_class.run(port: {
+        env: ["PORT"],
+        type: :integer,
+        override: ->(values) { values[:port] + 1 }
+      })
+
+      expect(result.port).to eq(2526)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -79,4 +79,18 @@ RSpec.describe User, type: :model do
 
     it { expect(subject.attributes_for_super_diff).to eq(id: subject.id.to_s, name: subject.name) }
   end
+
+  describe ".valid_google_domain?" do
+    before do
+      allow(Errbit::Config).to receive(:google_authorized_domains).and_return(["example.com", "example.org"])
+    end
+
+    it "accepts an authorized domain" do
+      expect(described_class.valid_google_domain?("user@example.com")).to be(true)
+    end
+
+    it "rejects an unauthorized domain" do
+      expect(described_class.valid_google_domain?("user@example.net")).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
Add explicit boolean, integer, string-array, and integer-array parsing to Configurator while preserving legacy mappings and override callbacks.

Apply typed parsing to notice thresholds and other settings with established runtime types. Normalize Google authorized domains for direct array consumption, document the accepted formats, and add configuration and consumer regression coverage.

Invalid typed values now fail during boot instead of surfacing later as runtime errors.

This is a more complete approach than #3083.

Closes #2010