### PR TITLE
Add authenticated read-only MCP investigation workflows

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -22,3 +22,5 @@ GITHUB_SITE_TITLE=GitHub
 DEVISE_MODULES='[database_authenticatable,recoverable,rememberable,trackable,validatable,omniauthable]'
 GOOGLE_AUTHENTICATION=true
 GOOGLE_SITE_TITLE=Google
+ERRBIT_MCP_SERVER=false
+ERRBIT_MCP_ALLOWED_HOSTS=

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem "uri"
 gem "rack-timeout"
 gem "puma"
 gem "ostruct"
+gem "mcp"
 gem "securerandom"
 gem "airbrake", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ GEM
       railties (>= 3.2, < 9.0)
     globalid (1.4.0)
       activesupport (>= 6.1)
+    hana (1.3.7)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
@@ -239,6 +240,11 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.21.2)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -281,6 +287,8 @@ GEM
       net-smtp
     marcel (1.2.1)
     matrix (0.4.3)
+    mcp (1.5.0)
+      json_schemer (>= 2.4)
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
@@ -577,6 +585,7 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     simplecov (1.2.0)
+    simpleidn (0.3.0)
     snaky_hash (2.0.7)
       hashie (>= 0.1.0, < 6)
       version_gem (~> 1.1, >= 1.1.14)
@@ -692,6 +701,7 @@ DEPENDENCIES
   kaminari-mongoid
   launchy
   listen (~> 3.10)
+  mcp
   mongoid
   mongoid-rspec
   nokogiri
@@ -813,6 +823,7 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   font-awesome-rails (4.7.0.9) sha256=b45044908fbf3178b8d84fbae415dae4b9bf847612bcb1170d88ed13842c8732
   globalid (1.4.0) sha256=037f12fbf1d9d7a014d501c2d5c77356fd4ddd96d7a7991d6700bba96706f427
+  hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
   herb (0.10.3) sha256=da76e8bfbb302586ee51a4fb608624f48218fbfea198a9493540b42f7654024b
@@ -838,6 +849,7 @@ CHECKSUMS
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jquery-rails (4.6.1) sha256=619f3496cdcdeaae1fd6dafa52dbac3fc45b745d4e09712da4184a16b3a8d9c0
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
@@ -854,6 +866,7 @@ CHECKSUMS
   mail (2.9.1) sha256=06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mcp (1.5.0) sha256=6f97785fa6e069eb667aa3d50299851ea9aca904b4abe8306f156bb8fd9eaff0
   method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
@@ -960,6 +973,7 @@ CHECKSUMS
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
   selenium-webdriver (4.48.0) sha256=0c8376ebc8a0a4879343fe6fe6eccdcea76748611cd25de370b33eded2077a94
   simplecov (1.2.0) sha256=ea6acd05eece5a41990e2a5171c57d15700d329326c7666c85ee8c6a0dd0977e
+  simpleidn (0.3.0) sha256=12ca730bed2f3db04d11e9bfd1bca3e11fb37f55b21eb2e9793fb5814bf54d03
   snaky_hash (2.0.7) sha256=7d02c70012a3f932e48860cd024577908300c9aa615e0cb9b450aaa749cbcb4d
   sprockets (4.4.1) sha256=fbd665edad0916de5c7abefef0fc616866a60c5e48ce2846f39ac3fc5df9e184
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e

--- a/app/lib/mcp_server/app_presenter.rb
+++ b/app/lib/mcp_server/app_presenter.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module McpServer
+  class AppPresenter
+    class << self
+      def summary(app)
+        {
+          id: app.id.to_s,
+          name: app.name,
+          created_at: app.created_at.iso8601,
+          updated_at: app.updated_at.iso8601
+        }
+      end
+
+      def detail(app)
+        summary(app).merge(
+          problem_count: app.problem_count,
+          unresolved_problem_count: app.unresolved_count
+        )
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/authenticated_transport.rb
+++ b/app/lib/mcp_server/authenticated_transport.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module McpServer
+  class AuthenticatedTransport
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      return not_found(env) unless Errbit::Config.mcp_server_enabled
+      return unauthorized(env) unless authenticated?(env["HTTP_AUTHORIZATION"])
+
+      @app.call(env)
+    rescue StandardError => e
+      Rails.logger.error("MCP request failed request_id=#{request_id(env)} error=#{e.class.name}")
+      internal_error(env)
+    end
+
+    private
+
+    def authenticated?(authorization)
+      expected_token = Errbit::Config.mcp_auth_token
+      return false if expected_token.blank? || authorization.blank?
+
+      scheme, token = authorization.split(" ", 2)
+      scheme&.casecmp?("Bearer") && token.present? && secure_compare(token, expected_token)
+    end
+
+    def secure_compare(token, expected)
+      ActiveSupport::SecurityUtils.secure_compare(
+        Digest::SHA256.hexdigest(token),
+        Digest::SHA256.hexdigest(expected)
+      )
+    end
+
+    def not_found(env)
+      response(404, {error: "Not found"}, env)
+    end
+
+    def unauthorized(env)
+      response(401, {error: "Unauthorized"}, env, "www-authenticate" => "Bearer")
+    end
+
+    def internal_error(env)
+      response(500, {error: "mcp_internal_error", request_id: request_id(env)}, env)
+    end
+
+    def response(status, body, env, headers = {})
+      headers = {"content-type" => "application/json", "cache-control" => "no-store"}.merge(headers)
+      headers["x-request-id"] = request_id(env) if request_id(env).present?
+      [status, headers, [body.to_json]]
+    end
+
+    def request_id(env)
+      env["action_dispatch.request_id"] || "unknown"
+    end
+  end
+end

--- a/app/lib/mcp_server/endpoint.rb
+++ b/app/lib/mcp_server/endpoint.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module McpServer
+  class Endpoint
+    def call(env)
+      AuthenticatedTransport.new(transport).call(env)
+    end
+
+    private
+
+    def transport
+      MCP::Server::Transports::StreamableHTTPTransport.new(
+        server,
+        stateless: true,
+        serve_subscriptions_listen: false,
+        enable_json_response: true,
+        max_request_bytes: 1_000_000,
+        allowed_hosts: Errbit::Config.mcp_allowed_hosts
+      )
+    end
+
+    def server
+      MCP::Server.new(
+        name: "errbit",
+        title: "Errbit MCP Server",
+        version: Errbit::Version.to_s,
+        instructions: "Use these tools to investigate Errbit applications.",
+        tools: [Tools::ListApps, Tools::GetApp, Tools::ListProblems, Tools::GetProblem, Tools::GetLatestNotice, Tools::GetNotice, Tools::ListNotices, Tools::GetIncidentSummary, Tools::GetAirbrakeSetupGuidance]
+      )
+    end
+  end
+end

--- a/app/lib/mcp_server/notice_presenter.rb
+++ b/app/lib/mcp_server/notice_presenter.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module McpServer
+  class NoticePresenter
+    MAX_STRING_LENGTH = 500
+
+    class << self
+      def full(notice)
+        metadata(notice).merge(
+          data(notice).merge(backtrace: notice.backtrace&.lines)
+        )
+      end
+
+      def summary(notice)
+        summary_metadata(notice).merge(
+          message: notice.message.to_s.truncate(MAX_STRING_LENGTH),
+          environment: bounded(notice.environment_name),
+          app_version: bounded(notice.app_version),
+          where: bounded(notice.where),
+          host: bounded(notice.host),
+          backtrace_id: notice.backtrace_id.to_s
+        )
+      end
+
+      def metadata(notice)
+        {
+          id: notice.id.to_s,
+          app_id: notice.app_id.to_s,
+          err_id: notice.err_id.to_s,
+          backtrace_id: notice.backtrace_id.to_s,
+          created_at: notice.created_at&.iso8601,
+          updated_at: notice.updated_at&.iso8601
+        }
+      end
+
+      def data(notice)
+        notice.attributes.slice(
+          "message", "server_environment", "request", "notifier", "user_attributes", "framework", "error_class"
+        ).transform_keys(&:to_sym)
+      end
+
+      private
+
+      def summary_metadata(notice)
+        {
+          id: notice.id.to_s,
+          created_at: notice.created_at&.iso8601,
+          app_id: notice.app_id.to_s,
+          err_id: notice.err_id.to_s,
+          problem_id: notice.err&.problem_id&.to_s,
+          error_class: bounded(notice.error_class),
+          framework: bounded(notice.framework)
+        }
+      end
+
+      def bounded(value)
+        value&.to_s&.truncate(MAX_STRING_LENGTH)
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/problem_presenter.rb
+++ b/app/lib/mcp_server/problem_presenter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module McpServer
+  class ProblemPresenter
+    MAX_STRING_LENGTH = 500
+
+    class << self
+      def summary(problem)
+        safe_attributes(problem).merge(metadata(problem))
+      end
+
+      def detail(problem)
+        summary(problem).merge(issue_link: bounded(problem.issue_link))
+      end
+
+      private
+
+      def string_metadata(problem)
+        {
+          app_name: bounded(problem.app_name),
+          message: problem.message.to_s.truncate(MAX_STRING_LENGTH),
+          url: bounded(problem.url)
+        }
+      end
+
+      def safe_attributes(problem)
+        attributes = problem.attributes.slice(
+          "environment", "error_class", "where", "resolved", "notices_count", "comments_count"
+        ).transform_keys(&:to_sym)
+        attributes.merge(
+          environment: bounded(attributes[:environment]),
+          error_class: bounded(attributes[:error_class]),
+          where: bounded(attributes[:where])
+        )
+      end
+
+      def metadata(problem)
+        {
+          id: problem.id.to_s,
+          app_id: problem.app_id.to_s,
+          first_notice_at: problem.first_notice_at&.iso8601,
+          last_notice_at: problem.last_notice_at&.iso8601,
+          resolved_at: problem.resolved_at&.iso8601
+        }.merge(string_metadata(problem))
+      end
+
+      def bounded(value)
+        value&.to_s&.truncate(MAX_STRING_LENGTH)
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tool_response.rb
+++ b/app/lib/mcp_server/tool_response.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module McpServer
+  class ToolResponse
+    class << self
+      def success(result)
+        response(result)
+      end
+
+      def error(result)
+        response(result, error: true)
+      end
+
+      def response(result, error: false)
+        MCP::Tool::Response.new(
+          [{type: "text", text: result.to_json}],
+          structured_content: result,
+          error: error
+        )
+      end
+      private :response
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/get_airbrake_setup_guidance.rb
+++ b/app/lib/mcp_server/tools/get_airbrake_setup_guidance.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class GetAirbrakeSetupGuidance < MCP::Tool
+      FRAMEWORKS = ["ruby", "node", "python", "go"].freeze
+
+      tool_name "errbit_get_airbrake_setup_guidance"
+      description "Get safe Airbrake-compatible Errbit setup guidance and app metadata without credentials."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          app_id: {type: "string", minLength: 1, maxLength: 100},
+          framework: {type: "string", minLength: 1, maxLength: 50}
+        }
+      )
+
+      class << self
+        def call(app_id: nil, framework: nil, **)
+          return ToolResponse.error({error: "unsupported_framework", framework: framework}) if framework && FRAMEWORKS.exclude?(framework)
+
+          app = App.find(app_id) if app_id
+          ToolResponse.success(guidance(app, framework))
+        rescue Mongoid::Errors::DocumentNotFound
+          ToolResponse.error({error: "app_not_found", app_id: app_id})
+        end
+
+        private
+
+        def guidance(app, framework)
+          {
+            endpoint: "https://#{Errbit::Config.host}/api/v3/projects/{project_id}/notices",
+            app: app && {id: app.id.to_s, name: app.name},
+            project_id: 1,
+            project_key: "<ERRBIT_APP_API_KEY>",
+            api_key_instructions: "Copy the app ingestion key from the Errbit app settings. MCP never returns app API keys.",
+            snippets: snippets(framework)
+          }
+        end
+
+        def snippets(framework)
+          framework ? {framework => template_for(framework)} : FRAMEWORKS.index_with { |name| template_for(name) }
+        end
+
+        def template_for(framework)
+          send(:"#{framework}_template")
+        end
+
+        def ruby_template
+          <<~RUBY
+            Airbrake.configure do |config|
+              config.error_host = "https://#{Errbit::Config.host}"
+              config.project_id = 1
+              config.project_key = "<ERRBIT_APP_API_KEY>"
+              config.environment = Rails.env
+              config.job_stats = false
+              config.query_stats = false
+              config.performance_stats = false
+              config.remote_config = false
+            end
+          RUBY
+        end
+
+        def node_template
+          "new Notifier({host: \"https://#{Errbit::Config.host}\", projectId: 1, projectKey: \"<ERRBIT_APP_API_KEY>\", environment: process.env.NODE_ENV});"
+        end
+
+        def python_template
+          "pybrake.Notifier(project_id=1, project_key=\"<ERRBIT_APP_API_KEY>\", host=\"https://#{Errbit::Config.host}\", environment=\"production\")"
+        end
+
+        def go_template
+          "gobrake.NewNotifierWithOptions(&gobrake.NotifierOptions{ProjectId: 1, ProjectKey: \"<ERRBIT_APP_API_KEY>\", Host: \"https://#{Errbit::Config.host}\", Environment: \"production\"})"
+        end
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/get_app.rb
+++ b/app/lib/mcp_server/tools/get_app.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class GetApp < MCP::Tool
+      tool_name "errbit_get_app"
+      description "Get safe details for an Errbit application by ID."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          id: {type: "string", minLength: 1}
+        },
+        required: ["id"]
+      )
+
+      class << self
+        def call(id:, **)
+          ToolResponse.success({app: AppPresenter.detail(App.find(id))})
+        rescue Mongoid::Errors::DocumentNotFound
+          ToolResponse.error({error: "app_not_found", id: id})
+        end
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/get_incident_summary.rb
+++ b/app/lib/mcp_server/tools/get_incident_summary.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    # rubocop:disable Metrics/ClassLength
+    class GetIncidentSummary < MCP::Tool
+      DEFAULT_LIMIT = 10
+      MAX_LIMIT = 25
+      MAX_PAYLOAD_BYTES = 1_000_000
+      tool_name "errbit_get_incident_summary"
+      description "Return deterministic aggregate facts for matching Errbit problems."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          app_id: {type: "string", minLength: 1, maxLength: 100},
+          app_name: {type: "string", minLength: 1, maxLength: 200},
+          environment: {type: "string", minLength: 1, maxLength: 100},
+          resolved: {type: "boolean"},
+          problem_id: {type: "string", minLength: 1, maxLength: 100},
+          search: {type: "string", minLength: 1, maxLength: 200},
+          since: {type: "string", format: "date-time"},
+          until: {type: "string", format: "date-time"},
+          limit: {type: "integer", minimum: 1, maximum: MAX_LIMIT}
+        }
+      )
+      class << self
+        def call(**arguments)
+          since = parse_time(arguments[:since])
+          until_time = parse_time(arguments[:until])
+          return ToolResponse.error(error: "invalid_date_range") if since && until_time && since > until_time
+
+          result = summary(arguments, since, until_time)
+          return ToolResponse.error(error: "summary_too_large", max_bytes: MAX_PAYLOAD_BYTES) if result.to_json.bytesize > MAX_PAYLOAD_BYTES
+
+          ToolResponse.success(result)
+        rescue Mongoid::Errors::DocumentNotFound
+          ToolResponse.error(error: "problem_not_found", problem_id: arguments[:problem_id])
+        rescue ArgumentError, TypeError
+          ToolResponse.error(error: "invalid_date_range")
+        end
+
+        private
+
+        def summary(arguments, since, until_time)
+          matching = filtered_problems(arguments, since, until_time).to_a
+          limit = arguments.fetch(:limit, DEFAULT_LIMIT)
+
+          summary_counts(matching).merge(
+            summary_lists(matching, limit)
+          )
+        end
+
+        def summary_counts(problems)
+          {
+            matching_problem_count: problems.size,
+            total_notice_count: problems.sum { |problem| problem.notices_count.to_i },
+            resolved_problem_count: problems.count(&:resolved?),
+            unresolved_problem_count: problems.count(&:unresolved?)
+          }
+        end
+
+        def summary_lists(matching, limit)
+          latest = latest_problems(matching)
+          problem_lists(latest, frequent_problems(matching), limit)
+            .merge(frequency_lists(matching, limit))
+            .merge(notice_lists(latest, limit))
+        end
+
+        def latest_problems(problems)
+          problems.sort_by { |problem| [-problem.last_notice_at.to_i, problem.id.to_s] }
+        end
+
+        def frequent_problems(problems)
+          problems.sort_by { |problem| [-problem.notices_count.to_i, problem.id.to_s] }
+        end
+
+        def problem_lists(latest, frequent, limit)
+          {
+            latest_affected_problems: latest.first(limit).map { |problem| ProblemPresenter.summary(problem) },
+            highest_frequency_problems: frequent.first(limit).map { |problem| ProblemPresenter.summary(problem) }
+          }
+        end
+
+        def frequency_lists(problems, limit)
+          {
+            top_error_classes: frequencies(problems, :error_class, limit),
+            top_environments: frequencies(problems, :environment, limit)
+          }
+        end
+
+        def notice_lists(problems, limit)
+          {representative_latest_notices: problems.first(limit).filter_map { |problem| notice_summary(problem) }}
+        end
+
+        def filtered_problems(arguments, since, until_time)
+          problems = Problem.all
+          filters = arguments.slice(:app_id, :app_name, :environment, :problem_id).compact
+          problems = problems.where(filters) if filters.any?
+          apply_filters(problems, arguments, since, until_time)
+        end
+
+        def apply_filters(problems, arguments, since, until_time)
+          problems = arguments[:resolved] ? problems.resolved : problems.unresolved unless arguments[:resolved].nil?
+          problems = problems.search(arguments[:search]) if arguments[:search]
+          problems = problems.where(:last_notice_at.gte => since) if since
+          problems = problems.where(:first_notice_at.lte => until_time) if until_time
+          problems
+        end
+
+        def parse_time(value)
+          return if value.blank?
+
+          Time.zone.parse(value.to_s)
+        end
+
+        def frequencies(problems, attribute, limit)
+          problems.group_by { |problem| problem.public_send(attribute).to_s }.map { |value, items| {value: value, count: items.size} }
+            .sort_by { |item| [-item[:count], item[:value]] }
+            .first(limit)
+        end
+
+        def notice_summary(problem)
+          notice = Notice.for_errs(problem.errs).reverse_ordered.first
+          NoticePresenter.summary(notice) if notice
+        end
+      end
+    end
+    # rubocop:enable Metrics/ClassLength
+  end
+end

--- a/app/lib/mcp_server/tools/get_latest_notice.rb
+++ b/app/lib/mcp_server/tools/get_latest_notice.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class GetLatestNotice < MCP::Tool
+      MAX_PAYLOAD_BYTES = 1_000_000
+
+      tool_name "errbit_get_latest_notice"
+      description "Get the latest persisted notice for an Errbit problem."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          problem_id: {type: "string", minLength: 1, maxLength: 100}
+        },
+        required: ["problem_id"]
+      )
+
+      class << self
+        def call(problem_id:, **)
+          problem = Problem.find(problem_id)
+          notice = latest_notice(problem)
+          return ToolResponse.error(error: "notice_not_found", problem_id: problem_id) unless notice
+
+          payload = payload(problem, notice)
+          return ToolResponse.error(error: "notice_too_large", max_bytes: MAX_PAYLOAD_BYTES) if payload.to_json.bytesize > MAX_PAYLOAD_BYTES
+
+          ToolResponse.success(notice: payload)
+        rescue Mongoid::Errors::DocumentNotFound
+          ToolResponse.error(error: "problem_not_found", problem_id: problem_id)
+        end
+
+        private
+
+        def latest_notice(problem)
+          Notice.for_errs(problem.errs).reverse_ordered.first
+        end
+
+        def payload(problem, notice)
+          NoticePresenter.full(notice).merge(problem_id: problem.id.to_s, problem_url: problem.url)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/get_notice.rb
+++ b/app/lib/mcp_server/tools/get_notice.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class GetNotice < MCP::Tool
+      MAX_PAYLOAD_BYTES = 1_000_000
+
+      tool_name "errbit_get_notice"
+      description "Get one persisted Errbit notice by ID."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          id: {type: "string", minLength: 1, maxLength: 100}
+        },
+        required: ["id"]
+      )
+
+      class << self
+        def call(id:, **)
+          notice = Notice.find(id)
+          payload = payload(notice)
+          return ToolResponse.error(error: "notice_too_large", max_bytes: MAX_PAYLOAD_BYTES) if payload.to_json.bytesize > MAX_PAYLOAD_BYTES
+
+          ToolResponse.success(notice: payload)
+        rescue Mongoid::Errors::DocumentNotFound
+          ToolResponse.error(error: "notice_not_found", id: id)
+        end
+
+        private
+
+        def payload(notice)
+          problem = notice.problem
+          NoticePresenter.full(notice).merge(
+            problem_id: problem.id.to_s,
+            problem_url: problem.url,
+            problem: ProblemPresenter.summary(problem),
+            app: AppPresenter.summary(problem.app)
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/get_problem.rb
+++ b/app/lib/mcp_server/tools/get_problem.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class GetProblem < MCP::Tool
+      tool_name "errbit_get_problem"
+      description "Get safe details for an Errbit problem by ID."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          id: {type: "string", minLength: 1, maxLength: 100}
+        },
+        required: ["id"]
+      )
+
+      class << self
+        def call(id:, **)
+          ToolResponse.success(problem: ProblemPresenter.detail(Problem.find(id)))
+        rescue Mongoid::Errors::DocumentNotFound
+          ToolResponse.error(error: "problem_not_found", id: id)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/list_apps.rb
+++ b/app/lib/mcp_server/tools/list_apps.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class ListApps < MCP::Tool
+      DEFAULT_PER_PAGE = 25
+      MAX_PER_PAGE = 100
+
+      tool_name "errbit_list_apps"
+      description "List Errbit applications, ordered by name."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          search: {type: "string", minLength: 1, maxLength: 200},
+          page: {type: "integer", minimum: 1},
+          per_page: {type: "integer", minimum: 1, maximum: MAX_PER_PAGE}
+        }
+      )
+
+      class << self
+        def call(search: nil, page: 1, per_page: DEFAULT_PER_PAGE, **)
+          apps = filtered_apps(search).order_by(name: :asc, _id: :asc).page(page).per(per_page)
+          ToolResponse.success({
+            apps: apps.map { |app| AppPresenter.summary(app) },
+            page: page,
+            per_page: per_page,
+            total_pages: apps.total_pages,
+            total_count: apps.total_count
+          })
+        end
+
+        private
+
+        def filtered_apps(search)
+          apps = App.all
+          apps = apps.where(name: /#{Regexp.escape(search)}/i) if search
+          apps
+        end
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/list_notices.rb
+++ b/app/lib/mcp_server/tools/list_notices.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class ListNotices < MCP::Tool
+      DEFAULT_PER_PAGE = 25
+      MAX_PER_PAGE = 100
+
+      tool_name "errbit_list_notices"
+      description "List notice summaries for an Errbit problem or filtered app set, newest first."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          problem_id: {type: "string", minLength: 1, maxLength: 100},
+          app_id: {type: "string", minLength: 1, maxLength: 100},
+          app_name: {type: "string", minLength: 1, maxLength: 200},
+          environment: {type: "string", minLength: 1, maxLength: 100},
+          resolved: {type: "boolean"},
+          search: {type: "string", minLength: 1, maxLength: 200},
+          page: {type: "integer", minimum: 1},
+          per_page: {type: "integer", minimum: 1, maximum: MAX_PER_PAGE}
+        }
+      )
+
+      class << self
+        def call(page: 1, per_page: DEFAULT_PER_PAGE, **arguments)
+          return ToolResponse.error(error: "invalid_filters") unless filter_present?(arguments)
+
+          notices = filtered_notices(arguments)
+          notices = notices.where("$or" => [{message: /#{Regexp.escape(arguments[:search])}/i}, {error_class: /#{Regexp.escape(arguments[:search])}/i}]) if arguments[:search]
+          notices = notices.order_by(created_at: :desc, _id: :desc).page(page).per(per_page)
+
+          ToolResponse.success(result(notices, page, per_page))
+        rescue Mongoid::Errors::DocumentNotFound
+          ToolResponse.error(error: "problem_not_found", problem_id: arguments[:problem_id])
+        end
+
+        private
+
+        def filter_present?(arguments)
+          arguments.values_at(:problem_id, :app_id, :app_name, :environment, :search).any?(&:present?) || !arguments[:resolved].nil?
+        end
+
+        def filtered_notices(arguments)
+          err_ids = Err.where(:problem_id.in => filtered_problems(arguments).pluck(:id)).pluck(:id)
+          Notice.where(:err_id.in => err_ids)
+        end
+
+        def filtered_problems(arguments)
+          problems = Problem.all
+          problems = Problem.where(_id: Problem.find(arguments[:problem_id]).id) if arguments[:problem_id]
+          apply_problem_filters(problems, arguments)
+        end
+
+        def apply_problem_filters(problems, arguments)
+          problems = problems.where(app_id: arguments[:app_id]) if arguments[:app_id]
+          problems = problems.where(app_name: arguments[:app_name]) if arguments[:app_name]
+          problems = problems.where(environment: arguments[:environment]) if arguments[:environment]
+          problems = arguments[:resolved] ? problems.resolved : problems.unresolved unless arguments[:resolved].nil?
+          problems
+        end
+
+        def result(notices, page, per_page)
+          {
+            notices: notices.map { |notice| NoticePresenter.summary(notice) },
+            page: page,
+            per_page: per_page,
+            total_pages: notices.total_pages,
+            total_count: notices.total_count
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/lib/mcp_server/tools/list_problems.rb
+++ b/app/lib/mcp_server/tools/list_problems.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module McpServer
+  module Tools
+    class ListProblems < MCP::Tool
+      DEFAULT_PER_PAGE = 25
+      MAX_PER_PAGE = 100
+
+      tool_name "errbit_list_problems"
+      description "List Errbit problems, ordered by most recent notice."
+      annotations read_only_hint: true, destructive_hint: false, idempotent_hint: true, open_world_hint: false
+      input_schema(
+        properties: {
+          app_id: {type: "string", minLength: 1, maxLength: 100},
+          app_name: {type: "string", minLength: 1, maxLength: 200},
+          environment: {type: "string", minLength: 1, maxLength: 100},
+          resolved: {type: "boolean"},
+          search: {type: "string", minLength: 1, maxLength: 200},
+          page: {type: "integer", minimum: 1},
+          per_page: {type: "integer", minimum: 1, maximum: MAX_PER_PAGE}
+        }
+      )
+
+      class << self
+        def call(**arguments)
+          page = arguments.fetch(:page, 1)
+          per_page = arguments.fetch(:per_page, DEFAULT_PER_PAGE)
+          problems = filtered_problems(arguments)
+          problems = problems.order_by(last_notice_at: :desc, _id: :desc).page(page).per(per_page)
+
+          ToolResponse.success(result(problems, page, per_page))
+        end
+
+        private
+
+        def result(problems, page, per_page)
+          {
+            problems: problems.map { |problem| ProblemPresenter.summary(problem) },
+            page: page,
+            per_page: per_page,
+            total_pages: problems.total_pages,
+            total_count: problems.total_count
+          }
+        end
+
+        def filtered_problems(arguments)
+          problems = Problem.all
+          filters = arguments.slice(:app_id, :app_name, :environment).compact
+          problems = problems.where(filters) if filters.any?
+          problems = arguments[:resolved] ? problems.resolved : problems.unresolved unless arguments[:resolved].nil?
+          problems = problems.search(arguments[:search]) if arguments[:search]
+          problems
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/mcp_configuration.rb
+++ b/config/initializers/mcp_configuration.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+raise "ERRBIT_MCP_AUTH_TOKEN must be set when ERRBIT_MCP_SERVER is enabled in production" if Errbit::Config.mcp_server_enabled && Errbit::Config.mcp_auth_token.blank? && Rails.env.production?

--- a/config/load.rb
+++ b/config/load.rb
@@ -46,6 +46,14 @@ Errbit::Config = Configurator.run(
   google_redirect_uri: ["GOOGLE_REDIRECT_URI"],
   google_authorized_domains: ["GOOGLE_AUTHORIZED_DOMAINS"],
 
+  # MCP
+  mcp_server_enabled: ["ERRBIT_MCP_SERVER"],
+  mcp_auth_token: ["ERRBIT_MCP_AUTH_TOKEN"],
+  mcp_allowed_hosts: ["ERRBIT_MCP_ALLOWED_HOSTS", lambda do |values|
+    configured_hosts = values[:mcp_allowed_hosts]
+    configured_hosts.present? ? configured_hosts.split(",").map(&:strip).compact_blank : [values[:host]]
+  end],
+
   email_delivery_method: ["EMAIL_DELIVERY_METHOD", lambda do |values|
     email_delivery_method = values[:email_delivery_method]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   get "/locate/:id" => "notices#locate", :as => :locate
   get "/notices/:id" => "notices#show_by_id", :as => :show_notice_by_id
 
+  mount McpServer::Endpoint.new => "/mcp"
+
   resources :notices, only: :show
 
   resources :users do

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,15 @@ Default: `3`.
 
 Default in container: same as default value.
 
+#### `ERRBIT_MCP_SERVER`, `ERRBIT_MCP_AUTH_TOKEN`, and `ERRBIT_MCP_ALLOWED_HOSTS`
+
+Enable the server-to-server MCP endpoint, which currently exposes read-only
+tools, and configure its bearer token. `ERRBIT_MCP_SERVER` defaults to `false`; when enabled in production,
+`ERRBIT_MCP_AUTH_TOKEN` is required. `ERRBIT_MCP_ALLOWED_HOSTS` defaults to
+`ERRBIT_HOST` when omitted or empty; standard deployments need not set it. It
+accepts a comma-separated host allow-list for reverse-proxy deployments. See
+[MCP](mcp.md) for setup, limits, and client configuration.
+
 TIP: The Errbit team recommends setting `RAILS_MAX_THREADS` to `2` in production.
 
 ### `thruster` (gem) environment variables
@@ -149,6 +158,15 @@ Default in container: same as default value.
 <dt>ERRBIT_PROBLEM_DESTROY_AFTER_DAYS
 <dd>Number of days to keep errors in the database when running `bundle exec rails errbit:clear_outdated`
 <dd>defaults to nil (off)
+<dt>ERRBIT_MCP_SERVER
+<dd>Enable the server-to-server MCP endpoint, which currently exposes read-only tools. When enabled, `ERRBIT_MCP_AUTH_TOKEN` is required in production.
+<dd>defaults to false
+<dt>ERRBIT_MCP_AUTH_TOKEN
+<dd>Bearer token required to access the MCP endpoint. This is distinct from application ingestion API keys.
+<dd>defaults to nil
+<dt>ERRBIT_MCP_ALLOWED_HOSTS
+<dd>Comma-separated Host header allow-list for the MCP endpoint. A bare host permits every port; a host with a port permits only that port.
+<dd>defaults to ERRBIT_HOST when omitted or empty; leaving it empty does not disable Host validation
 <dt>SECRET_KEY_BASE
 <dd>For production environments, you should run `bundle exec rails secret` to generate a secret, unique key for this parameter
 <dd>defaults to f258ed69266dc8ad0ca79363c3d2f945c388a9c5920fc9a1ae99a98fbb619f135001c6434849b625884a9405a60cd3d50fc3e3b07ecd38cbed7406a4fccdb59c

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,129 @@
+# Errbit MCP Server
+
+Errbit provides a Model Context Protocol (MCP) endpoint for server-to-server
+clients that currently exposes read-only tools. It is disabled by default.
+
+## Enablement
+
+Set both variables and restart Errbit:
+
+```sh
+ERRBIT_MCP_SERVER=true
+ERRBIT_MCP_AUTH_TOKEN=replace-with-a-long-random-token
+```
+
+Every request to `https://errbit.example.com/mcp` must send the configured token
+in an `Authorization: Bearer` header. This token is separate from application
+ingestion API keys. Rotate it by changing `ERRBIT_MCP_AUTH_TOKEN` and restarting
+all Errbit processes.
+
+Do not expose the endpoint publicly without TLS and a strong token. The single
+deployment-wide bearer credential has global visibility of Errbit data. The
+current server only exposes read-only tools; browser clients and CORS are not
+supported.
+
+The SDK validates the request `Host` header to prevent DNS rebinding.
+`ERRBIT_MCP_ALLOWED_HOSTS` is optional: when it is omitted or empty, it defaults
+to `ERRBIT_HOST`. A standard deployment using
+`ERRBIT_HOST=errbit.example.com` therefore needs no additional MCP host
+configuration.
+
+Set `ERRBIT_MCP_ALLOWED_HOSTS` only when a reverse proxy presents a different
+host, or when using an IP address or custom port. It accepts a comma-separated
+list of hosts. A bare host permits every port; include `host:port` to permit
+only that port. Leaving it empty does not disable Host validation.
+
+The first release uses one deployment-wide bearer principal. It is not mapped to
+an Errbit `User`, does not provide per-user authorization, and is not an app
+ingestion credential. Future per-user or scoped access requires a new
+authentication design rather than passing this token into individual tools.
+
+## Clients
+
+Configure Streamable HTTP clients with the endpoint URL and bearer token. For
+example, an OpenCode MCP configuration uses:
+
+```json
+{
+  "type": "remote",
+  "url": "https://errbit.example.com/mcp",
+  "headers": {"Authorization": "Bearer replace-with-a-long-random-token"}
+}
+```
+
+Cursor, Claude, and other Streamable HTTP clients use the same URL and header.
+
+## Tools and limits
+
+- `errbit_list_apps`: lists applications ordered by name. It accepts an optional
+  case-insensitive substring `search` against app names, defaults to 25 results,
+  and accepts `page` and `per_page`; `per_page` is capped at 100. Organization
+  filtering is not supported because Errbit has no app ownership model.
+- `errbit_get_app`: returns safe application metadata and problem counts for an
+  application ID.
+- `errbit_list_problems`: lists bounded problem summaries. It accepts optional
+  exact `app_id` and cached `app_name`, exact `environment`, `resolved`, and
+  existing MongoDB full-text `search` filters, plus `page` and `per_page`;
+  `per_page` is capped at 100. Full-text search covers the indexed problem
+  fields and also accepts an exact notice ID. Results are ordered by latest
+  notice time and then ID.
+- `errbit_get_problem`: returns safe details for a problem ID, including its
+  Errbit URL and configured issue link when present.
+- `errbit_get_latest_notice`: returns the latest persisted notice for a problem,
+  including request, environment, notifier, user, and complete backtrace data.
+  The payload is rejected when it exceeds 1 MB rather than silently dropping
+  troubleshooting fields.
+- `errbit_get_notice`: returns the same bounded persisted troubleshooting context
+  for one notice ID, allowing agents to inspect a specific occurrence after
+  `errbit_list_notices`.
+- `errbit_list_notices`: lists notice summaries newest first. It accepts the
+  existing `problem_id` filter or bounded cross-app filters for `app_id`,
+  `app_name`, `environment`, `resolved`, and notice message/error-class
+  `search`, plus `page` and `per_page`; `per_page` is capped at 100. At least
+  one filter is required. Use `errbit_get_notice` or
+  `errbit_get_latest_notice` when full persisted context is needed.
+- `errbit_get_incident_summary`: returns deterministic counts, resolved-state
+  totals, latest affected problems, highest-frequency problems, top error
+  classes, top environments, and representative latest notice summaries.
+  It accepts the same app/problem filters plus ISO 8601 `since`, `until`, and a
+  `limit` capped at 25. Date filters select problems whose recorded activity
+  overlaps the range; notice totals and frequency use cached problem counters.
+- `errbit_get_airbrake_setup_guidance`: returns placeholder-only setup snippets
+  for Ruby, Node, Python, and Go. With an optional Errbit `app_id`, it resolves
+  and returns only that app's ID and name. It also accepts a `framework` filter.
+  It never reads or returns an app API key; users must copy that key from the
+  app settings. See the supported
+  [Airbrake client documentation](https://docs.airbrake.io/docs/platforms/ruby/)
+  for the selected client version.
+
+All tool responses include structured JSON and text JSON for older clients.
+Application API keys and embedded app integration configuration are never
+included in app responses. Latest-notice data follows the persisted notice
+sanitization setting: disabling sanitization can expose raw credentials and
+private request data to the MCP bearer principal.
+
+The endpoint uses stateless Streamable HTTP. It supports simple request/response
+calls only, does not retain sessions, and does not provide subscription streams.
+
+## Operations
+
+The endpoint has no application-level rate limiter. Put it behind the same
+trusted reverse proxy or gateway used for Errbit and apply deployment-level
+request throttling and a maximum `/mcp` request body of 1 MB there. MCP does not
+accept file uploads, and the gateway must reject oversized requests before they
+reach Rails. MCP requests use Errbit's existing Rack timeout; slow MongoDB
+queries are not given a separate MCP timeout.
+
+The bearer token is not an application user credential and must not be written
+to request logs. The endpoint is stateless, so it does not require session
+affinity. When disabled, `/mcp` returns `404`; when enabled in production
+without a token, Errbit refuses to boot. Latest-notice responses are rejected
+above 1 MB rather than truncated. Their persisted fields follow the configured
+notice-sanitization setting, so disabling sanitization can expose private data
+to the bearer principal. Unexpected MCP failures return a generic `500` response
+with error code `mcp_internal_error` and the request ID; exception messages and
+notice payloads are not returned or logged.
+
+The endpoint accepts `POST` requests with JSON content and the MCP protocol
+version `2025-03-26`. Other HTTP methods or media types are rejected by the
+transport.

--- a/spec/lib/mcp_server/authenticated_transport_spec.rb
+++ b/spec/lib/mcp_server/authenticated_transport_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe McpServer::AuthenticatedTransport do
+  let(:token) { "mcp-test-token" }
+  let(:env) do
+    {
+      "HTTP_AUTHORIZATION" => "Bearer #{token}",
+      "action_dispatch.request_id" => "request-123"
+    }
+  end
+  let(:internal_error_response) do
+    [
+      500,
+      {
+        "content-type" => "application/json",
+        "cache-control" => "no-store",
+        "x-request-id" => "request-123"
+      },
+      ['{"error":"mcp_internal_error","request_id":"request-123"}']
+    ]
+  end
+
+  before do
+    allow(Errbit::Config).to receive(:mcp_server_enabled).and_return(true)
+    allow(Errbit::Config).to receive(:mcp_auth_token).and_return(token)
+  end
+
+  it "returns a stable internal error without exposing exception details" do
+    app = ->(_) { raise "secret notice payload" }
+
+    expect(described_class.new(app).call(env)).to eq(internal_error_response)
+  end
+
+  it "logs only the request ID and exception class" do
+    app = ->(_) { raise "secret notice payload" }
+    expect(Rails.logger).to receive(:error).with("MCP request failed request_id=request-123 error=RuntimeError")
+
+    described_class.new(app).call(env)
+  end
+end

--- a/spec/lib/mcp_server/notice_presenter_spec.rb
+++ b/spec/lib/mcp_server/notice_presenter_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe McpServer::NoticePresenter do
+  let(:notice) do
+    create(
+      :notice,
+      message: "m" * 600,
+      error_class: "e" * 600,
+      framework: "f" * 600,
+      server_environment: {"environment-name" => "n" * 600, "app-version" => "v" * 600},
+      request: {"component" => "c" * 600}
+    )
+  end
+
+  before { allow(notice).to receive(:host).and_return("h" * 600) }
+
+  it "bounds every string in notice summaries" do
+    expect(described_class.summary(notice).values_at(:message, :error_class, :framework, :environment, :app_version, :where, :host).map(&:length)).to all(eq(500))
+  end
+end

--- a/spec/lib/mcp_server/problem_presenter_spec.rb
+++ b/spec/lib/mcp_server/problem_presenter_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe McpServer::ProblemPresenter do
+  let(:problem) do
+    create(
+      :problem,
+      app_name: "a" * 600,
+      message: "m" * 600,
+      environment: "n" * 600,
+      error_class: "e" * 600,
+      where: "w" * 600,
+      issue_link: "i" * 600
+    )
+  end
+  let(:summary) { described_class.summary(problem) }
+  let(:detail) { described_class.detail(problem) }
+
+  before do
+    allow(problem).to receive(:app_name).and_return("a" * 600)
+    allow(problem).to receive(:url).and_return("u" * 600)
+  end
+
+  it "bounds every string in problem summaries and details" do
+    expect((summary.values_at(:app_name, :message, :url, :environment, :error_class, :where) + [detail.fetch(:issue_link)]).map(&:length)).to all(eq(500))
+  end
+end

--- a/spec/requests/mcp_server_spec.rb
+++ b/spec/requests/mcp_server_spec.rb
@@ -1,0 +1,543 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "MCP server", type: :request do
+  let(:token) { "mcp-test-token" }
+  let(:headers) do
+    {
+      "ACCEPT" => "application/json",
+      "CONTENT_TYPE" => "application/json",
+      "HOST" => Errbit::Config.host
+    }
+  end
+
+  before do
+    allow(Errbit::Config).to receive(:mcp_server_enabled).and_return(true)
+    allow(Errbit::Config).to receive(:mcp_auth_token).and_return(token)
+  end
+
+  it "returns not found when disabled" do
+    allow(Errbit::Config).to receive(:mcp_server_enabled).and_return(false)
+
+    mcp_request("tools/list", authorization: nil)
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "rejects missing, malformed, and invalid credentials without exposing the token" do
+    [nil, "Basic #{token}", "Bearer incorrect-token"].each do |authorization|
+      mcp_request("tools/list", authorization: authorization)
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.headers["WWW-Authenticate"]).to eq("Bearer")
+      expect(response.body).not_to include(token)
+    end
+  end
+
+  it "accepts bearer authentication schemes case-insensitively" do
+    ["bearer", "BEARER"].each do |scheme|
+      mcp_request("tools/list", authorization: "#{scheme} #{token}")
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  it "rejects request bodies larger than 1 MB" do
+    mcp_request(
+      "tools/list",
+      authorization: "Bearer #{token}",
+      payload: {jsonrpc: "2.0", id: 1, method: "tools/list", padding: "x" * 1_000_001}.to_json
+    )
+
+    expect(response).to have_http_status(:content_too_large)
+  end
+
+  it "lists the advertised read-only tools for a valid credential" do
+    mcp_request("tools/list", authorization: "Bearer #{token}")
+
+    expect(response).to have_http_status(:ok)
+    expect(json.dig("result", "tools").pluck("name")).to contain_exactly("errbit_list_apps", "errbit_get_app", "errbit_list_problems", "errbit_get_problem", "errbit_get_latest_notice", "errbit_get_notice", "errbit_list_notices", "errbit_get_incident_summary", "errbit_get_airbrake_setup_guidance")
+    expect(response.headers).not_to have_key("Access-Control-Allow-Origin")
+  end
+
+  it "rejects a request with an unapproved host" do
+    mcp_request("tools/list", authorization: "Bearer #{token}", headers: {"HOST" => "unapproved.example.com"})
+
+    expect(response).to have_http_status(:forbidden)
+  end
+
+  it "rejects non-POST MCP requests" do
+    get "/mcp", headers: headers.merge("Authorization" => "Bearer #{token}")
+
+    expect(response).to have_http_status(:method_not_allowed)
+  end
+
+  it "rejects requests without the JSON media type" do
+    mcp_request(
+      "tools/list",
+      authorization: "Bearer #{token}",
+      headers: {"CONTENT_TYPE" => "text/plain"}
+    )
+
+    expect(response).to have_http_status(:unsupported_media_type)
+  end
+
+  it "accepts the documented MCP protocol version" do
+    mcp_request(
+      "tools/list",
+      authorization: "Bearer #{token}",
+      headers: {"HTTP_MCP_PROTOCOL_VERSION" => "2025-03-26"}
+    )
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "lists bounded app metadata without API keys" do
+    app = create(:app, api_key: "sensitive-api-key")
+
+    mcp_request("tools/call", {name: "errbit_list_apps", arguments: {per_page: 1}}, authorization: "Bearer #{token}")
+
+    result = json.dig("result", "structuredContent")
+    expect(result.fetch("apps")).to include(hash_including("id" => app.id.to_s, "name" => app.name))
+    expect(result.fetch("per_page")).to eq(1)
+    expect(response.body).not_to include("sensitive-api-key")
+  end
+
+  it "orders apps with the same name by ID" do
+    first_app = build(:app, name: "Same name")
+    second_app = build(:app, name: "Same name")
+    first_app.save!(validate: false)
+    second_app.save!(validate: false)
+    expected_ids = [first_app.id, second_app.id].sort
+
+    mcp_request("tools/call", {name: "errbit_list_apps", arguments: {per_page: 100}}, authorization: "Bearer #{token}")
+
+    actual_ids = json.dig("result", "structuredContent", "apps").filter_map do |app|
+      app.fetch("id") if expected_ids.include?(app.fetch("id"))
+    end
+    expect(actual_ids).to eq(expected_ids)
+  end
+
+  it "searches apps by name without exposing other app metadata" do
+    matching = create(:app, name: "Checkout production", api_key: "sensitive-api-key")
+    create(:app, name: "Billing production")
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_apps", arguments: {search: "CHECKOUT"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent", "apps").map { |app| app.fetch("id") }).to eq([matching.id.to_s])
+    expect(response.body).not_to include("sensitive-api-key")
+  end
+
+  it "returns safe app details and a stable error for an unknown app" do
+    app = create(:app, api_key: "sensitive-api-key")
+
+    mcp_request("tools/call", {name: "errbit_get_app", arguments: {id: app.id}}, authorization: "Bearer #{token}")
+
+    expect(json.dig("result", "structuredContent", "app")).to include("id" => app.id.to_s, "name" => app.name)
+    expect(response.body).not_to include("sensitive-api-key")
+
+    mcp_request("tools/call", {name: "errbit_get_app", arguments: {id: "missing"}}, authorization: "Bearer #{token}")
+
+    expect(json.dig("result", "isError")).to be(true)
+    expect(json.dig("result", "structuredContent", "error")).to eq("app_not_found")
+  end
+
+  it "returns a stable error for a malformed app ID" do
+    mcp_request("tools/call", {name: "errbit_get_app", arguments: {id: "not/an/id"}}, authorization: "Bearer #{token}")
+
+    expect(json.dig("result", "isError")).to be(true)
+    expect(json.dig("result", "structuredContent")).to eq("error" => "app_not_found", "id" => "not/an/id")
+  end
+
+  it "does not mutate application or problem data" do
+    app = create(:app)
+    problem = create(:problem, app: app)
+    app_attributes = app.reload.attributes
+    problem_attributes = problem.reload.attributes
+    app_count = App.count
+    problem_count = Problem.count
+
+    mcp_request("tools/call", {name: "errbit_list_apps", arguments: {}}, authorization: "Bearer #{token}")
+    mcp_request("tools/call", {name: "errbit_get_app", arguments: {id: app.id}}, authorization: "Bearer #{token}")
+
+    expect(App.count).to eq(app_count)
+    expect(Problem.count).to eq(problem_count)
+    expect(app.reload.attributes).to eq(app_attributes)
+    expect(problem.reload.attributes).to eq(problem_attributes)
+  end
+
+  it "returns a stable tool error for invalid tool arguments" do
+    mcp_request("tools/call", {name: "errbit_list_apps", arguments: {per_page: 101}}, authorization: "Bearer #{token}")
+
+    expect(json.dig("result", "isError")).to be(true)
+    expect(json.dig("result", "content", 0, "text")).to include("/per_page")
+  end
+
+  it "lists filtered, bounded problem metadata" do
+    app = create(:app, name: "Problems app")
+    create(:problem, app: app, environment: "production", message: "NoMethodError: missing value", resolved: false, last_notice_at: 2.hours.ago)
+    create(:problem, app: app, environment: "production", message: "NoMethodError: resolved", resolved: true)
+    create(:problem, app: app, environment: "staging", message: "NoMethodError: staging")
+    create(:problem, environment: "production", message: "NoMethodError: another app")
+
+    mcp_request(
+      "tools/call",
+      {
+        name: "errbit_list_problems",
+        arguments: {app_id: app.id, app_name: app.name, environment: "production", resolved: false, search: "NoMethodError", per_page: 1}
+      },
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent")
+    expect(result.fetch("problems").size).to eq(1)
+    expect(result.fetch("problems").first).to include(
+      "app_id" => app.id.to_s,
+      "app_name" => app.name,
+      "environment" => "production",
+      "resolved" => false
+    )
+    expect(result.fetch("per_page")).to eq(1)
+    expect(result.fetch("total_count")).to eq(1)
+  end
+
+  it "returns deterministic incident facts and representative notice summaries" do
+    app = create(:app, name: "Incident app")
+    first = create(:problem, app: app, error_class: "TimeoutError", environment: "production", notices_count: 4, last_notice_at: 2.hours.ago)
+    second = create(:problem, app: app, error_class: "TimeoutError", environment: "staging", notices_count: 2, last_notice_at: 1.hour.ago, resolved: true)
+    err = create(:err, problem: second)
+    notice = create(:notice, err: err, app: app, error_class: "TimeoutError")
+    second.resolve!
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_incident_summary", arguments: {app_name: "Incident app", limit: 1}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent")
+    expect(result).to include(
+      "matching_problem_count" => 2,
+      "total_notice_count" => 7,
+      "resolved_problem_count" => 1,
+      "unresolved_problem_count" => 1
+    )
+    expect(result.fetch("highest_frequency_problems").first.fetch("id")).to eq(first.id.to_s)
+    expect(result.fetch("representative_latest_notices").first.fetch("id")).to eq(notice.id.to_s)
+    expect(result.fetch("top_error_classes")).to eq([{"value" => "TimeoutError", "count" => 2}])
+  end
+
+  it "rejects an invalid incident summary date range" do
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_incident_summary", arguments: {since: "2026-09-08T00:00:00Z", until: "2026-09-07T00:00:00Z"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "invalid_date_range")
+  end
+
+  it "returns setup guidance without app credentials" do
+    app = create(:app, name: "Checkout", api_key: "sensitive-api-key")
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_airbrake_setup_guidance", arguments: {app_id: app.id, framework: "ruby"}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent")
+    expect(result).to include("app" => {"id" => app.id.to_s, "name" => "Checkout"}, "project_id" => 1, "project_key" => "<ERRBIT_APP_API_KEY>")
+    expect(result.fetch("snippets").keys).to eq(["ruby"])
+    expect(response.body).not_to include("sensitive-api-key")
+  end
+
+  it "returns a stable error for an unknown setup guidance app" do
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_airbrake_setup_guidance", arguments: {app_id: "missing"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "app_not_found", "app_id" => "missing")
+  end
+
+  it "rejects unsupported setup guidance frameworks" do
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_airbrake_setup_guidance", arguments: {framework: "cobol"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "unsupported_framework", "framework" => "cobol")
+  end
+
+  it "orders problems by latest notice and then ID" do
+    app = create(:app)
+    timestamp = 1.hour.ago
+    first_problem = create(:problem, app: app, last_notice_at: timestamp)
+    second_problem = create(:problem, app: app, last_notice_at: timestamp)
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_problems", arguments: {app_id: app.id, per_page: 100}},
+      authorization: "Bearer #{token}"
+    )
+
+    ids = json.dig("result", "structuredContent", "problems").pluck("id")
+    expect(ids.first(2)).to eq([first_problem.id.to_s, second_problem.id.to_s].sort.reverse)
+  end
+
+  it "returns an empty page when no problems match" do
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_problems", arguments: {app_id: "missing-app"}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent")
+    expect(result.fetch("problems")).to eq([])
+    expect(result.fetch("total_count")).to eq(0)
+  end
+
+  it "returns safe problem details and a stable error for an unknown problem" do
+    app = create(:app, api_key: "sensitive-api-key")
+    problem = create(
+      :problem,
+      app: app,
+      message: "NoMethodError: missing value",
+      issue_link: "https://issues.example.test/123",
+      messages: {"secret" => {"value" => "request-password"}},
+      hosts: {"secret" => {"value" => "internal.example.test"}}
+    )
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_problem", arguments: {id: problem.id}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent", "problem")
+    expect(result).to include(
+      "id" => problem.id.to_s,
+      "app_id" => app.id.to_s,
+      "message" => "NoMethodError: missing value",
+      "issue_link" => "https://issues.example.test/123",
+      "url" => problem.url
+    )
+    expect(response.body).not_to include("sensitive-api-key", "request-password", "internal.example.test")
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_problem", arguments: {id: "missing"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "isError")).to be(true)
+    expect(json.dig("result", "structuredContent")).to eq("error" => "problem_not_found", "id" => "missing")
+  end
+
+  it "returns a stable error for a malformed problem ID" do
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_problem", arguments: {id: "not/an/id"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "isError")).to be(true)
+    expect(json.dig("result", "structuredContent")).to eq("error" => "problem_not_found", "id" => "not/an/id")
+  end
+
+  it "returns the complete persisted latest notice context" do
+    app = create(:app)
+    problem = create(:problem, app: app)
+    notice = create(
+      :notice,
+      app: app,
+      err: create(:err, problem: problem),
+      message: "NoMethodError: missing value",
+      request: {"url" => "https://example.test/orders?token=stored-value", "params" => {"order_id" => "42"}},
+      server_environment: {"environment-name" => "production", "app-version" => "2026.09.07"},
+      notifier: {"name" => "custom-notifier", "version" => "1"},
+      user_attributes: {"account_id" => "account-42"}
+    )
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_latest_notice", arguments: {problem_id: problem.id}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent", "notice")
+    expect(result).to include(
+      "id" => notice.id.to_s,
+      "problem_id" => problem.id.to_s,
+      "message" => notice.message,
+      "request" => hash_including("url" => "https://example.test/orders?token=stored-value"),
+      "server_environment" => hash_including("app-version" => "2026.09.07"),
+      "notifier" => hash_including("name" => "custom-notifier"),
+      "user_attributes" => hash_including("account_id" => "account-42"),
+      "backtrace" => JSON.parse(notice.backtrace.lines.to_json)
+    )
+  end
+
+  it "returns stable errors for missing notices and oversized notices" do
+    problem = create(:problem)
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_latest_notice", arguments: {problem_id: problem.id}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "notice_not_found", "problem_id" => problem.id.to_s)
+
+    notice = create(:notice, request: {"payload" => "x" * 1_000_001})
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_latest_notice", arguments: {problem_id: notice.problem.id}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "notice_too_large", "max_bytes" => 1_000_000)
+    expect(response.body).not_to include("x" * 1_000)
+  end
+
+  it "returns one persisted notice by ID with bounded troubleshooting context" do
+    app = create(:app)
+    problem = create(:problem, app: app)
+    notice = create(:notice, app: app, err: create(:err, problem: problem))
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_notice", arguments: {id: notice.id}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent", "notice")
+    expect(result).to include("id" => notice.id.to_s, "problem_id" => problem.id.to_s, "problem" => hash_including("id" => problem.id.to_s), "app" => hash_including("id" => app.id.to_s))
+    expect(result).to include("request", "server_environment", "notifier", "backtrace")
+  end
+
+  it "returns a stable error for an unknown notice ID" do
+    mcp_request(
+      "tools/call",
+      {name: "errbit_get_notice", arguments: {id: "missing"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "notice_not_found", "id" => "missing")
+  end
+
+  it "lists notices across apps with bounded filters" do
+    matching_app = create(:app, name: "Checkout")
+    other_app = create(:app, name: "Billing")
+    matching_problem = create(:problem, app: matching_app, environment: "production", resolved: false)
+    other_problem = create(:problem, app: other_app, environment: "production", resolved: false)
+    matching_notice = create(:notice, app: matching_app, err: create(:err, problem: matching_problem), message: "Checkout timeout")
+    create(:notice, app: other_app, err: create(:err, problem: other_problem), message: "Billing timeout")
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_notices", arguments: {app_name: "Checkout", environment: "production", resolved: false, search: "Checkout"}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent")
+    expect(result.fetch("notices").map { |notice| notice.fetch("id") }).to eq([matching_notice.id.to_s])
+    expect(result.fetch("notices").first).to include("problem_id" => matching_problem.id.to_s)
+  end
+
+  it "rejects an unscoped notice list" do
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_notices", arguments: {}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "invalid_filters")
+  end
+
+  it "lists newest notice summaries with pagination and no raw context" do
+    problem = create(:problem)
+    err = create(:err, problem: problem)
+    first_notice = create(
+      :notice,
+      err: err,
+      created_at: 2.hours.ago,
+      request: {"url" => "https://example.test/old?token=secret-value"}
+    )
+    second_notice = create(
+      :notice,
+      err: err,
+      created_at: 1.hour.ago,
+      message: "m" * 600,
+      error_class: "e" * 600,
+      framework: "f" * 600,
+      server_environment: {"environment-name" => "n" * 600, "app-version" => "v" * 600},
+      request: {"url" => "https://example.test/new?token=secret-value", "component" => "c" * 600}
+    )
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_notices", arguments: {problem_id: problem.id, page: 1, per_page: 1}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent")
+    expect(result.fetch("notices").map { |notice| notice.fetch("id") }).to eq([second_notice.id.to_s])
+    expect(result.fetch("total_count")).to eq(2)
+    expect(result.fetch("total_pages")).to eq(2)
+    summary = result.fetch("notices").first
+    expect(summary.slice("message", "error_class", "framework", "environment", "app_version", "where").values.map(&:length)).to all(eq(500))
+    expect(response.body).not_to include("secret-value")
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_notices", arguments: {problem_id: problem.id, page: 2, per_page: 1}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent", "notices").map { |notice| notice.fetch("id") }).to eq([first_notice.id.to_s])
+  end
+
+  it "returns an empty notice page and a stable error for an unknown problem" do
+    problem = create(:problem)
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_notices", arguments: {problem_id: problem.id}},
+      authorization: "Bearer #{token}"
+    )
+
+    result = json.dig("result", "structuredContent")
+    expect(result.fetch("notices")).to eq([])
+    expect(result.fetch("total_count")).to eq(0)
+
+    mcp_request(
+      "tools/call",
+      {name: "errbit_list_notices", arguments: {problem_id: "missing"}},
+      authorization: "Bearer #{token}"
+    )
+
+    expect(json.dig("result", "structuredContent")).to eq("error" => "problem_not_found", "problem_id" => "missing")
+  end
+
+  private
+
+  def mcp_request(method, params = {}, authorization:, headers: {}, payload: nil)
+    request_headers = self.headers.merge(headers)
+    request_headers["Authorization"] = authorization if authorization
+    payload ||= {jsonrpc: "2.0", id: 1, method: method, params: params}.to_json
+    post "/mcp", params: payload, headers: request_headers
+  end
+
+  def json
+    response.parsed_body
+  end
+end


### PR DESCRIPTION
- Add a disabled-by-default read-only Streamable HTTP MCP endpoint at `/mcp`
- Authenticate requests with a deployment-scoped bearer token
- Add app discovery and lookup tools with bounded safe metadata
- Add optional app-name search with deterministic ordering and pagination
- Add problem investigation tools with app, environment, resolved-state, search and pagination filters
- Add cross-app notice listing with app, environment, resolved-state and message/error-class search filters
- Add specific notice lookup with persisted request, environment, notifier, user and complete backtrace context
- Add deterministic incident summaries with matching counts, resolved-state totals, frequency rankings, top error classes, environments and representative notices
- Add safe Airbrake setup guidance for supported clients without exposing app ingestion API keys or embedded integration configuration
- Preserve persisted notice sanitization and reject oversized payloads
- Enforce bounded responses, pagination limits, deterministic ordering and response-size limits
- Add stable errors, request IDs, host validation, and safe logging
- Document deployment limits, privacy behavior, client configuration, search semantics, incident summaries and setup guidance
- Add protocol, security, filtering, aggregation, credential-safety, regression and read-only behavior coverage

Closes #2621