### PR TITLE
Unbounded api v1 notices pagination

### DIFF
--- a/app/controllers/api/v1/notices_controller.rb
+++ b/app/controllers/api/v1/notices_controller.rb
@@ -6,23 +6,59 @@ module Api
       respond_to :json, :xml
 
       def index
-        query = {}
-        fields = ["created_at", "message", "error_class"]
-
-        if params.key?(:start_date) && params.key?(:end_date)
-          start_date = Time.zone.parse(params[:start_date]).utc
-          end_date = Time.zone.parse(params[:end_date]).utc
-          query = {created_at: {"$lte" => end_date, "$gte" => start_date}}
-        end
-
         results = benchmark("[api/v1/notices_controller] query time") do
-          Notice.where(query).only(fields).to_a
+          notice_results.to_a
         end
 
         respond_to do |format|
           format.any(:html, :json) { render json: results } # render JSON if no extension specified on path
           format.xml { render xml: results }
         end
+      end
+
+      private
+
+      def notice_results
+        notices_query(
+          date_query,
+          ["created_at", "message", "error_class"],
+          parse_positive_integer(params[:page], default: 1),
+          [parse_positive_integer(params[:per_page], default: 100), 100].min
+        )
+      end
+
+      def date_query
+        return {} unless params.key?(:start_date) && params.key?(:end_date)
+
+        start_date = parse_date(params[:start_date])
+        end_date = parse_date(params[:end_date])
+        return {} unless start_date && end_date
+
+        {created_at: {"$lte" => end_date, "$gte" => start_date}}
+      end
+
+      def notices_query(query, fields, page, per_page)
+        Notice.where(query)
+          .only(fields)
+          .order_by(created_at: :asc, _id: :asc)
+          .page(page)
+          .per(per_page)
+      end
+
+      def parse_positive_integer(value, default:)
+        return default unless value.is_a?(String) || value.is_a?(Integer)
+        return default unless value.to_s.match?(/\A\d+\z/)
+
+        parsed_value = value.to_i
+        parsed_value.positive? ? parsed_value : default
+      end
+
+      def parse_date(value)
+        return unless value.is_a?(String) && value.present?
+
+        Time.zone.parse(value).presence
+      rescue ArgumentError, TypeError
+        nil
       end
     end
   end

--- a/docs/api/notices.md
+++ b/docs/api/notices.md
@@ -1,0 +1,70 @@
+# Notices API Documentation
+
+## List Notices
+
+Returns notices visible to the authenticated user. The v1 API intentionally
+has global visibility: authenticated users can see notices from all apps.
+
+### Request
+
+```shell
+curl 'https://myerrbit.com/api/v1/notices?auth_token=USER_AUTHENTICATION_TOKEN&start_date=2015-04-01&end_date=2015-04-30&page=2&per_page=25'
+```
+
+Authentication uses a per-user authentication token, passed as the `auth_token`
+query parameter. This is a bearer credential. The query-parameter form is
+retained for API v1 compatibility.
+
+Query-string credentials can be exposed in URLs, browser history, proxy logs,
+and application logs.
+
+Parameters:
+
+- **start_date** and **end_date** - optional date range. The filter is
+  applied only when both parameters are present.
+- **page** - optional positive integer page number, defaulting to `1`.
+- **per_page** - optional positive integer page size, defaulting to `100` and
+  capped at `100`.
+
+Malformed, blank, non-integer, and non-positive pagination values use their
+defaults. Results are ordered by `created_at` ascending and `_id` ascending.
+
+### Response
+
+The response is an array with no pagination metadata. Request subsequent pages
+when more results are needed.
+
+```json
+[
+  {
+    "_id": "552941336a756e4e71012345",
+    "created_at": "2015-04-12T08:43:47.480Z",
+    "message": "Something went wrong",
+    "error_class": "RuntimeError"
+  }
+]
+```
+
+JSON is returned by default. XML is also supported with `format=xml` or an XML
+`Accept` header, while retaining the same array response shape and fields.
+
+For example, request XML explicitly with:
+
+```shell
+curl 'https://myerrbit.com/api/v1/notices?auth_token=USER_AUTHENTICATION_TOKEN&start_date=2015-04-01&end_date=2015-04-30&page=1&per_page=10&format=xml' \
+  -H 'Accept: application/xml'
+```
+
+An XML response has the following shape:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<objects type="array">
+  <object>
+    <_id>552941336a756e4e71012345</_id>
+    <created-at type="dateTime">2015-04-12T08:43:47Z</created-at>
+    <message>Something went wrong</message>
+    <error-class>RuntimeError</error-class>
+  </object>
+</objects>
+```

--- a/docs/relnotes/v0.11.6.md
+++ b/docs/relnotes/v0.11.6.md
@@ -1,0 +1,13 @@
+# v0.11.6 Release notes
+
+## Compatibility
+
+1. Bound the API v1 notices response to 100 notices by default, with explicit
+   pagination and a maximum page size of 100. Clients that previously omitted
+   pagination and received all notices must request subsequent pages to retrieve
+   more than 100 results.
+
+## Documentation
+
+1. Added documentation for the API v1 notices endpoint, including filtering,
+   pagination, ordering, authentication, and JSON/XML response formats.

--- a/spec/controllers/api/v1/notices_controller_spec.rb
+++ b/spec/controllers/api/v1/notices_controller_spec.rb
@@ -10,10 +10,22 @@ RSpec.describe Api::V1::NoticesController, type: :controller do
 
     describe "GET /api/v1/notices" do
       before do
-        create(:notice, created_at: Time.zone.parse("2012-08-01"))
+        @first_notice = create(:notice, created_at: Time.zone.parse("2012-08-01"))
         create(:notice, created_at: Time.zone.parse("2012-08-01"))
         create(:notice, created_at: Time.zone.parse("2012-08-21"))
         create(:notice, created_at: Time.zone.parse("2012-08-30"))
+      end
+
+      let(:additional_notices) do
+        Array.new(101) do |index|
+          create(:notice, created_at: Time.zone.parse("2012-08-31") + index.seconds)
+        end
+      end
+
+      let(:page_notices) do
+        Array.new(6) do |index|
+          create(:notice, created_at: Time.zone.parse("2012-08-31") + index.seconds)
+        end
       end
 
       it "should return JSON if JSON is requested" do
@@ -46,14 +58,90 @@ RSpec.describe Api::V1::NoticesController, type: :controller do
         end
       end
 
-      it "should return all notices" do
+      describe "given an invalid date range" do
+        it "should ignore blank and malformed dates" do
+          additional_notices
+
+          [
+            {start_date: "", end_date: ""},
+            {start_date: "invalid", end_date: "2012-08-27"},
+            {start_date: ["2012-08-01"], end_date: "2012-08-27"}
+          ].each do |date_range|
+            get :index, params: {auth_token: @user.authentication_token}.merge(date_range)
+
+            expect(response).to be_successful
+            expect(JSON.parse(response.body).length).to eq(100)
+          end
+        end
+      end
+
+      it "should return at most 100 notices by default" do
+        additional_notices
+
         get :index, params: {auth_token: @user.authentication_token}
 
         expect(response).to be_successful
 
         notices = JSON.parse(response.body)
 
-        expect(notices.length).to eq(4)
+        expect(notices.length).to eq(100)
+      end
+
+      it "should return the requested number of notices per page" do
+        page_notices
+
+        get :index, params: {auth_token: @user.authentication_token, per_page: 10}
+
+        expect(JSON.parse(response.body).length).to eq(10)
+      end
+
+      it "should return the requested page" do
+        page_notices
+
+        get :index, params: {auth_token: @user.authentication_token, page: 2, per_page: 5}
+
+        notices = JSON.parse(response.body)
+
+        expect(notices.length).to eq(5)
+        expect(notices.first["_id"]).to eq(page_notices[1].id.to_s)
+      end
+
+      it "uses the default per page value for non-positive values" do
+        additional_notices
+
+        [0, -5].each do |per_page|
+          get :index, params: {auth_token: @user.authentication_token, per_page: per_page}
+
+          expect(JSON.parse(response.body).length).to eq(100)
+        end
+      end
+
+      it "uses the default per page value for malformed values" do
+        additional_notices
+
+        ["", "invalid", "1.5", [10]].each do |per_page|
+          get :index, params: {auth_token: @user.authentication_token, per_page: per_page}
+
+          expect(JSON.parse(response.body).length).to eq(100)
+        end
+      end
+
+      it "caps per page at 100" do
+        additional_notices
+
+        get :index, params: {auth_token: @user.authentication_token, per_page: 500}
+
+        expect(JSON.parse(response.body).length).to eq(100)
+      end
+
+      it "uses the first page for malformed page values" do
+        [0, -5, "", "invalid", "1.5", [2]].each do |page|
+          get :index, params: {auth_token: @user.authentication_token, page: page, per_page: 5}
+
+          notices = JSON.parse(response.body)
+
+          expect(notices.first["_id"]).to eq(@first_notice.id.to_s)
+        end
       end
 
       it "should return notice objects with correct fields" do


### PR DESCRIPTION
The API v1 notices endpoint currently loads all matching notices into memory, which can exhaust workers on large datasets.

This adds deterministic pagination with a default and maximum page size of 100, while preserving existing filters, response formats, fields, and authentication.

The intentional compatibility change is documented in the v0.11.6 release notes.

Closes #3136 