### PR TITLE
Persist active tab in URL hash across notice pagination

### DIFF
--- a/app/assets/javascripts/errbit.js
+++ b/app/assets/javascripts/errbit.js
@@ -2,7 +2,7 @@
 
 $(function() {
 
-  var currentTab = "summary";
+  var currentTab = window.location.hash.replace(/^#/, '') || "summary";
 
   function init() {
 
@@ -30,7 +30,13 @@ $(function() {
     $('.notice-pagination').each(function() {
       $.pjax.defaults = {timeout: 2000};
 
-      $('#content').pjax('.notice-pagination a').on('pjax:start', function() {
+      $(document).pjax('.notice-pagination a', '#content').on('pjax:click', function(event, options) {
+        // Carry the fragment on the request URL so pjax's full-navigation
+        // fallback (timeout/error) also preserves the active tab
+        if (currentTab) {
+          options.url = options.url.split('#')[0] + '#' + currentTab;
+        }
+      }).on('pjax:start', function() {
         $('.notice-pagination-loader').addClass('visible');
         currentTab = $('.tab-bar ul li a.button.active').attr('rel');
       }).on('pjax:end', function() {
@@ -64,12 +70,23 @@ $(function() {
       activateTab($(this));
       return(false);
     });
-    activateTab($('.tab-bar ul li a.button[rel=' + currentTab + ']'));
+    var tab = $('.tab-bar ul li a.button').filter(function() {
+      return $(this).attr('rel') === currentTab;
+    });
+    if (!tab.length) {
+      tab = $('.tab-bar ul li a.button[rel=summary]');
+    }
+    activateTab(tab);
   }
 
   function activateTab(tab) {
     tab = $(tab);
     var panel = $('#'+tab.attr('rel'));
+
+    currentTab = tab.attr('rel');
+    if (currentTab) {
+      history.replaceState(history.state, '', '#' + currentTab);
+    }
 
     tab.closest('.tab-bar').find('a.active').removeClass('active');
     tab.addClass('active');


### PR DESCRIPTION
Often I want to compare URL params for a group of logged errors. This was tedious as I had to click previous error, switch tab, click previous error, switch tab. This PR will keep focus on selected tab. I am not familiar with pjax so had Claude arrange this PR for me. Let me know if there is a preferred different approach.

By Claude:
The tab links on the problem page set a fragment (#params, #backtrace, etc.) that was never read back, so opening a link with a hash or paging through notices with Older/Newer always reset the view to Summary and dropped the hash from the URL.

Initialize the current tab from location.hash on load, write the hash via history.replaceState when a tab is activated, and re-append it after pjax pagination so the URL stays shareable. Unknown hashes fall back to the Summary tab.

Also fix the pjax setup for the vendored jquery-pjax API: the container must be passed as a string selector ($(document).pjax(links, '#content')) instead of calling .pjax() on the container element, which threw "expected string value for 'container' option" and fell back to full page loads on every pagination click. The replaceState calls preserve history.state so pjax's back/forward handling keeps working.