### PR TITLE
Drop the stray quote after the request url in issue reports

### DIFF
--- a/app/views/issue_trackers/markdown.erb
+++ b/app/views/issue_trackers/markdown.erb
@@ -4,7 +4,7 @@
 ## Summary ##
 <% if notice.request['url'].present? %>
 ### URL ###
-[<%= notice.request['url'] %>](<%= notice.request['url'] %>)"
+[<%= notice.request['url'] %>](<%= notice.request['url'] %>)
 <% end %>
 ### Where ###
 <%= notice.where %>


### PR DESCRIPTION
With spec coverage to prevent regression.