### PR TITLE
Use Time.current for Atom feed timestamps

### DIFF
--- a/app/views/problems/_list.atom.builder
+++ b/app/views/problems/_list.atom.builder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-feed.updated(problems.first.try(:created_at) || Time.now)
+feed.updated(problems.first.try(:created_at) || Time.current)
 
 problems.each do |problem|
   notice = problem.notices.first


### PR DESCRIPTION
`Time.now` uses the system timezone and can produce timestamps inconsistent with Rails' configured timezone. `Time.current` respects `Time.zone`, keeping the Atom feed timestamp consistent with the rest of the application.