### PR TITLE
Keep issue links in the problems table without a configured tracker

### DIFF
--- a/app/views/problems/_table.html.erb
+++ b/app/views/problems/_table.html.erb
@@ -80,7 +80,7 @@
             <%# TODO: this if looks like wrong and should be up for one element (td in td?). %>
             <% if any_issue_links %>
               <td class="issue_link narrow-as-possible">
-                <% if problem.app.issue_tracker_configured? && problem.issue_link.present? && problem.issue_link != "pending" %>
+                <% if problem.issue_type.present? && problem.issue_link.present? && problem.issue_link != "pending" %>
                   <%= link_to image_tag("#{problem.issue_type}_goto.png"), problem.issue_link, target: "_blank", rel: "noopener noreferrer" %>
                 <% end %>
               </td>


### PR DESCRIPTION
The table only linked a problem's issue while its app still had an issue tracker configured, although the problem itself records both the link and the tracker it came from. Show the link whenever the problem carries one, so it stays reachable after the tracker was removed or replaced.